### PR TITLE
Implement better type equality

### DIFF
--- a/Sources/Player/ItemState.swift
+++ b/Sources/Player/ItemState.swift
@@ -28,11 +28,12 @@ enum ItemState: Equatable {
         }
     }
 
-    // Ignore differences between errors (different errors should never occur in practice for the same item anyway).
     static func == (lhs: ItemState, rhs: ItemState) -> Bool {
         switch (lhs, rhs) {
-        case (.unknown, .unknown), (.readyToPlay, .readyToPlay), (.ended, .ended), (.failed, .failed):
+        case (.unknown, .unknown), (.readyToPlay, .readyToPlay), (.ended, .ended):
             return true
+        case let (.failed(error: lhsError), .failed(error: rhsError)):
+            return lhsError as NSError == rhsError as NSError
         default:
             return false
         }

--- a/Sources/Player/PlaybackState.swift
+++ b/Sources/Player/PlaybackState.swift
@@ -32,11 +32,12 @@ public enum PlaybackState: Equatable {
         }
     }
 
-    // Ignore differences between errors (different errors should never occur in practice for the same session anyway).
     public static func == (lhs: PlaybackState, rhs: PlaybackState) -> Bool {
         switch (lhs, rhs) {
-        case (.idle, .idle), (.playing, .playing), (.paused, .paused), (.ended, .ended), (.failed, .failed):
+        case (.idle, .idle), (.playing, .playing), (.paused, .paused), (.ended, .ended):
             return true
+        case let (.failed(error: lhsError), .failed(error: rhsError)):
+            return lhsError as NSError == rhsError as NSError
         default:
             return false
         }

--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -23,7 +23,7 @@ final class PlayerItemTests: XCTestCase {
     func testFailure() {
         let item = AVPlayerItem(urn: "invalid")
         let player = AVPlayer(playerItem: item)
-        expectAtLeastEqualPublished(values: [.idle, .failed(error: TestError.any)], from: player.playbackStatePublisher()) {
+        expectAtLeastSimilarPublished(values: [.idle, .failed(error: TestError.any)], from: player.playbackStatePublisher()) {
             player.play()
         }
     }

--- a/Tests/CoreBusinessTests/Similarity.swift
+++ b/Tests/CoreBusinessTests/Similarity.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Circumspect
+import Player
+
+extension PlaybackState: Similar {
+    public static func ~= (lhs: PlaybackState, rhs: PlaybackState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.playing, .playing), (.paused, .paused), (.ended, .ended), (.failed, .failed):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
@@ -30,7 +30,7 @@ final class ItemStatePublisherQueueTests: XCTestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectEqualPublished(
+        expectSimilarPublished(
             // The third item cannot be pre-buffered and goes through the usual states
             values: [
                 .unknown, .readyToPlay, .ended,

--- a/Tests/PlayerTests/ItemStatePublisherTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherTests.swift
@@ -47,7 +47,7 @@ final class ItemStatePublisherTests: XCTestCase {
     func testUnavailableStream() {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectSimilarPublished(
             values: [.unknown, .failed(error: TestError.any)],
             from: player.itemStatePublisher(),
             during: 1
@@ -57,7 +57,7 @@ final class ItemStatePublisherTests: XCTestCase {
     func testCorruptStream() {
         let item = AVPlayerItem(url: Stream.corruptOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectSimilarPublished(
             values: [.unknown, .failed(error: TestError.any)],
             from: player.itemStatePublisher(),
             during: 1
@@ -69,7 +69,7 @@ final class ItemStatePublisherTests: XCTestCase {
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: .global())
         let item = AVPlayerItem(asset: asset)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectSimilarPublished(
             values: [.unknown, .failed(error: TestError.any)],
             from: player.itemStatePublisher(),
             during: 1

--- a/Tests/PlayerTests/ItemStateTests.swift
+++ b/Tests/PlayerTests/ItemStateTests.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Circumspect
+import Nimble
+import XCTest
+
+final class ItemStateTests: XCTestCase {
+    func testEquality() {
+        expect(ItemState.unknown).to(equal(.unknown))
+        expect(ItemState.readyToPlay).to(equal(.readyToPlay))
+        expect(ItemState.ended).to(equal(.ended))
+        expect(ItemState.failed(error: TestError.any)).to(equal(.failed(error: TestError.any)))
+    }
+
+    func testInequality() {
+        expect(ItemState.unknown).notTo(equal(.readyToPlay))
+        expect(ItemState.failed(error: TestError.error1)).notTo(equal(.failed(error: TestError.error2)))
+    }
+
+    func testSimilarity() {
+        expect(ItemState.unknown).to(equal(.unknown, by: ~=))
+        expect(ItemState.readyToPlay).to(equal(.readyToPlay, by: ~=))
+        expect(ItemState.ended).to(equal(.ended, by: ~=))
+        expect(ItemState.failed(error: TestError.any)).to(equal(.failed(error: TestError.any), by: ~=))
+    }
+}

--- a/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
@@ -30,7 +30,7 @@ final class PlaybackStatePublisherQueueTests: XCTestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectEqualPublished(
+        expectSimilarPublished(
             // The third item cannot be pre-buffered and goes through the usual states
             values: [
                 .idle, .playing, .ended,

--- a/Tests/PlayerTests/PlaybackStatePublisherTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherTests.swift
@@ -56,7 +56,7 @@ final class PlaybackStatePublisherTests: XCTestCase {
     func testPlaybackFailure() {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectSimilarPublished(
             values: [.idle, .failed(error: TestError.any)],
             from: player.playbackStatePublisher(),
             during: 2

--- a/Tests/PlayerTests/PlaybackStateTests.swift
+++ b/Tests/PlayerTests/PlaybackStateTests.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Circumspect
+import Nimble
+import XCTest
+
+final class PlaybackStateTests: XCTestCase {
+    func testEquality() {
+        expect(PlaybackState.idle).to(equal(.idle))
+        expect(PlaybackState.playing).to(equal(.playing))
+        expect(PlaybackState.paused).to(equal(.paused))
+        expect(PlaybackState.ended).to(equal(.ended))
+        expect(ItemState.failed(error: TestError.any)).to(equal(.failed(error: TestError.any)))
+    }
+
+    func testInequality() {
+        expect(PlaybackState.idle).notTo(equal(.playing))
+        expect(PlaybackState.failed(error: TestError.error1)).notTo(equal(.failed(error: TestError.error2)))
+    }
+
+    func testSimilarity() {
+        expect(PlaybackState.idle).to(equal(.idle, by: ~=))
+        expect(PlaybackState.playing).to(equal(.playing, by: ~=))
+        expect(PlaybackState.paused).to(equal(.paused, by: ~=))
+        expect(PlaybackState.ended).to(equal(.ended, by: ~=))
+        expect(ItemState.failed(error: TestError.any)).to(equal(.failed(error: TestError.any), by: ~=))
+    }
+}

--- a/Tests/PlayerTests/PlayerItemPublishersTests.swift
+++ b/Tests/PlayerTests/PlayerItemPublishersTests.swift
@@ -37,7 +37,7 @@ final class PlayerItemPublishersTests: XCTestCase {
     func testCorruptStream() {
         let item = AVPlayerItem(url: Stream.corruptOnDemand.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectSimilarPublished(
             values: [.unknown, .failed(error: TestError.any)],
             from: item.itemStatePublisher(),
             during: 2

--- a/Tests/PlayerTests/Similarity.swift
+++ b/Tests/PlayerTests/Similarity.swift
@@ -16,6 +16,28 @@ extension Pulse: Similar {
     }
 }
 
+extension ItemState: Similar {
+    public static func ~= (lhs: ItemState, rhs: ItemState) -> Bool {
+        switch (lhs, rhs) {
+        case (.unknown, .unknown), (.readyToPlay, .readyToPlay), (.ended, .ended), (.failed, .failed):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+extension PlaybackState: Similar {
+    public static func ~= (lhs: PlaybackState, rhs: PlaybackState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.playing, .playing), (.paused, .paused), (.ended, .ended), (.failed, .failed):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 func beClose(within tolerance: TimeInterval) -> ((CMTime, CMTime) -> Bool) {
     CMTime.close(within: tolerance)
 }

--- a/Tests/PlayerTests/Tools.swift
+++ b/Tests/PlayerTests/Tools.swift
@@ -37,6 +37,8 @@ final class FailingResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
 enum TestError: Error {
     case any
+    case error1
+    case error2
 }
 
 struct Stream {


### PR DESCRIPTION
# Pull request

## Description

This PR improves enum equality for cases with errors as associated values.

## Changes made

- Upddate `PlaybackState` and `ItemState`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
