### PR TITLE
Add seek behaviors

### DIFF
--- a/Sources/Player/PlaybackProgress.swift
+++ b/Sources/Player/PlaybackProgress.swift
@@ -17,7 +17,7 @@ public struct PlaybackProgress: Equatable {
         case deferred
     }
 
-    static var empty: Self {
+    static var none: Self {
         PlaybackProgress(value: nil, isInteracting: false)
     }
 

--- a/Sources/Player/PlaybackProgress.swift
+++ b/Sources/Player/PlaybackProgress.swift
@@ -9,6 +9,14 @@ import Foundation
 
 /// Playback progress.
 public struct PlaybackProgress: Equatable {
+    /// Seek behavior during progress updates.
+    public enum SeekBehavior {
+        /// Seek immediately when updated.
+        case immediate
+        /// Deferred until interaction ends (see `isInteracting`).
+        case deferred
+    }
+
     static var empty: Self {
         PlaybackProgress(value: nil, isInteracting: false)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -19,7 +19,14 @@ public final class Player: ObservableObject {
     /// Current playback progress.
     @Published public var progress: PlaybackProgress = .empty {
         willSet {
-            guard let progress = newValue.value, let time = pulse?.time(forProgress: progress) else { return }
+            guard configuration.seekBehavior == .immediate
+                    || (!newValue.isInteracting && progress.isInteracting) else {
+                return
+            }
+
+            guard let progress = newValue.value, let time = pulse?.time(forProgress: progress) else {
+                return
+            }
             seek(to: time)
         }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -17,7 +17,7 @@ public final class Player: ObservableObject {
     @Published private var pulse: Pulse?
 
     /// Current playback progress.
-    @Published public var progress: PlaybackProgress = .empty {
+    @Published public var progress: PlaybackProgress = .none {
         willSet {
             guard configuration.seekBehavior == .immediate
                     || (!newValue.isInteracting && progress.isInteracting) else {

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -21,6 +21,9 @@ public struct PlayerConfiguration {
         set { _dvrThreshold = CMTimeMaximum(newValue, .zero) }
     }
 
+    /// Seek behavior during progress updates.
+    public var seekBehavior: PlaybackProgress.SeekBehavior = .immediate
+
     private var _tick = CMTime(value: 1, timescale: 1)
     private var _dvrThreshold = CMTime.zero
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -21,7 +21,7 @@ public struct PlayerConfiguration {
         set { _dvrThreshold = CMTimeMaximum(newValue, .zero) }
     }
 
-    /// Seek behavior during progress updates.
+    /// Seek behavior during progress updates. Default is `.immediate`.
     public var seekBehavior: PlaybackProgress.SeekBehavior = .immediate
 
     private var _tick = CMTime(value: 1, timescale: 1)


### PR DESCRIPTION
# Pull request

## Description

This PR adds two seek behaviors required for Pillarbox Apple, as the player is also an observable object and must deal with bindings on the progress property.

## Changes made

- Add two modes as an enum.
- No UTs have been written as internals would have been tested in a way tightly coupled to the `Player` implementation details. We should better test this behavior with future player states we might add (`seeking`, `buffering`). I added special dedicated tasks to the corresponding backlog item to do it at a later time.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
