### PR TITLE
Basic error reporting

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Analytics.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Analytics.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en">
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Circumspect.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Circumspect.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Core.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Core.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CoreBusiness.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CoreBusiness.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Diagnostics.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Diagnostics.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Pillarbox-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Pillarbox-Package.xcscheme
@@ -195,6 +195,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Player.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Player.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/UserInterface.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/UserInterface.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -101,6 +101,11 @@ private struct Example: Identifiable {
             media: MediaURL.appleAdvanced_16_9_HEVC_h264_HLS
         ),
         Example(
+            title: "Expired media",
+            description: "This media is not available anymore",
+            media: MediaURN.expired
+        ),
+        Example(
             title: "Unknown media",
             description: "This media does not exist",
             media: MediaURN.unknown

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -101,18 +101,18 @@ private struct Example: Identifiable {
             media: MediaURL.appleAdvanced_16_9_HEVC_h264_HLS
         ),
         Example(
-            title: "Expired media",
-            description: "This media is not available anymore",
+            title: "Expired content",
+            description: "This content is not available anymore",
             media: MediaURN.expired
         ),
         Example(
-            title: "Unknown media",
-            description: "This media does not exist",
+            title: "Unknown content",
+            description: "This content does not exist",
             media: MediaURN.unknown
         ),
         Example(
             title: "Empty",
-            description: "No media is provided",
+            description: "No content is provided",
             media: .empty
         )
     ]

--- a/Demo/Sources/Media.swift
+++ b/Demo/Sources/Media.swift
@@ -45,6 +45,7 @@ enum MediaURN {
     static let dvrAudio = Media.urn("urn:rts:audio:3262363")
     static let onDemandAudio = Media.urn("urn:rsi:audio:8833144")
 
+    static let expired = Media.urn("urn:rts:video:13382911")
     static let unknown = Media.urn("urn:srf:video:unknown")
 }
 

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -65,6 +65,7 @@ private struct MessageView: View {
 
     var body: some View {
         Text(message)
+            .multilineTextAlignment(.center)
             .foregroundColor(.white)
             .padding()
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -60,12 +60,13 @@ private struct ControlsView: View {
     }
 }
 
-private struct ErrorView: View {
-    let error: Error
+private struct MessageView: View {
+    let message: String
 
     var body: some View {
-        Text(error.localizedDescription)
+        Text(message)
             .foregroundColor(.white)
+            .padding()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
@@ -137,11 +138,16 @@ struct PlayerView: View {
 
     var body: some View {
         ZStack {
-            switch player.playbackState {
-            case let .failed(error: error):
-                ErrorView(error: error)
-            default:
-                ContentView(player: player)
+            if !player.items.isEmpty {
+                switch player.playbackState {
+                case let .failed(error: error):
+                    MessageView(message: error.localizedDescription)
+                default:
+                    ContentView(player: player)
+                }
+            }
+            else {
+                MessageView(message: "No content")
             }
         }
         .background(.black)

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -576,7 +576,6 @@ public extension XCTestCase {
                 expectation.fulfill()
             case .failure:
                 XCTFail("The publisher incorrectly failed", file: file, line: line)
-                break
             }
         } receiveValue: { _ in
         }
@@ -605,7 +604,6 @@ public extension XCTestCase {
             switch completion {
             case .finished:
                 XCTFail("The publisher incorrectly succeeded", file: file, line: line)
-                break
             case let .failure(actualError):
                 if let error {
                     XCTAssertEqual(error as NSError, actualError as NSError, file: file, line: line)

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -573,10 +573,11 @@ public extension XCTestCase {
         let cancellable = publisher.sink { completion in
             switch completion {
             case .finished:
-                expectation.fulfill()
+                break
             case .failure:
                 XCTFail("The publisher incorrectly failed", file: file, line: line)
             }
+            expectation.fulfill()
         } receiveValue: { _ in
         }
         defer {
@@ -608,8 +609,8 @@ public extension XCTestCase {
                 if let error {
                     XCTAssertEqual(error as NSError, actualError as NSError, file: file, line: line)
                 }
-                expectation.fulfill()
             }
+            expectation.fulfill()
         } receiveValue: { _ in
         }
         defer {

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -575,6 +575,7 @@ public extension XCTestCase {
             case .finished:
                 expectation.fulfill()
             case .failure:
+                XCTFail("The publisher incorrectly failed", file: file, line: line)
                 break
             }
         } receiveValue: { _ in
@@ -592,6 +593,7 @@ public extension XCTestCase {
 
     /// Expect a publisher to complete with a failure.
     func expectFailure<P: Publisher>(
+        _ error: Error? = nil,
         from publisher: P,
         timeout: TimeInterval = 10,
         file: StaticString = #file,
@@ -602,8 +604,12 @@ public extension XCTestCase {
         let cancellable = publisher.sink { completion in
             switch completion {
             case .finished:
+                XCTFail("The publisher incorrectly succeeded", file: file, line: line)
                 break
-            case .failure:
+            case let .failure(actualError):
+                if let error {
+                    XCTAssertEqual(error as NSError, actualError as NSError, file: file, line: line)
+                }
                 expectation.fulfill()
             }
         } receiveValue: { _ in

--- a/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
+++ b/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
@@ -55,6 +55,6 @@ private extension AVAssetResourceLoadingRequest {
         var redirectRequest = request
         redirectRequest.url = url
         redirect = redirectRequest
-        response = HTTPURLResponse(url: url, statusCode: 303, httpVersion: nil, headerFields: nil)
+        response = HTTPURLResponse(url: url, statusCode: 302, httpVersion: nil, headerFields: nil)
     }
 }

--- a/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
+++ b/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
@@ -35,14 +35,7 @@ final class AssetResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate
 
     private func processLoadingRequest(_ loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
         guard let url = loadingRequest.request.url, let urn = URLCoding.decodeUrn(from: url) else { return false }
-        cancellable = DataProvider(environment: environment).mediaComposition(forUrn: urn)
-            .map(\.mainChapter.recommendedResource)
-            .tryMap { resource in
-                guard let resource else {
-                    throw ResourceLoadingError.notFound
-                }
-                return resource
-            }
+        cancellable = DataProvider(environment: environment).recommendedResource(forUrn: urn)
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .finished:

--- a/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
+++ b/Sources/CoreBusiness/AssetResourceLoaderDelegate.swift
@@ -35,7 +35,7 @@ final class AssetResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate
 
     private func processLoadingRequest(_ loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
         guard let url = loadingRequest.request.url, let urn = URLCoding.decodeUrn(from: url) else { return false }
-        cancellable = DataProvider(environment: environment).recommendedResource(forUrn: urn)
+        cancellable = DataProvider(environment: environment).recommendedPlayableResource(forUrn: urn)
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .finished:

--- a/Sources/CoreBusiness/BlockingReason.swift
+++ b/Sources/CoreBusiness/BlockingReason.swift
@@ -19,21 +19,45 @@ enum BlockingReason: String, Decodable {
     public var description: String {
         switch self {
         case .ageRating12:
-            return "To protect children this content is only available between 8PM and 6AM."
+            return NSLocalizedString(
+                "To protect children this content is only available between 8PM and 6AM.",
+                comment: "Blocking reason description message"
+            )
         case .ageRating18:
-            return "To protect children this content is only available between 10PM and 5AM."
+            return NSLocalizedString(
+                "To protect children this content is only available between 10PM and 5AM.",
+                comment: "Blocking reason description message"
+            )
         case .commercial:
-            return "This commercial content is not available."
+            return NSLocalizedString(
+                "This commercial content is not available.",
+                comment: "Blocking reason description message"
+            )
         case .endDate:
-            return "This content is not available anymore."
+            return NSLocalizedString(
+                "This content is not available anymore.",
+                comment: "Blocking reason description message"
+            )
         case .geoblocked:
-            return "This content is not available outside Switzerland."
+            return NSLocalizedString(
+                "This content is not available outside Switzerland.",
+                comment: "Blocking reason description message"
+            )
         case .legal:
-            return "This content is not available due to legal restrictions."
+            return NSLocalizedString(
+                "This content is not available due to legal restrictions.",
+                comment: "Blocking reason description message"
+            )
         case .startDate:
-            return "This content is not available yet. Please try again later."
+            return NSLocalizedString(
+                "This content is not available yet. Please try again later.",
+                comment: "Blocking reason description message"
+            )
         case .unknown:
-            return "This content is not available."
+            return NSLocalizedString(
+                "This content is not available.",
+                comment: "Blocking reason description message"
+            )
         }
     }
 }

--- a/Sources/CoreBusiness/BlockingReason.swift
+++ b/Sources/CoreBusiness/BlockingReason.swift
@@ -19,21 +19,21 @@ enum BlockingReason: String, Decodable {
     public var description: String {
         switch self {
         case .ageRating12:
-            return "To protect children, this media is only available between 8PM and 6AM."
+            return "To protect children, this content is only available between 8PM and 6AM."
         case .ageRating18:
-            return "To protect children, this media is only available between 10PM and 5AM."
+            return "To protect children, this content is only available between 10PM and 5AM."
         case .commercial:
-            return "This commercial media is not available."
+            return "This commercial content is not available."
         case .endDate:
-            return "This media is not available anymore."
+            return "This content is not available anymore."
         case .geoblocked:
-            return "This media is not available outside Switzerland."
+            return "This content is not available outside Switzerland."
         case .legal:
-            return "This media is not available due to legal restrictions."
+            return "This content is not available due to legal restrictions."
         case .startDate:
-            return "This media is not available yet. Please try again later."
+            return "This content is not available yet. Please try again later."
         case .unknown:
-            return "This media is not available."
+            return "This content is not available."
         }
     }
 }

--- a/Sources/CoreBusiness/BlockingReason.swift
+++ b/Sources/CoreBusiness/BlockingReason.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum BlockingReason: String, Decodable {
+    case ageRating12 = "AGERATING12"
+    case ageRating18 = "AGERATING18"
+    case commercial = "COMMERCIAL"
+    case endDate = "ENDDATE"
+    case geoblocked = "GEOBLOCK"
+    case legal = "LEGAL"
+    case startDate = "STARTDATE"
+    case unknown = "UNKNOWN"
+
+    public var description: String {
+        switch self {
+        case .ageRating12:
+            return "To protect children, this media is only available between 8PM and 6AM."
+        case .ageRating18:
+            return "To protect children, this media is only available between 10PM and 5AM."
+        case .commercial:
+            return "This commercial media is not available."
+        case .endDate:
+            return "This media is not available anymore."
+        case .geoblocked:
+            return "This media is not available outside Switzerland."
+        case .legal:
+            return "This media is not available due to legal restrictions."
+        case .startDate:
+            return "This media is not available yet. Please try again later."
+        case .unknown:
+            return "This media is not available."
+        }
+    }
+}

--- a/Sources/CoreBusiness/BlockingReason.swift
+++ b/Sources/CoreBusiness/BlockingReason.swift
@@ -19,9 +19,9 @@ enum BlockingReason: String, Decodable {
     public var description: String {
         switch self {
         case .ageRating12:
-            return "To protect children, this content is only available between 8PM and 6AM."
+            return "To protect children this content is only available between 8PM and 6AM."
         case .ageRating18:
-            return "To protect children, this content is only available between 10PM and 5AM."
+            return "To protect children this content is only available between 10PM and 5AM."
         case .commercial:
             return "This commercial content is not available."
         case .endDate:

--- a/Sources/CoreBusiness/Chapter.swift
+++ b/Sources/CoreBusiness/Chapter.swift
@@ -8,14 +8,37 @@ import Foundation
 
 struct Chapter: Decodable {
     enum CodingKeys: String, CodingKey {
-        case urn
-        case title
+        case blockingReason = "blockReason"
+        case endDate = "validTo"
         case resources = "resourceList"
+        case startDate = "validFrom"
+        case title
+        case urn
     }
+
+    private let blockingReason: BlockingReason?
 
     let urn: String
     let title: String
     let resources: [Resource]
+
+    let startDate: Date?
+    let endDate: Date?
+
+    func blockingReason(at date: Date = Date()) -> BlockingReason? {
+        if blockingReason != .none {
+            return blockingReason
+        }
+        else if let startDate, date < startDate {
+            return .startDate
+        }
+        else if let endDate, date > endDate {
+            return .endDate
+        }
+        else {
+            return .none
+        }
+    }
 }
 
 extension Chapter {

--- a/Sources/CoreBusiness/CoreBusiness.swift
+++ b/Sources/CoreBusiness/CoreBusiness.swift
@@ -1,9 +1,0 @@
-//
-//  Copyright (c) SRG SSR. All rights reserved.
-//
-//  License information is available from the LICENSE file.
-//
-
-/// Core business logic
-public struct CoreBusiness {
-}

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -23,4 +23,16 @@ final class DataProvider {
             .decode(type: MediaComposition.self, decoder: JSONDecoder())
             .eraseToAnyPublisher()
     }
+
+    func recommendedResource(forUrn urn: String) -> AnyPublisher<Resource, Error> {
+        mediaComposition(forUrn: urn)
+            .map(\.mainChapter.recommendedResource)
+            .tryMap { resource in
+                guard let resource else {
+                    throw ResourceLoadingError.notFound
+                }
+                return resource
+            }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -19,6 +19,7 @@ final class DataProvider {
     func mediaComposition(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
         let url = environment.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         return session.dataTaskPublisher(for: url)
+            .mapHttpErrors()
             .map(\.data)
             .decode(type: MediaComposition.self, decoder: JSONDecoder())
             .eraseToAnyPublisher()
@@ -29,7 +30,7 @@ final class DataProvider {
             .map(\.mainChapter.recommendedResource)
             .tryMap { resource in
                 guard let resource else {
-                    throw ResourceLoadingError.notFound
+                    throw DataError.notFound
                 }
                 return resource
             }

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -16,12 +16,18 @@ final class DataProvider {
         session = URLSession(configuration: .default)
     }
 
+    static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
     func mediaComposition(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
         let url = environment.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         return session.dataTaskPublisher(for: url)
             .mapHttpErrors()
             .map(\.data)
-            .decode(type: MediaComposition.self, decoder: JSONDecoder())
+            .decode(type: MediaComposition.self, decoder: Self.decoder())
             .eraseToAnyPublisher()
     }
 

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -30,22 +30,3 @@ struct DataError: LocalizedError {
         DataError(errorDescription: message)
     }
 }
-
-private extension String {
-    func capitalizingFirstLetter() -> String {
-        prefix(1).capitalized + dropFirst()
-    }
-}
-
-private extension HTTPURLResponse {
-    static func fixedLocalizedString(forStatusCode statusCode: Int) -> String {
-        // The `localizedString(forStatusCode:)` method always returns the English version, which we use as localization key
-        let key = localizedString(forStatusCode: statusCode)
-        if let description = Bundle(identifier: "com.apple.CFNetwork")?.localizedString(forKey: key, value: nil, table: nil) {
-            return description.capitalizingFirstLetter()
-        }
-        else {
-            return NSLocalizedString("Unknown error", comment: "Generic error message")
-        }
-    }
-}

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -8,4 +8,5 @@ import Foundation
 
 enum ResourceLoadingError: Error {
     case notFound
+    case http(statusCode: Int)
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -6,10 +6,10 @@
 
 import Foundation
 
-enum NetworkError: Error {
-    case http(statusCode: Int)
-}
-
 enum DataError: Error {
     case notFound
+}
+
+enum NetworkError: Error {
+    case http(statusCode: Int)
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -10,7 +10,10 @@ struct DataError: LocalizedError {
     let errorDescription: String?
 
     static var notFound: Self {
-        DataError(errorDescription: NSLocalizedString("The content cannot be played", comment: "Generic error message when some content cannot be played"))
+        DataError(errorDescription: NSLocalizedString(
+            "The content cannot be played",
+            comment: "Generic error message when some content cannot be played")
+        )
     }
 
     static func http(from response: URLResponse) -> Self? {
@@ -42,7 +45,7 @@ private extension HTTPURLResponse {
             return description.capitalizingFirstLetter()
         }
         else {
-            return "Unknown error"
+            return NSLocalizedString("Unknown error", comment: "Generic error message")
         }
     }
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -6,23 +6,25 @@
 
 import Foundation
 
-enum DataError: Error {
-    case notFound
-}
+struct DataError: LocalizedError {
+    let errorDescription: String?
 
-extension NSError {
-    static func httpError(from response: URLResponse) -> NSError? {
-        guard let httpResponse = response as? HTTPURLResponse else { return nil }
-        return httpError(withStatusCode: httpResponse.statusCode)
+    static var notFound: Self {
+        DataError(errorDescription: NSLocalizedString("The content cannot be played", comment: "Generic error message when some content cannot be played"))
     }
 
-    // Only errors with codes different from zero can be properly forwarded through the resource loader. The status
-    // code is therefore a natural choice for HTTP errors in a common dedicated domain.
-    static func httpError(withStatusCode statusCode: Int) -> NSError? {
+    static func http(from response: URLResponse) -> Self? {
+        guard let httpResponse = response as? HTTPURLResponse else { return nil }
+        return http(withStatusCode: httpResponse.statusCode)
+    }
+
+    static func http(withStatusCode statusCode: Int) -> Self? {
         guard statusCode >= 400 else { return nil }
-        return Self(domain: "ch.srgssr.pillarbox.core_business.network", code: statusCode, userInfo: [
-            NSLocalizedDescriptionKey: HTTPURLResponse.fixedLocalizedString(forStatusCode: statusCode)
-        ])
+        return DataError(errorDescription: HTTPURLResponse.fixedLocalizedString(forStatusCode: statusCode))
+    }
+
+    static func blocked(withMessage message: String) -> Self {
+        DataError(errorDescription: message)
     }
 }
 

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -10,6 +10,37 @@ enum DataError: Error {
     case notFound
 }
 
-enum NetworkError: Error {
-    case http(statusCode: Int)
+extension NSError {
+    static func httpError(from response: URLResponse) -> NSError? {
+        guard let httpResponse = response as? HTTPURLResponse else { return nil }
+        return httpError(withStatusCode: httpResponse.statusCode)
+    }
+
+    // Only errors with codes different from zero can be properly forwarded through the resource loader. The status
+    // code is therefore a natural choice for HTTP errors in a common dedicated domain.
+    static func httpError(withStatusCode statusCode: Int) -> NSError? {
+        guard statusCode >= 400 else { return nil }
+        return Self.init(domain: "ch.srgssr.pillarbox.core_business.network", code: statusCode, userInfo: [
+            NSLocalizedDescriptionKey: HTTPURLResponse.fixedLocalizedString(forStatusCode: statusCode)
+        ])
+    }
+}
+
+private extension String {
+    func capitalizingFirstLetter() -> String {
+        return prefix(1).capitalized + dropFirst()
+    }
+}
+
+private extension HTTPURLResponse {
+    static func fixedLocalizedString(forStatusCode statusCode: Int) -> String {
+        // The `localizedString(forStatusCode:)` method always returns the English version, which we use as localization key
+        let key = localizedString(forStatusCode: statusCode)
+        if let description = Bundle(identifier: "com.apple.CFNetwork")?.localizedString(forKey: key, value: nil, table: nil) {
+            return description.capitalizingFirstLetter()
+        }
+        else {
+            return "Unknown error"
+        }
+    }
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -6,7 +6,10 @@
 
 import Foundation
 
-enum ResourceLoadingError: Error {
-    case notFound
+enum NetworkError: Error {
     case http(statusCode: Int)
+}
+
+enum DataError: Error {
+    case notFound
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -20,7 +20,7 @@ extension NSError {
     // code is therefore a natural choice for HTTP errors in a common dedicated domain.
     static func httpError(withStatusCode statusCode: Int) -> NSError? {
         guard statusCode >= 400 else { return nil }
-        return Self.init(domain: "ch.srgssr.pillarbox.core_business.network", code: statusCode, userInfo: [
+        return Self(domain: "ch.srgssr.pillarbox.core_business.network", code: statusCode, userInfo: [
             NSLocalizedDescriptionKey: HTTPURLResponse.fixedLocalizedString(forStatusCode: statusCode)
         ])
     }
@@ -28,7 +28,7 @@ extension NSError {
 
 private extension String {
     func capitalizingFirstLetter() -> String {
-        return prefix(1).capitalized + dropFirst()
+        prefix(1).capitalized + dropFirst()
     }
 }
 

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -7,14 +7,14 @@
 import Foundation
 
 struct DataError: LocalizedError {
-    let errorDescription: String?
-
     static var notFound: Self {
         DataError(errorDescription: NSLocalizedString(
             "The content cannot be played",
-            comment: "Generic error message when some content cannot be played")
-        )
+            comment: "Generic error message when some content cannot be played"
+        ))
     }
+
+    let errorDescription: String?
 
     static func http(from response: URLResponse) -> Self? {
         guard let httpResponse = response as? HTTPURLResponse else { return nil }

--- a/Sources/CoreBusiness/HTTPURLResponse.swift
+++ b/Sources/CoreBusiness/HTTPURLResponse.swift
@@ -6,12 +6,6 @@
 
 import Foundation
 
-private extension String {
-    func capitalizingFirstLetter() -> String {
-        prefix(1).capitalized + dropFirst()
-    }
-}
-
 extension HTTPURLResponse {
     static func fixedLocalizedString(forStatusCode statusCode: Int) -> String {
         // The `localizedString(forStatusCode:)` method always returns the English version (FB5751726). We can still use
@@ -29,5 +23,11 @@ extension HTTPURLResponse {
         else {
             return NSLocalizedString("Unknown error", comment: "Generic error message")
         }
+    }
+}
+
+private extension String {
+    func capitalizingFirstLetter() -> String {
+        prefix(1).capitalized + dropFirst()
     }
 }

--- a/Sources/CoreBusiness/HTTPURLResponse.swift
+++ b/Sources/CoreBusiness/HTTPURLResponse.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+private extension String {
+    func capitalizingFirstLetter() -> String {
+        prefix(1).capitalized + dropFirst()
+    }
+}
+
+extension HTTPURLResponse {
+    static func fixedLocalizedString(forStatusCode statusCode: Int) -> String {
+        // The `localizedString(forStatusCode:)` method always returns the English version (FB5751726). We can still use
+        // this string as key to retrieve the correct translation from CFNetwork. If the status code is invalid the method
+        // always returns "Server error".
+        return coreNetworkLocalizedString(forKey: localizedString(forStatusCode: statusCode))
+    }
+
+    static func coreNetworkLocalizedString(forKey key: String) -> String {
+        let missingKey = "pillarbox_missing_key"
+        if let description = Bundle(identifier: "com.apple.CFNetwork")?.localizedString(forKey: key, value: missingKey, table: nil),
+           description != missingKey {
+            return description.capitalizingFirstLetter()
+        }
+        else {
+            return NSLocalizedString("Unknown error", comment: "Generic error message")
+        }
+    }
+}

--- a/Sources/CoreBusiness/Publishers.swift
+++ b/Sources/CoreBusiness/Publishers.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Publisher {
     func mapHttpErrors() -> Publishers.TryMap<Self, Output> where Output == URLSession.DataTaskPublisher.Output {
-        return tryMap { result in
+        tryMap { result in
             if let httpResponse = result.response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
                 throw NetworkError.http(statusCode: httpResponse.statusCode)
             }

--- a/Sources/CoreBusiness/Publishers.swift
+++ b/Sources/CoreBusiness/Publishers.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Publisher {
     func mapHttpErrors() -> Publishers.TryMap<Self, Output> where Output == URLSession.DataTaskPublisher.Output {
         tryMap { result in
-            if let httpError = NSError.httpError(from: result.response) {
+            if let httpError = DataError.http(from: result.response) {
                 throw httpError
             }
             return result

--- a/Sources/CoreBusiness/Publishers.swift
+++ b/Sources/CoreBusiness/Publishers.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Foundation
+
+extension Publisher {
+    func mapHttpErrors() -> Publishers.TryMap<Self, Output> where Output == URLSession.DataTaskPublisher.Output {
+        return tryMap { result in
+            if let httpResponse = result.response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
+                throw NetworkError.http(statusCode: httpResponse.statusCode)
+            }
+            return result
+        }
+    }
+}

--- a/Sources/CoreBusiness/Publishers.swift
+++ b/Sources/CoreBusiness/Publishers.swift
@@ -10,8 +10,8 @@ import Foundation
 extension Publisher {
     func mapHttpErrors() -> Publishers.TryMap<Self, Output> where Output == URLSession.DataTaskPublisher.Output {
         tryMap { result in
-            if let httpResponse = result.response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-                throw NetworkError.http(statusCode: httpResponse.statusCode)
+            if let httpError = NSError.httpError(from: result.response) {
+                throw httpError
             }
             return result
         }

--- a/Sources/CoreBusiness/URLCoding.swift
+++ b/Sources/CoreBusiness/URLCoding.swift
@@ -11,7 +11,8 @@ enum URLCoding {
     private static let parameterName = "urn"
 
     static func encodeUrl(fromUrn urn: String) -> URL {
-        var components = URLComponents(string: "\(scheme)://mediacomposition")!
+        // An appropriate extension is required so that errors can be correctly forwarded by the resource loader.
+        var components = URLComponents(string: "\(scheme)://mediacomposition.m3u8")!
         components.queryItems = [
             URLQueryItem(name: parameterName, value: urn.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         ]

--- a/Sources/Player/Errors.swift
+++ b/Sources/Player/Errors.swift
@@ -9,3 +9,16 @@ import Foundation
 enum PlaybackError: Error {
     case unknown
 }
+
+extension Error {
+    // Errors returned through `AVAssetResourceLoader` do not apply correct error localization rules. Fix.
+    func localized() -> Error {
+        let error = self as NSError
+        var userInfo = error.userInfo
+        let descriptionKey = "NSDescription"
+        guard let description = userInfo[descriptionKey] else { return self }
+        userInfo[NSLocalizedDescriptionKey] = description
+        userInfo[descriptionKey] = nil
+        return NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+    }
+}

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -13,7 +13,7 @@ extension AVPlayerItem {
             publisher(for: \.status)
                 .weakCapture(self, at: \.error)
                 .map { status, error in
-                    ItemState.itemState(for: status, error: Self.localizeError(error))
+                    ItemState.itemState(for: status, error: error?.localized())
                 },
             NotificationCenter.default.weakPublisher(for: .AVPlayerItemDidPlayToEndTime, object: self)
                 .map { _ in .ended }
@@ -42,15 +42,5 @@ extension AVPlayerItem {
             }
         }
         .eraseToAnyPublisher()
-    }
-
-    // Errors returned through `AVAssetResourceLoader` do not apply correct error localization rules. Fix.
-    private static func localizeError(_ error: Error?) -> Error? {
-        guard let error = error as? NSError else { return nil }
-        var userInfo = error.userInfo
-        let descriptionKey = "NSDescription"
-        userInfo[NSLocalizedDescriptionKey] = userInfo[descriptionKey]
-        userInfo[descriptionKey] = nil
-        return NSError(domain: error.domain, code: error.code, userInfo: userInfo)
     }
 }

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -13,7 +13,7 @@ extension AVPlayerItem {
             publisher(for: \.status)
                 .weakCapture(self, at: \.error)
                 .map { status, error in
-                    ItemState.itemState(for: status, error: error)
+                    ItemState.itemState(for: status, error: Self.localizeError(error))
                 },
             NotificationCenter.default.weakPublisher(for: .AVPlayerItemDidPlayToEndTime, object: self)
                 .map { _ in .ended }
@@ -42,5 +42,15 @@ extension AVPlayerItem {
             }
         }
         .eraseToAnyPublisher()
+    }
+
+    // Errors returned through `AVAssetResourceLoader` do not apply correct error localization rules. Fix.
+    private static func localizeError(_ error: Error?) -> Error? {
+        guard let error = error as? NSError else { return nil }
+        var userInfo = error.userInfo
+        let descriptionKey = "NSDescription"
+        userInfo[NSLocalizedDescriptionKey] = userInfo[descriptionKey]
+        userInfo[descriptionKey] = nil
+        return NSError(domain: error.domain, code: error.code, userInfo: userInfo)
     }
 }

--- a/Tests/CircumspectTests/ExpectationsTests.swift
+++ b/Tests/CircumspectTests/ExpectationsTests.swift
@@ -110,8 +110,12 @@ final class ExpectationTests: XCTestCase {
         expectSuccess(from: Empty<Int, Error>())
     }
 
-    func testFailure() {
+    func testExpectFailure() {
         expectFailure(from: Fail<Int, Error>(error: TestError.any))
+    }
+
+    func testExpectFailureWithError() {
+        expectFailure(TestError.any, from: Fail<Int, Error>(error: TestError.any))
     }
 
     func testExpectReceivedNotifications() {

--- a/Tests/CoreBusinessTests/ChaptersTests.swift
+++ b/Tests/CoreBusinessTests/ChaptersTests.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Nimble
+import XCTest
+
+final class ChaptersTests: XCTestCase {
+    private static func date(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        return Calendar.current.date(from: components)!
+    }
+
+    func testNotBlocked() {
+        expect(Mock.chapter().blockingReason()).to(beNil())
+    }
+
+    func testGeoblocked() {
+        expect(Mock.chapter(.geoblocked).blockingReason()).to(equal(.geoblocked))
+    }
+
+    func testAvailable() {
+        let date = Self.date(year: 2022, month: 09, day: 21)
+        expect(Mock.chapter(.timeLimited).blockingReason(at: date)).to(beNil())
+    }
+
+    func testNotAvailableYet() {
+        let date = Self.date(year: 2022, month: 01, day: 01)
+        expect(Mock.chapter(.timeLimited).blockingReason(at: date)).to(equal(.startDate))
+    }
+
+    func testNotAvailableAnymore() {
+        let date = Self.date(year: 2022, month: 12, day: 31)
+        expect(Mock.chapter(.timeLimited).blockingReason(at: date)).to(equal(.endDate))
+    }
+}

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import XCTest
 
 final class DataProviderTests: XCTestCase {
-    func testValidMediaComposition() {
+    func testExistingMediaComposition() {
         expectSuccess(
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:6820736")
         )
@@ -18,14 +18,21 @@ final class DataProviderTests: XCTestCase {
 
     func testNonExistingMediaComposition() {
         expectFailure(
-            NSError.httpError(withStatusCode: 404),
+            DataError.http(withStatusCode: 404),
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:unknown")
         )
     }
 
-    func testValidRecommendedResource() {
+    func testExistingRecommendedResource() {
         expectSuccess(
-            from: DataProvider().recommendedResource(forUrn: "urn:rts:video:6820736")
+            from: DataProvider().recommendedPlayableResource(forUrn: "urn:rts:video:6820736")
+        )
+    }
+
+    func testBlockedMediaComposition() {
+        expectFailure(
+            DataError.blocked(withMessage: "This content is not available anymore."),
+            from: DataProvider().playableMediaComposition(forUrn: "urn:rts:video:13382911")
         )
     }
 }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -18,7 +18,7 @@ final class DataProviderTests: XCTestCase {
 
     func testNonExistingMediaComposition() {
         expectFailure(
-            NetworkError.http(statusCode: 404),
+            NSError.httpError(withStatusCode: 404),
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:unknown")
         )
     }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -18,6 +18,7 @@ final class DataProviderTests: XCTestCase {
 
     func testNonExistingMediaComposition() {
         expectFailure(
+            ResourceLoadingError.http(statusCode: 404),
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:unknown")
         )
     }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -18,7 +18,7 @@ final class DataProviderTests: XCTestCase {
 
     func testNonExistingMediaComposition() {
         expectFailure(
-            ResourceLoadingError.http(statusCode: 404),
+            NetworkError.http(statusCode: 404),
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:unknown")
         )
     }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -22,4 +22,10 @@ final class DataProviderTests: XCTestCase {
             from: DataProvider().mediaComposition(forUrn: "urn:rts:video:unknown")
         )
     }
+
+    func testValidRecommendedResource() {
+        expectSuccess(
+            from: DataProvider().recommendedResource(forUrn: "urn:rts:video:6820736")
+        )
+    }
 }

--- a/Tests/CoreBusinessTests/ErrorsTests.swift
+++ b/Tests/CoreBusinessTests/ErrorsTests.swift
@@ -21,4 +21,3 @@ final class ErrorTests: XCTestCase {
         expect(NSError.httpError(withStatusCode: 200)).to(beNil())
     }
 }
-

--- a/Tests/CoreBusinessTests/ErrorsTests.swift
+++ b/Tests/CoreBusinessTests/ErrorsTests.swift
@@ -11,13 +11,10 @@ import XCTest
 
 final class ErrorTests: XCTestCase {
     func testHttpError() {
-        let error = NSError.httpError(withStatusCode: 404)!
-        expect(error.domain).to(equal("ch.srgssr.pillarbox.core_business.network"))
-        expect(error.code).to(equal(404))
-        expect(error.localizedDescription).notTo(beNil())
+        expect(DataError.http(withStatusCode: 404)).notTo(beNil())
     }
 
-    func testNotHttpError() {
-        expect(NSError.httpError(withStatusCode: 200)).to(beNil())
+    func testNotHttpNSError() {
+        expect(DataError.http(withStatusCode: 200)).to(beNil())
     }
 }

--- a/Tests/CoreBusinessTests/ErrorsTests.swift
+++ b/Tests/CoreBusinessTests/ErrorsTests.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Nimble
+import XCTest
+
+final class ErrorTests: XCTestCase {
+    func testHttpError() {
+        let error = NSError.httpError(withStatusCode: 404)!
+        expect(error.domain).to(equal("ch.srgssr.pillarbox.core_business.network"))
+        expect(error.code).to(equal(404))
+        expect(error.localizedDescription).notTo(beNil())
+    }
+
+    func testNotHttpError() {
+        expect(NSError.httpError(withStatusCode: 200)).to(beNil())
+    }
+}
+

--- a/Tests/CoreBusinessTests/HTTPURLResponseTests.swift
+++ b/Tests/CoreBusinessTests/HTTPURLResponseTests.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Nimble
+import XCTest
+
+final class HTTPURLResponseTests: XCTestCase {
+    func testFixedLocalizedStringForValidStatusCode() {
+        expect(HTTPURLResponse.fixedLocalizedString(forStatusCode: 404)).to(equal("Not found"))
+    }
+
+    func testFixedLocalizedStringForInvalidStatusCode() {
+        expect(HTTPURLResponse.fixedLocalizedString(forStatusCode: 956)).to(equal("Server error"))
+    }
+
+    func testNetworkLocalizedStringForValidKey() {
+        expect(HTTPURLResponse.coreNetworkLocalizedString(forKey: "not found")).to(equal("Not found"))
+    }
+
+    func testNetworkLocalizedStringForInvalidKey() {
+        expect(HTTPURLResponse.coreNetworkLocalizedString(forKey: "Some key which does not exist")).to(equal("Unknown error"))
+    }
+}

--- a/Tests/CoreBusinessTests/Mock.swift
+++ b/Tests/CoreBusinessTests/Mock.swift
@@ -10,13 +10,24 @@ import Foundation
 import UIKit
 
 enum Mock {
+    enum ChapterKind: String {
+        case standard
+        case geoblocked
+        case timeLimited
+    }
+
     enum MediaCompositionKind: String {
         case onDemand
         case live
     }
 
+    static func chapter(_ kind: ChapterKind = .standard) -> Chapter {
+        let data = NSDataAsset(name: "Chapter_\(kind.rawValue)", bundle: .module)!.data
+        return try! DataProvider.decoder().decode(Chapter.self, from: data)
+    }
+
     static func mediaComposition(_ kind: MediaCompositionKind = .onDemand) -> MediaComposition {
         let data = NSDataAsset(name: "MediaComposition_\(kind.rawValue)", bundle: .module)!.data
-        return try! JSONDecoder().decode(MediaComposition.self, from: data)
+        return try! DataProvider.decoder().decode(MediaComposition.self, from: data)
     }
 }

--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 final class PlayerItemTests: XCTestCase {
     func testPlayback() {
-        let item = PlayerItem(urn: "urn:srf:video:2fde31db-e9a7-4233-a9eb-06ec19f18ba9", automaticallyLoadedAssetKeys: [])
+        let item = PlayerItem(urn: "urn:srf:video:2fde31db-e9a7-4233-a9eb-06ec19f18ba9")
         let player = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher()) {
             player.play()
@@ -21,7 +21,7 @@ final class PlayerItemTests: XCTestCase {
     }
 
     func testFailure() {
-        let item = PlayerItem(urn: "invalid", automaticallyLoadedAssetKeys: [])
+        let item = PlayerItem(urn: "invalid")
         let player = AVPlayer(playerItem: item)
         expectAtLeastSimilarPublished(values: [.idle, .failed(error: TestError.any)], from: player.playbackStatePublisher()) {
             player.play()

--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -20,13 +20,27 @@ final class PlayerItemTests: XCTestCase {
         }
     }
 
-    func testFailure() {
+    func testUnknownMedia() {
         let item = PlayerItem(urn: "urn:srf:video:unknown")
         let player = AVPlayer(playerItem: item)
-        expectAtLeastEqualPublished(
+        expectAtLeastSimilarPublished(
             values: [
                 .idle,
-                .failed(error: NSError.httpError(withStatusCode: 404)!)
+                .failed(error: TestError.any)
+            ],
+            from: player.playbackStatePublisher()
+        ) {
+            player.play()
+        }
+    }
+
+    func testUnavailableMedia() {
+        let item = PlayerItem(urn: "urn:rts:video:13382911")
+        let player = AVPlayer(playerItem: item)
+        expectAtLeastSimilarPublished(
+            values: [
+                .idle,
+                .failed(error: TestError.any)
             ],
             from: player.playbackStatePublisher()
         ) {

--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -21,9 +21,15 @@ final class PlayerItemTests: XCTestCase {
     }
 
     func testFailure() {
-        let item = PlayerItem(urn: "invalid")
+        let item = PlayerItem(urn: "urn:srf:video:unknown")
         let player = AVPlayer(playerItem: item)
-        expectAtLeastSimilarPublished(values: [.idle, .failed(error: TestError.any)], from: player.playbackStatePublisher()) {
+        expectAtLeastEqualPublished(
+            values: [
+                .idle,
+                .failed(error: NSError.httpError(withStatusCode: 404)!)
+            ],
+            from: player.playbackStatePublisher()
+        ) {
             player.play()
         }
     }

--- a/Tests/CoreBusinessTests/PublishersTests.swift
+++ b/Tests/CoreBusinessTests/PublishersTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class PublishersTests: XCTestCase {
     func testHttpError() {
         expectFailure(
-            NSError.httpError(withStatusCode: 404),
+            DataError.http(withStatusCode: 404),
             from: URLSession.shared.dataTaskPublisher(for: URL(string: "http://localhost:8123/not_found")!)
                 .mapHttpErrors()
         )

--- a/Tests/CoreBusinessTests/PublishersTests.swift
+++ b/Tests/CoreBusinessTests/PublishersTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class PublishersTests: XCTestCase {
     func testHttpError() {
         expectFailure(
-            NetworkError.http(statusCode: 404),
+            NSError.httpError(withStatusCode: 404),
             from: URLSession.shared.dataTaskPublisher(for: URL(string: "http://localhost:8123/not_found")!)
                 .mapHttpErrors()
         )

--- a/Tests/CoreBusinessTests/PublishersTests.swift
+++ b/Tests/CoreBusinessTests/PublishersTests.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Circumspect
+import XCTest
+
+final class PublishersTests: XCTestCase {
+    func testHttpError() {
+        expectFailure(
+            NetworkError.http(statusCode: 404),
+            from: URLSession.shared.dataTaskPublisher(for: URL(string: "http://localhost:8123/not_found")!)
+                .mapHttpErrors()
+        )
+    }
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_geoblocked.dataset/Chapter_geoblocked.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_geoblocked.dataset/Chapter_geoblocked.json
@@ -1,0 +1,139 @@
+{
+  "id": "13382911",
+  "mediaType": "VIDEO",
+  "vendor": "RTS",
+  "urn": "urn:rts:video:13382911",
+  "title": "Hostiles",
+  "description": "En 1892, le capitaine de cavalerie Joseph Blocker, ancien héros de guerre devenu gardien de prison, est contraint d’escorter Yellow Hawk, chef de guerre Cheyenne mourant, sur ses anciennes terres tribales. Peu après avoir pris la route, ils rencontrent Rosalee Quaid. Seule rescapée du massacre de sa famille par les Comanches, la jeune femme traumatisée se joint à eux dans leur périple.",
+  "imageUrl": "https://www.rts.ch/2022/09/20/09/57/13365589.image/16x9",
+  "imageTitle": "Hostiles, Scott Cooper. [RTS]",
+  "imageCopyright": "RTS",
+  "blockReason": "GEOBLOCK",
+  "youthProtectionColor": "RED",
+  "type": "EPISODE",
+  "date": "2022-09-17T22:50:54+02:00",
+  "duration": 7663440,
+  "playableAbroad": false,
+  "socialCountList": [
+    {
+      "key": "srgView",
+      "value": 5191
+    },
+    {
+      "key": "srgLike",
+      "value": 0
+    },
+    {
+      "key": "fbShare",
+      "value": 0
+    },
+    {
+      "key": "twitterShare",
+      "value": 0
+    },
+    {
+      "key": "googleShare",
+      "value": 0
+    },
+    {
+      "key": "whatsAppShare",
+      "value": 0
+    }
+  ],
+  "displayable": false,
+  "position": 0,
+  "noEmbed": true,
+  "analyticsData": {
+    "ns_st_ep": "Hostiles",
+    "ns_st_ty": "Video",
+    "ns_st_ci": "13382911",
+    "ns_st_el": "7663440",
+    "ns_st_cl": "7663440",
+    "ns_st_sl": "7663440",
+    "srg_mgeobl": "true",
+    "ns_st_tp": "1",
+    "ns_st_cn": "1",
+    "ns_st_ct": "vc12",
+    "ns_st_pn": "1",
+    "ns_st_cdm": "to",
+    "ns_st_cmt": "fc"
+  },
+  "analyticsMetadata": {
+    "media_segment": "Hostiles",
+    "media_type": "Video",
+    "media_segment_id": "13382911",
+    "media_episode_length": "7663",
+    "media_segment_length": "7663",
+    "media_number_of_segment_selected": "1",
+    "media_number_of_segments_total": "1",
+    "media_duration_category": "long",
+    "media_is_geoblocked": "true",
+    "media_is_web_only": "false",
+    "media_production_source": "produced.for.broadcasting",
+    "media_urn": "urn:rts:video:13382911"
+  },
+  "eventData": "$a9c6d2762abebe96$804b2c3c8875dd495b391d33f77909e63e235fc20d76db67d73ca917289f237e9e170283053e040bf965c2665b2fccc00acb5cd2a54f079c0b34f76b6874f403d83e04d416499c010c500815e22dc6fcde5cbe1d710059ef53b94ddb7c33a6df6b820ebfa74cd71ececa0c7aecae55906066acb90de95cca7f59928842d9cbcd5368cd640545af698a48ea21711ffd5fa6d941dc6806c1b641b7f836b14ab86e1896bdab8f234ea4c3c53a7df786029b0645f8e9d95dcfd80f66ee6897109fe36276f849c09a601a177fb4668322b085c7acb436ac4e7781bf29a3523c173214f704f171376ff199319859d95f86dbe3007781adcd33c841b0d2cb6724b66a79a7c17793063cec859a4e65d680ee13b511abbdc80c4632ccf7ba1e954507a3f2b47028c7b02699253682fc43ffd16350c06adc9993bb984ac708f3af034bd184b9f3aa02d462374e54761c9a012cc94a5462d745497ea6f1aa7c5b7c4719b0e05d056b784667855175ca1a7ae0762422",
+  "resourceList": [
+    {
+      "url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8",
+      "quality": "HD",
+      "protocol": "HLS",
+      "encoding": "H264",
+      "mimeType": "application/x-mpegURL",
+      "presentation": "DEFAULT",
+      "streaming": "HLS",
+      "dvr": false,
+      "live": false,
+      "mediaContainer": "MPEG2_TS",
+      "audioCodec": "AAC",
+      "videoCodec": "H264",
+      "tokenType": "NONE",
+      "audioTrackList": [
+        {
+          "locale": "fr",
+          "language": "Français",
+          "source": "HLS"
+        },
+        {
+          "locale": "en",
+          "language": "English",
+          "source": "HLS"
+        }
+      ],
+      "subtitleInformationList": [
+        {
+          "locale": "fr",
+          "language": "Français (SDH)",
+          "source": "HLS",
+          "type": "SDH"
+        }
+      ],
+      "analyticsData": {
+        "srg_mqual": "HD",
+        "srg_mpres": "DEFAULT"
+      },
+      "analyticsMetadata": {
+        "media_streaming_quality": "HD",
+        "media_special_format": "DEFAULT",
+        "media_url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8"
+      }
+    }
+  ],
+  "aspectRatio": "16:9",
+  "spriteSheet": {
+    "urn": "urn:rts:video:13382911",
+    "rows": 30,
+    "columns": 20,
+    "thumbnailHeight": 84,
+    "thumbnailWidth": 150,
+    "interval": 13000,
+    "url": "https://il.srgssr.ch/spritesheet/urn/rts/video/13382911/sprite-13382911.jpeg"
+  },
+  "timeIntervalList": [
+    {
+      "type": "CLOSING_CREDITS",
+      "markIn": 7297480,
+      "markOut": 7663440
+    }
+  ]
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_geoblocked.dataset/Contents.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_geoblocked.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "Chapter_geoblocked.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_standard.dataset/Chapter_standard.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_standard.dataset/Chapter_standard.json
@@ -1,0 +1,138 @@
+{
+  "id": "13382911",
+  "mediaType": "VIDEO",
+  "vendor": "RTS",
+  "urn": "urn:rts:video:13382911",
+  "title": "Hostiles",
+  "description": "En 1892, le capitaine de cavalerie Joseph Blocker, ancien héros de guerre devenu gardien de prison, est contraint d’escorter Yellow Hawk, chef de guerre Cheyenne mourant, sur ses anciennes terres tribales. Peu après avoir pris la route, ils rencontrent Rosalee Quaid. Seule rescapée du massacre de sa famille par les Comanches, la jeune femme traumatisée se joint à eux dans leur périple.",
+  "imageUrl": "https://www.rts.ch/2022/09/20/09/57/13365589.image/16x9",
+  "imageTitle": "Hostiles, Scott Cooper. [RTS]",
+  "imageCopyright": "RTS",
+  "youthProtectionColor": "RED",
+  "type": "EPISODE",
+  "date": "2022-09-17T22:50:54+02:00",
+  "duration": 7663440,
+  "playableAbroad": false,
+  "socialCountList": [
+    {
+      "key": "srgView",
+      "value": 5191
+    },
+    {
+      "key": "srgLike",
+      "value": 0
+    },
+    {
+      "key": "fbShare",
+      "value": 0
+    },
+    {
+      "key": "twitterShare",
+      "value": 0
+    },
+    {
+      "key": "googleShare",
+      "value": 0
+    },
+    {
+      "key": "whatsAppShare",
+      "value": 0
+    }
+  ],
+  "displayable": false,
+  "position": 0,
+  "noEmbed": true,
+  "analyticsData": {
+    "ns_st_ep": "Hostiles",
+    "ns_st_ty": "Video",
+    "ns_st_ci": "13382911",
+    "ns_st_el": "7663440",
+    "ns_st_cl": "7663440",
+    "ns_st_sl": "7663440",
+    "srg_mgeobl": "true",
+    "ns_st_tp": "1",
+    "ns_st_cn": "1",
+    "ns_st_ct": "vc12",
+    "ns_st_pn": "1",
+    "ns_st_cdm": "to",
+    "ns_st_cmt": "fc"
+  },
+  "analyticsMetadata": {
+    "media_segment": "Hostiles",
+    "media_type": "Video",
+    "media_segment_id": "13382911",
+    "media_episode_length": "7663",
+    "media_segment_length": "7663",
+    "media_number_of_segment_selected": "1",
+    "media_number_of_segments_total": "1",
+    "media_duration_category": "long",
+    "media_is_geoblocked": "true",
+    "media_is_web_only": "false",
+    "media_production_source": "produced.for.broadcasting",
+    "media_urn": "urn:rts:video:13382911"
+  },
+  "eventData": "$a9c6d2762abebe96$804b2c3c8875dd495b391d33f77909e63e235fc20d76db67d73ca917289f237e9e170283053e040bf965c2665b2fccc00acb5cd2a54f079c0b34f76b6874f403d83e04d416499c010c500815e22dc6fcde5cbe1d710059ef53b94ddb7c33a6df6b820ebfa74cd71ececa0c7aecae55906066acb90de95cca7f59928842d9cbcd5368cd640545af698a48ea21711ffd5fa6d941dc6806c1b641b7f836b14ab86e1896bdab8f234ea4c3c53a7df786029b0645f8e9d95dcfd80f66ee6897109fe36276f849c09a601a177fb4668322b085c7acb436ac4e7781bf29a3523c173214f704f171376ff199319859d95f86dbe3007781adcd33c841b0d2cb6724b66a79a7c17793063cec859a4e65d680ee13b511abbdc80c4632ccf7ba1e954507a3f2b47028c7b02699253682fc43ffd16350c06adc9993bb984ac708f3af034bd184b9f3aa02d462374e54761c9a012cc94a5462d745497ea6f1aa7c5b7c4719b0e05d056b784667855175ca1a7ae0762422",
+  "resourceList": [
+    {
+      "url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8",
+      "quality": "HD",
+      "protocol": "HLS",
+      "encoding": "H264",
+      "mimeType": "application/x-mpegURL",
+      "presentation": "DEFAULT",
+      "streaming": "HLS",
+      "dvr": false,
+      "live": false,
+      "mediaContainer": "MPEG2_TS",
+      "audioCodec": "AAC",
+      "videoCodec": "H264",
+      "tokenType": "NONE",
+      "audioTrackList": [
+        {
+          "locale": "fr",
+          "language": "Français",
+          "source": "HLS"
+        },
+        {
+          "locale": "en",
+          "language": "English",
+          "source": "HLS"
+        }
+      ],
+      "subtitleInformationList": [
+        {
+          "locale": "fr",
+          "language": "Français (SDH)",
+          "source": "HLS",
+          "type": "SDH"
+        }
+      ],
+      "analyticsData": {
+        "srg_mqual": "HD",
+        "srg_mpres": "DEFAULT"
+      },
+      "analyticsMetadata": {
+        "media_streaming_quality": "HD",
+        "media_special_format": "DEFAULT",
+        "media_url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8"
+      }
+    }
+  ],
+  "aspectRatio": "16:9",
+  "spriteSheet": {
+    "urn": "urn:rts:video:13382911",
+    "rows": 30,
+    "columns": 20,
+    "thumbnailHeight": 84,
+    "thumbnailWidth": 150,
+    "interval": 13000,
+    "url": "https://il.srgssr.ch/spritesheet/urn/rts/video/13382911/sprite-13382911.jpeg"
+  },
+  "timeIntervalList": [
+    {
+      "type": "CLOSING_CREDITS",
+      "markIn": 7297480,
+      "markOut": 7663440
+    }
+  ]
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_standard.dataset/Contents.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_standard.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "Chapter_standard.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_timeLimited.dataset/Chapter_timeLimited.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_timeLimited.dataset/Chapter_timeLimited.json
@@ -1,0 +1,140 @@
+{
+  "id": "13382911",
+  "mediaType": "VIDEO",
+  "vendor": "RTS",
+  "urn": "urn:rts:video:13382911",
+  "title": "Hostiles",
+  "description": "En 1892, le capitaine de cavalerie Joseph Blocker, ancien héros de guerre devenu gardien de prison, est contraint d’escorter Yellow Hawk, chef de guerre Cheyenne mourant, sur ses anciennes terres tribales. Peu après avoir pris la route, ils rencontrent Rosalee Quaid. Seule rescapée du massacre de sa famille par les Comanches, la jeune femme traumatisée se joint à eux dans leur périple.",
+  "imageUrl": "https://www.rts.ch/2022/09/20/09/57/13365589.image/16x9",
+  "imageTitle": "Hostiles, Scott Cooper. [RTS]",
+  "imageCopyright": "RTS",
+  "youthProtectionColor": "RED",
+  "type": "EPISODE",
+  "date": "2022-09-17T22:50:54+02:00",
+  "duration": 7663440,
+  "validFrom": "2022-09-18T01:07:59+02:00",
+  "validTo": "2022-09-24T23:59:00+02:00",
+  "playableAbroad": false,
+  "socialCountList": [
+    {
+      "key": "srgView",
+      "value": 5191
+    },
+    {
+      "key": "srgLike",
+      "value": 0
+    },
+    {
+      "key": "fbShare",
+      "value": 0
+    },
+    {
+      "key": "twitterShare",
+      "value": 0
+    },
+    {
+      "key": "googleShare",
+      "value": 0
+    },
+    {
+      "key": "whatsAppShare",
+      "value": 0
+    }
+  ],
+  "displayable": false,
+  "position": 0,
+  "noEmbed": true,
+  "analyticsData": {
+    "ns_st_ep": "Hostiles",
+    "ns_st_ty": "Video",
+    "ns_st_ci": "13382911",
+    "ns_st_el": "7663440",
+    "ns_st_cl": "7663440",
+    "ns_st_sl": "7663440",
+    "srg_mgeobl": "true",
+    "ns_st_tp": "1",
+    "ns_st_cn": "1",
+    "ns_st_ct": "vc12",
+    "ns_st_pn": "1",
+    "ns_st_cdm": "to",
+    "ns_st_cmt": "fc"
+  },
+  "analyticsMetadata": {
+    "media_segment": "Hostiles",
+    "media_type": "Video",
+    "media_segment_id": "13382911",
+    "media_episode_length": "7663",
+    "media_segment_length": "7663",
+    "media_number_of_segment_selected": "1",
+    "media_number_of_segments_total": "1",
+    "media_duration_category": "long",
+    "media_is_geoblocked": "true",
+    "media_is_web_only": "false",
+    "media_production_source": "produced.for.broadcasting",
+    "media_urn": "urn:rts:video:13382911"
+  },
+  "eventData": "$a9c6d2762abebe96$804b2c3c8875dd495b391d33f77909e63e235fc20d76db67d73ca917289f237e9e170283053e040bf965c2665b2fccc00acb5cd2a54f079c0b34f76b6874f403d83e04d416499c010c500815e22dc6fcde5cbe1d710059ef53b94ddb7c33a6df6b820ebfa74cd71ececa0c7aecae55906066acb90de95cca7f59928842d9cbcd5368cd640545af698a48ea21711ffd5fa6d941dc6806c1b641b7f836b14ab86e1896bdab8f234ea4c3c53a7df786029b0645f8e9d95dcfd80f66ee6897109fe36276f849c09a601a177fb4668322b085c7acb436ac4e7781bf29a3523c173214f704f171376ff199319859d95f86dbe3007781adcd33c841b0d2cb6724b66a79a7c17793063cec859a4e65d680ee13b511abbdc80c4632ccf7ba1e954507a3f2b47028c7b02699253682fc43ffd16350c06adc9993bb984ac708f3af034bd184b9f3aa02d462374e54761c9a012cc94a5462d745497ea6f1aa7c5b7c4719b0e05d056b784667855175ca1a7ae0762422",
+  "resourceList": [
+    {
+      "url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8",
+      "quality": "HD",
+      "protocol": "HLS",
+      "encoding": "H264",
+      "mimeType": "application/x-mpegURL",
+      "presentation": "DEFAULT",
+      "streaming": "HLS",
+      "dvr": false,
+      "live": false,
+      "mediaContainer": "MPEG2_TS",
+      "audioCodec": "AAC",
+      "videoCodec": "H264",
+      "tokenType": "NONE",
+      "audioTrackList": [
+        {
+          "locale": "fr",
+          "language": "Français",
+          "source": "HLS"
+        },
+        {
+          "locale": "en",
+          "language": "English",
+          "source": "HLS"
+        }
+      ],
+      "subtitleInformationList": [
+        {
+          "locale": "fr",
+          "language": "Français (SDH)",
+          "source": "HLS",
+          "type": "SDH"
+        }
+      ],
+      "analyticsData": {
+        "srg_mqual": "HD",
+        "srg_mpres": "DEFAULT"
+      },
+      "analyticsMetadata": {
+        "media_streaming_quality": "HD",
+        "media_special_format": "DEFAULT",
+        "media_url": "https://rts-vod-amd.akamaized.net/ch/13382911/22b713f0-8b90-3a8f-8189-e29d4eb10eb9/master.m3u8"
+      }
+    }
+  ],
+  "aspectRatio": "16:9",
+  "spriteSheet": {
+    "urn": "urn:rts:video:13382911",
+    "rows": 30,
+    "columns": 20,
+    "thumbnailHeight": 84,
+    "thumbnailWidth": 150,
+    "interval": 13000,
+    "url": "https://il.srgssr.ch/spritesheet/urn/rts/video/13382911/sprite-13382911.jpeg"
+  },
+  "timeIntervalList": [
+    {
+      "type": "CLOSING_CREDITS",
+      "markIn": 7297480,
+      "markOut": 7663440
+    }
+  ]
+}

--- a/Tests/CoreBusinessTests/Resources.xcassets/Chapter_timeLimited.dataset/Contents.json
+++ b/Tests/CoreBusinessTests/Resources.xcassets/Chapter_timeLimited.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "Chapter_timeLimited.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CoreBusinessTests/URLCodingTests.swift
+++ b/Tests/CoreBusinessTests/URLCodingTests.swift
@@ -12,9 +12,9 @@ import XCTest
 final class URLCodingTests: XCTestCase {
     func testEncoding() {
         expect(URLCoding.encodeUrl(fromUrn: "urn:srf:video:6440e95f-71c5-4510-a165-f81e9c0dd391"))
-            .to(equal(URL(string: "urn://mediacomposition?urn=urn:srf:video:6440e95f-71c5-4510-a165-f81e9c0dd391")))
+            .to(equal(URL(string: "urn://mediacomposition.m3u8?urn=urn:srf:video:6440e95f-71c5-4510-a165-f81e9c0dd391")))
         expect(URLCoding.encodeUrl(fromUrn: "random-string"))
-            .to(equal(URL(string: "urn://mediacomposition?urn=random-string")))
+            .to(equal(URL(string: "urn://mediacomposition.m3u8?urn=random-string")))
     }
 
     func testDecoding() {

--- a/Tests/PlayerTests/ErrorsTests.swift
+++ b/Tests/PlayerTests/ErrorsTests.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Nimble
+import XCTest
+
+final class ErrorsTests: XCTestCase {
+    private enum TestError: LocalizedError {
+        case message
+
+        var errorDescription: String? {
+            "Message"
+        }
+    }
+
+    func testLocalizedNSError() {
+        let error = NSError(domain: "domain", code: 1012, userInfo: [
+            NSLocalizedDescriptionKey: "Message"
+        ])
+        expect(error.localized() as NSError).to(equal(error))
+    }
+
+    func testNonLocalizedNSError() {
+        let error = NSError(domain: "domain", code: 1012, userInfo: [
+            "NSDescription": "Message"
+        ])
+        let expectedError = NSError(domain: "domain", code: 1012, userInfo: [
+            NSLocalizedDescriptionKey: "Message"
+        ])
+        expect(error.localized() as NSError).to(equal(expectedError))
+    }
+
+    func testSwiftError() {
+        expect(TestError.message.localized() as NSError).to(equal(TestError.message as NSError))
+    }
+}

--- a/Tests/PlayerTests/ItemStatePublisherTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherTests.swift
@@ -70,7 +70,7 @@ final class ItemStatePublisherTests: XCTestCase {
         let item = AVPlayerItem(asset: asset)
         let player = AVPlayer(playerItem: item)
         expectSimilarPublished(
-            values: [.unknown, .failed(error: TestError.any)],
+            values: [.unknown, .failed(error: ResourceLoaderError.cannotLoadResource)],
             from: player.itemStatePublisher(),
             during: 1
         )

--- a/Tests/PlayerTests/Tools.swift
+++ b/Tests/PlayerTests/Tools.swift
@@ -6,31 +6,31 @@
 
 import AVFoundation
 
-final class FailingResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
-    // Correct error propagation from the resource loader to the player item requires the following:
-    //   - The error code must be an `Int`.
-    //   - The error code must be different from 0.
-    enum PlaybackError: Int, LocalizedError {
-        case cannotLoadResource = 1
-        case cannotRenewResource
+// Correct error propagation from the resource loader to the player item requires the following:
+//   - The error code must be an `Int`.
+//   - The error code must be different from 0.
+enum ResourceLoaderError: Int, LocalizedError {
+    case cannotLoadResource = 1
+    case cannotRenewResource
 
-        var errorDescription: String? {
-            switch self {
-            case .cannotLoadResource:
-                return "Failed to load the resource (custom message)"
-            case .cannotRenewResource:
-                return "Failed to renew the resource (custom message)"
-            }
+    var errorDescription: String? {
+        switch self {
+        case .cannotLoadResource:
+            return "Failed to load the resource (custom message)"
+        case .cannotRenewResource:
+            return "Failed to renew the resource (custom message)"
         }
     }
+}
 
+final class FailingResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
     func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
-        loadingRequest.finishLoading(with: PlaybackError.cannotLoadResource)
+        loadingRequest.finishLoading(with: ResourceLoaderError.cannotLoadResource)
         return true
     }
 
     func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForRenewalOfRequestedResource renewalRequest: AVAssetResourceRenewalRequest) -> Bool {
-        renewalRequest.finishLoading(with: PlaybackError.cannotRenewResource)
+        renewalRequest.finishLoading(with: ResourceLoaderError.cannotRenewResource)
         return true
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ TESTFLIGHT_PLATFORMS = {
 }.freeze
 
 DEVICES = {
-  ios: 'iPhone 13',
+  ios: 'iPhone 14',
   tvos: 'Apple TV'
 }.freeze
 


### PR DESCRIPTION
# Pull request

## Description

This PR is a first attempt at implementing error management. It correctly forwards errors to the user interface but fails to play any kind of content we have for reasons explained in #106. Still the changes made in this PR are relevant and more important changes to code existing prior to this PR are required to fix the problem.

## Changes made

- Implement better error management when retrieving resources.
- Display errors to the user.

Note that this PR breaks MP3 playback for reasons explained in #106. I had the choice between non-working error forwarding through the asset loader or broken playback, and I chose to favor error reporting as it is focus of this PR.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
