### PR TITLE
Update Tag Commander binaries to version 5

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,17 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
       "state" : {
-        "revision" : "eb686883e63af28174472a09eda97acf07179c88",
-        "version" : "4.5.4-srg5"
+        "revision" : "6f5e24bed11558da8c1479157ec74a0485443834",
+        "version" : "5.1.1"
       }
     },
     {
-      "identity" : "tcsdk-xcframework-apple",
+      "identity" : "tcserverside-xcframework-apple",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SRGSSR/TCSDK-xcframework-apple.git",
+      "location" : "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
       "state" : {
-        "revision" : "c4becb0b250258b78cb46225af5e269da834db5a",
-        "version" : "4.4.1-srg5"
+        "revision" : "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
+        "version" : "5.1.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,17 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/TCCore-xcframework-apple.git",
       "state" : {
-        "revision" : "eb686883e63af28174472a09eda97acf07179c88",
-        "version" : "4.5.4-srg5"
+        "revision" : "6f5e24bed11558da8c1479157ec74a0485443834",
+        "version" : "5.1.1"
       }
     },
     {
-      "identity" : "tcsdk-xcframework-apple",
+      "identity" : "tcserverside-xcframework-apple",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SRGSSR/TCSDK-xcframework-apple.git",
+      "location" : "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git",
       "state" : {
-        "revision" : "c4becb0b250258b78cb46225af5e269da834db5a",
-        "version" : "4.4.1-srg5"
+        "revision" : "bb47eef2a14d486aa72896abc8d911fe9aed67d0",
+        "version" : "5.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,8 +45,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.10.0")),
         .package(url: "https://github.com/SRGSSR/GoogleCastSDK-no-bluetooth.git", .upToNextMinor(from: "4.7.1-beta.1")),
-        .package(url: "https://github.com/SRGSSR/TCCore-xcframework-apple.git", .upToNextMinor(from: "4.5.4-srg5")),
-        .package(url: "https://github.com/SRGSSR/TCSDK-xcframework-apple.git", .upToNextMinor(from: "4.4.1-srg5")),
+        .package(url: "https://github.com/SRGSSR/TCCore-xcframework-apple.git", .upToNextMinor(from: "5.1.1")),
+        .package(url: "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git", .upToNextMinor(from: "5.1.2")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", .upToNextMajor(from: "1.0.1")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0")),
@@ -58,7 +58,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ComScore", package: "Comscore-Swift-Package-Manager"),
                 .product(name: "TCCore", package: "TCCore-xcframework-apple"),
-                .product(name: "TCSDK", package: "TCSDK-xcframework-apple")
+                .product(name: "TCServerSide", package: "TCServerSide-xcframework-apple")
             ]
         ),
         .target(name: "Appearance"),


### PR DESCRIPTION
# Pull request

## Description

This PR replaces Tag Commander custom binaries we distributed for v4 with official binaries for v5. Those support iOS and now tvOS as well, but are still packaged on our side until Commanders Act provides official SPM support.

## Changes made

- Replace Tag Commander v4 SDKs with v5.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
