### PR TITLE
Add Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,14 @@
+---
+# Documentation: https://github.com/probot/stale
+daysUntilStale: 180
+daysUntilClose: 14
+exemptLabels:
+  - bug
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs during
+  the next 14 days. Thanks for your contribution.
+closeComment: >
+  This issue has been automatically closed because it has not had recent
+  activity.


### PR DESCRIPTION
# Pull request

## Description

This PR adds support for the [Stale bot](https://github.com/probot/stale) which automatically closes issues after a period of inactivity. Automatic cleanup is especially useful considering we will use issues to manage both our work and incoming requests.

## Changes made

- Mark issues as stale after 180 days (seems fair).
- Provide 2 more weeks to revive the issue / PR.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
