### PR TITLE
Add memory leak unit tests

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -7,7 +7,7 @@
 import AVFoundation
 import Combine
 
-/// Audio and vide player.
+/// Audio and video player.
 public final class Player: ObservableObject {
     /// The current player state.
     @Published public private(set) var state: State = .idle

--- a/Tests/PlayerTests/MemoryTests.swift
+++ b/Tests/PlayerTests/MemoryTests.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import AVFoundation
+import Nimble
+import XCTest
+
+final class MemoryTests: XCTestCase {
+    func testPlayerRelease() {
+        let item = AVPlayerItem(url: TestStreams.validStreamUrl)
+        var player: Player? = Player(item: item)
+
+        weak var weakPlayer = player
+        autoreleasepool {
+            player = nil
+        }
+        expect(weakPlayer).to(beNil())
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

A unit test suite has been added to check for proper object deallocation. I checked that removing the current `weak player` reference we have in code makes the test fail.

## Changes made

- Add `Player` deallocation test.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
