### PR TITLE
Prevent SRG SSR livestreams from being played in the past

### DIFF
--- a/Demo/Sources/BasicPlayerView.swift
+++ b/Demo/Sources/BasicPlayerView.swift
@@ -15,10 +15,15 @@ struct BasicPlayerView: View {
     @StateObject private var player = Player(item: AVPlayerItem(url: Stream.appleAdvanced_16_9_HEVC_h264))
 
     var body: some View {
-        VideoView(player: player)
-            .onAppear {
-                player.play()
+        ZStack {
+            VideoView(player: player)
+            if player.isBuffering {
+                ProgressView()
             }
+        }
+        .onAppear {
+            player.play()
+        }
     }
 }
 

--- a/Demo/Sources/Media.swift
+++ b/Demo/Sources/Media.swift
@@ -7,6 +7,13 @@
 import Foundation
 
 struct Media: Identifiable {
+    static var liveMedia = Media(
+        id: "live",
+        title: "Couleur 3",
+        description: "Couleur 3 livestream",
+        source: .url(Stream.couleur3_livestream)
+    )
+
     static var urnPlaylist: [Media] = [
         Media(
             id: "playlist:1",

--- a/Demo/Sources/MediasView.swift
+++ b/Demo/Sources/MediasView.swift
@@ -56,13 +56,13 @@ struct MediasView: View {
             id: "assets:video_live_hls",
             title: "Video livestream - HLS",
             description: "Couleur 3 en vidéo",
-            source: .url(URL(string: "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0")!)
+            source: .url(Stream.couleur3_livestream)
         ),
         Media(
             id: "assets:video_live_dvr_hls",
             title: "Video livestream with DVR - HLS",
             description: "Couleur 3 en vidéo",
-            source: .url(URL(string: "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8")!)
+            source: .url(Stream.couleur3_livestream_dvr)
         ),
         Media(
             id: "assets:video_live_dvr_timestamps_hls",

--- a/Demo/Sources/MediasView.swift
+++ b/Demo/Sources/MediasView.swift
@@ -172,7 +172,7 @@ struct MediasView: View {
 
 // MARK: Preview
 
-struct DemosView_Previews: PreviewProvider {
+struct MediasView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             MediasView()

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -96,6 +96,7 @@ private struct PreviousButton: View {
 
 struct PlayerView: View {
     let medias: [Media]
+    let buffered: Bool
 
     @StateObject private var player = Player()
     @State private var isUserInterfaceHidden = false
@@ -125,16 +126,21 @@ struct PlayerView: View {
         }
     }
 
-    init(medias: [Media]) {
+    init(medias: [Media], buffered: Bool = true) {
         self.medias = medias
+        self.buffered = buffered
     }
 
-    init(media: Media) {
-        self.init(medias: [media])
+    init(media: Media, buffered: Bool = true) {
+        self.init(medias: [media], buffered: buffered)
     }
 
     private func play() {
         medias.compactMap(\.source.playerItem).forEach { item in
+            if !buffered {
+                item.automaticallyPreservesTimeOffsetFromLive = true
+                item.preferredForwardBufferDuration = 1
+            }
             player.append(item)
         }
         player.play()

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -33,6 +33,9 @@ struct ShowcaseView: View {
             Cell(title: "Basic") {
                 BasicPlayerView()
             }
+            Cell(title: "Unbuffered live playback") {
+                PlayerView(media: .liveMedia, buffered: false)
+            }
             Cell(title: "Stories") {
                 StoriesView()
             }

--- a/Demo/Sources/Stream.swift
+++ b/Demo/Sources/Stream.swift
@@ -14,5 +14,10 @@ enum Stream {
     static let appleAdvanced_16_9_fMP4 = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8")!
     static let appleAdvanced_16_9_HEVC_h264 = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8")!
 
+    // Livestreams
+    static let couleur3_livestream = URL(string: "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0")!
+    static let couleur3_livestream_dvr = URL(string: "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8")!
+
+    // Other
     static let local = URL(string: "http://localhost:8123/on_demand/master.m3u8")!
 }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -23,5 +23,6 @@ public extension AVPlayerItem {
         let asset = AVURLAsset(url: URLCoding.encodeUrl(fromUrn: urn))
         asset.resourceLoader.setDelegate(kAssetResourceLoaders[environment], queue: .global(qos: .userInitiated))
         self.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
+        automaticallyPreservesTimeOffsetFromLive = true
     }
 }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -18,11 +18,25 @@ public extension AVPlayerItem {
     ///   - urn: The URN to play.
     ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play.
     ///   - environment: The environment which the URN is played from.
-    convenience init(urn: String, automaticallyLoadedAssetKeys keys: [String]? = nil, environment: Environment = .production) {
+    convenience init(urn: String, automaticallyLoadedAssetKeys keys: [String], environment: Environment = .production) {
+        self.init(asset: Self.asset(fromUrn: urn, environment: environment), automaticallyLoadedAssetKeys: keys)
+        preventLivestreamDelayedPlayback()
+    }
+
+    /// Create a player item from a URN played in the specified environment. Loads standard asset keys before the item
+    /// is ready to play.
+    /// - Parameters:
+    ///   - urn: The URN to play.
+    ///   - environment: The environment which the URN is played from.
+    convenience init(urn: String, environment: Environment = .production) {
+        self.init(asset: Self.asset(fromUrn: urn, environment: environment))
+        preventLivestreamDelayedPlayback()
+    }
+
+    private static func asset(fromUrn urn: String, environment: Environment) -> AVAsset {
         let asset = AVURLAsset(url: URLCoding.encodeUrl(fromUrn: urn))
         asset.resourceLoader.setDelegate(kAssetResourceLoaders[environment], queue: .global(qos: .userInitiated))
-        self.init(asset: asset, automaticallyLoadedAssetKeys: keys)
-        preventLivestreamDelayedPlayback()
+        return asset
     }
 
     /// Limit buffering and force the player to return to the live edge when re-buffering. This ensures livestreams

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -16,13 +16,16 @@ public extension AVPlayerItem {
     /// Create a player item from a URN played in the specified environment.
     /// - Parameters:
     ///   - urn: The URN to play.
-    ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play, ensuring they are
-    ///     available, but increasing startup time.
+    ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play.
     ///   - environment: The environment which the URN is played from.
-    convenience init(urn: String, automaticallyLoadedAssetKeys: [String], environment: Environment = .production) {
+    convenience init(urn: String, automaticallyLoadedAssetKeys keys: [String]? = nil, environment: Environment = .production) {
         let asset = AVURLAsset(url: URLCoding.encodeUrl(fromUrn: urn))
         asset.resourceLoader.setDelegate(kAssetResourceLoaders[environment], queue: .global(qos: .userInitiated))
-        self.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
+        self.init(asset: asset, automaticallyLoadedAssetKeys: keys)
+
+        // Limit buffering. This ensures that paused livestreams without DVR cannot be played from buffer. Instead
+        // force the player to return to the live edge when re-buffering live content.
         automaticallyPreservesTimeOffsetFromLive = true
+        preferredForwardBufferDuration = 1
     }
 }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -22,9 +22,14 @@ public extension AVPlayerItem {
         let asset = AVURLAsset(url: URLCoding.encodeUrl(fromUrn: urn))
         asset.resourceLoader.setDelegate(kAssetResourceLoaders[environment], queue: .global(qos: .userInitiated))
         self.init(asset: asset, automaticallyLoadedAssetKeys: keys)
+        preventLivestreamDelayedPlayback()
+    }
 
-        // Limit buffering. This ensures that paused livestreams without DVR cannot be played from buffer. Instead
-        // force the player to return to the live edge when re-buffering live content.
+    /// Limit buffering and force the player to return to the live edge when re-buffering. This ensures livestreams
+    /// cannot be paused and resumed in the past, as requested by business people.
+    ///
+    /// Remark: These settings do not negatively affect on-demand or DVR livestream playback.
+    private func preventLivestreamDelayedPlayback() {
         automaticallyPreservesTimeOffsetFromLive = true
         preferredForwardBufferDuration = 1
     }

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -10,10 +10,9 @@ public extension AVPlayerItem {
     /// Create a player item from a URL.
     /// - Parameters:
     ///   - url: The URL to play.
-    ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play, ensuring they are
-    ///     available, but increasing startup time.
-    convenience init(url: URL, automaticallyLoadedAssetKeys: [String]) {
+    ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play.
+    convenience init(url: URL, automaticallyLoadedAssetKeys keys: [String]) {
         let asset = AVURLAsset(url: url)
-        self.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
+        self.init(asset: asset, automaticallyLoadedAssetKeys: keys)
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR ensures that player livestream items delivered by `CoreBusiness` cannot be played in the past.

## Changes made

- Implement short buffering strategy with live edge anchoring.
- Update the demo with an example (Showcase tab).
- Update player item creation API.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
