### PR TITLE
Play Akamai token protected content

### DIFF
--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -574,8 +574,8 @@ public extension XCTestCase {
             switch completion {
             case .finished:
                 break
-            case .failure:
-                XCTFail("The publisher incorrectly failed", file: file, line: line)
+            case let .failure(error):
+                XCTFail("The publisher incorrectly failed with error: \(error)", file: file, line: line)
             }
             expectation.fulfill()
         } receiveValue: { _ in

--- a/Sources/CoreBusiness/AkamaiProvider.swift
+++ b/Sources/CoreBusiness/AkamaiProvider.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Foundation
+
+final class AkamaiProvider {
+    private static let tokenServiceUrl = URL(string: "https://tp.srgssr.ch/akahd/token")!
+
+    let session = URLSession(configuration: .default)
+
+    static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private static func acl(for url: URL) -> String {
+        url.deletingLastPathComponent().appending(component: "*").path
+    }
+
+    private static func tokenRequestUrl(for url: URL) -> URL? {
+        guard var components = URLComponents(url: tokenServiceUrl, resolvingAgainstBaseURL: false) else { return nil }
+        components.queryItems = [
+            URLQueryItem(name: "acl", value: acl(for: url))
+        ]
+        return components.url
+    }
+
+    private static func mergeQueryItems(_ queryItems: [URLQueryItem], into url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        var mergedQueryItems = components.queryItems ?? []
+        mergedQueryItems += queryItems
+        components.queryItems = mergedQueryItems
+        return components.url
+    }
+
+    /// Attempt to tokenize the provided URL.
+    /// - Parameter url: The URL to tokenize.
+    /// - Returns: The tokenized URL or the original URL in case of failure (this URL might still be playable by chance).
+    func tokenizeUrl(_ url: URL) -> AnyPublisher<URL, Never> {
+        guard let requestUrl = Self.tokenRequestUrl(for: url) else {
+            return Just(url)
+                .eraseToAnyPublisher()
+        }
+        return session.dataTaskPublisher(for: requestUrl)
+            .mapHttpErrors()
+            .map(\.data)
+            .decode(type: TokenPayload.self, decoder: JSONDecoder())
+            .map(\.token)
+            .tryMap { token in
+                guard let queryItems = token.queryItems(),
+                      let tokenizedUrl = Self.mergeQueryItems(queryItems, into: url) else {
+                    throw TokenError.malformedParameters
+                }
+                return tokenizedUrl
+            }
+            .replaceError(with: url)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/CoreBusiness/AkamaiProvider.swift
+++ b/Sources/CoreBusiness/AkamaiProvider.swift
@@ -52,8 +52,7 @@ final class AkamaiProvider {
             .decode(type: TokenPayload.self, decoder: JSONDecoder())
             .map(\.token)
             .tryMap { token in
-                guard let queryItems = token.queryItems(),
-                      let tokenizedUrl = Self.mergeQueryItems(queryItems, into: url) else {
+                guard let tokenizedUrl = Self.mergeQueryItems(token.queryItems(), into: url) else {
                     throw TokenError.malformedParameters
                 }
                 return tokenizedUrl

--- a/Sources/CoreBusiness/AkamaiProvider.swift
+++ b/Sources/CoreBusiness/AkamaiProvider.swift
@@ -10,7 +10,7 @@ import Foundation
 final class AkamaiProvider {
     private static let tokenServiceUrl = URL(string: "https://tp.srgssr.ch/akahd/token")!
 
-    let session = URLSession(configuration: .default)
+    private let session = URLSession(configuration: .default)
 
     static func decoder() -> JSONDecoder {
         let decoder = JSONDecoder()

--- a/Sources/CoreBusiness/AkamaiResourceLoaderDelegate.swift
+++ b/Sources/CoreBusiness/AkamaiResourceLoaderDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+final class AkamaiResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
+    ) -> Bool {
+        true
+    }
+
+    func resourceLoader(
+        _ resourceLoader: AVAssetResourceLoader,
+        shouldWaitForRenewalOfRequestedResource renewalRequest: AVAssetResourceRenewalRequest
+    ) -> Bool {
+        true
+    }
+}

--- a/Sources/CoreBusiness/AkamaiResourceLoaderDelegate.swift
+++ b/Sources/CoreBusiness/AkamaiResourceLoaderDelegate.swift
@@ -5,19 +5,39 @@
 //
 
 import AVFoundation
+import Combine
 
 final class AkamaiResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
+    private var cancellable: AnyCancellable?
+
     func resourceLoader(
         _ resourceLoader: AVAssetResourceLoader,
         shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
     ) -> Bool {
-        true
+        processRequest(loadingRequest)
     }
 
     func resourceLoader(
         _ resourceLoader: AVAssetResourceLoader,
         shouldWaitForRenewalOfRequestedResource renewalRequest: AVAssetResourceRenewalRequest
     ) -> Bool {
-        true
+        processRequest(renewalRequest)
+    }
+
+    func resourceLoader(_ resourceLoader: AVAssetResourceLoader, didCancel loadingRequest: AVAssetResourceLoadingRequest) {
+        cancellable = nil
+    }
+
+    private func processRequest(_ loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
+        guard let requestUrl = loadingRequest.request.url, let url = AkamaiURLCoding.decodeUrl(requestUrl) else {
+            return false
+        }
+        cancellable = AkamaiProvider().tokenizeUrl(url)
+            .sink(receiveCompletion: { _ in
+                loadingRequest.finishLoading()
+            }, receiveValue: { tokenizedUrl in
+                loadingRequest.redirect(to: tokenizedUrl)
+            })
+        return true
     }
 }

--- a/Sources/CoreBusiness/AkamaiURLCoding.swift
+++ b/Sources/CoreBusiness/AkamaiURLCoding.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum AkamaiURLCoding {
+    private static let schemePrefix = "akamai"
+    private static let separator = "+"
+
+    static func encodeUrl(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme else {
+            return url
+        }
+        components.scheme = "\(schemePrefix)\(separator)\(scheme)"
+        return components.url ?? url
+    }
+
+    static func decodeUrl(_ url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme else {
+            return nil
+        }
+        let schemeComponents = scheme.components(separatedBy: separator)
+        guard schemeComponents.count == 2 && schemeComponents[0] == schemePrefix else {
+            return nil
+        }
+        components.scheme = schemeComponents[1]
+        return components.url
+    }
+}

--- a/Sources/CoreBusiness/AssetResourceLoadingRequest.swift
+++ b/Sources/CoreBusiness/AssetResourceLoadingRequest.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+extension AVAssetResourceLoadingRequest {
+     func redirect(to url: URL) {
+         var redirectRequest = request
+         redirectRequest.url = url
+         redirect = redirectRequest
+         response = HTTPURLResponse(url: url, statusCode: 302, httpVersion: nil, headerFields: nil)
+     }
+ }

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -8,6 +8,8 @@ import Combine
 import Foundation
 
 final class DataProvider {
+    private static let tokenServiceUrl = URL(string: "https://tp.srgssr.ch/akahd/token")!
+
     let environment: Environment
     let session: URLSession
 
@@ -20,6 +22,26 @@ final class DataProvider {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
+    }
+
+    private static func acl(for url: URL) -> String {
+        url.deletingLastPathComponent().appending(component: "*").path
+    }
+
+    private static func tokenRequestUrl(for url: URL) -> URL? {
+        guard var components = URLComponents(url: tokenServiceUrl, resolvingAgainstBaseURL: false) else { return nil }
+        components.queryItems = [
+            URLQueryItem(name: "acl", value: acl(for: url))
+        ]
+        return components.url
+    }
+
+    private static func mergeQueryItems(_ queryItems: [URLQueryItem], into url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        var mergedQueryItems = components.queryItems ?? []
+        mergedQueryItems += queryItems
+        components.queryItems = mergedQueryItems
+        return components.url
     }
 
     func mediaComposition(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
@@ -47,10 +69,34 @@ final class DataProvider {
             .map(\.mainChapter.recommendedResource)
             .tryMap { resource in
                 guard let resource else {
-                    throw DataError.notFound
+                    throw DataError.noResourceAvailable
                 }
                 return resource
             }
+            .eraseToAnyPublisher()
+    }
+
+    /// Attempt to tokenize the provided URL.
+    /// - Parameter url: The URL to tokenize.
+    /// - Returns: The tokenized URL or the original URL in case of failure (this URL might still be playable by chance).
+    func tokenizeUrl(_ url: URL) -> AnyPublisher<URL, Never> {
+        guard let requestUrl = Self.tokenRequestUrl(for: url) else {
+            return Just(url)
+                .eraseToAnyPublisher()
+        }
+        return session.dataTaskPublisher(for: requestUrl)
+            .mapHttpErrors()
+            .map(\.data)
+            .decode(type: TokenPayload.self, decoder: JSONDecoder())
+            .map(\.token)
+            .tryMap { token in
+                guard let queryItems = token.queryItems(),
+                      let tokenizedUrl = Self.mergeQueryItems(queryItems, into: url) else {
+                    throw TokenError.malformedParameters
+                }
+                return tokenizedUrl
+            }
+            .replaceError(with: url)
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -8,8 +8,6 @@ import Combine
 import Foundation
 
 final class DataProvider {
-    private static let tokenServiceUrl = URL(string: "https://tp.srgssr.ch/akahd/token")!
-
     let environment: Environment
     let session: URLSession
 
@@ -22,26 +20,6 @@ final class DataProvider {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
-    }
-
-    private static func acl(for url: URL) -> String {
-        url.deletingLastPathComponent().appending(component: "*").path
-    }
-
-    private static func tokenRequestUrl(for url: URL) -> URL? {
-        guard var components = URLComponents(url: tokenServiceUrl, resolvingAgainstBaseURL: false) else { return nil }
-        components.queryItems = [
-            URLQueryItem(name: "acl", value: acl(for: url))
-        ]
-        return components.url
-    }
-
-    private static func mergeQueryItems(_ queryItems: [URLQueryItem], into url: URL) -> URL? {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
-        var mergedQueryItems = components.queryItems ?? []
-        mergedQueryItems += queryItems
-        components.queryItems = mergedQueryItems
-        return components.url
     }
 
     func mediaComposition(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
@@ -73,30 +51,6 @@ final class DataProvider {
                 }
                 return resource
             }
-            .eraseToAnyPublisher()
-    }
-
-    /// Attempt to tokenize the provided URL.
-    /// - Parameter url: The URL to tokenize.
-    /// - Returns: The tokenized URL or the original URL in case of failure (this URL might still be playable by chance).
-    func tokenizeUrl(_ url: URL) -> AnyPublisher<URL, Never> {
-        guard let requestUrl = Self.tokenRequestUrl(for: url) else {
-            return Just(url)
-                .eraseToAnyPublisher()
-        }
-        return session.dataTaskPublisher(for: requestUrl)
-            .mapHttpErrors()
-            .map(\.data)
-            .decode(type: TokenPayload.self, decoder: JSONDecoder())
-            .map(\.token)
-            .tryMap { token in
-                guard let queryItems = token.queryItems(),
-                      let tokenizedUrl = Self.mergeQueryItems(queryItems, into: url) else {
-                    throw TokenError.malformedParameters
-                }
-                return tokenizedUrl
-            }
-            .replaceError(with: url)
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -6,6 +6,10 @@
 
 import Foundation
 
+enum TokenError: Error {
+    case malformedParameters
+}
+
 struct DataError: LocalizedError {
     static var noResourceAvailable: Self {
         DataError(errorDescription: NSLocalizedString(
@@ -29,8 +33,4 @@ struct DataError: LocalizedError {
     static func blocked(withMessage message: String) -> Self {
         DataError(errorDescription: message)
     }
-}
-
-enum TokenError: Error {
-    case malformedParameters
 }

--- a/Sources/CoreBusiness/Errors.swift
+++ b/Sources/CoreBusiness/Errors.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 struct DataError: LocalizedError {
-    static var notFound: Self {
+    static var noResourceAvailable: Self {
         DataError(errorDescription: NSLocalizedString(
-            "The content cannot be played",
-            comment: "Generic error message when some content cannot be played"
+            "No playable resources could be found",
+            comment: "Generic error message returned when no playable resources could be found"
         ))
     }
 
@@ -29,4 +29,8 @@ struct DataError: LocalizedError {
     static func blocked(withMessage message: String) -> Self {
         DataError(errorDescription: message)
     }
+}
+
+enum TokenError: Error {
+    case malformedParameters
 }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -24,6 +24,15 @@ public extension PlayerItem {
 
     // swiftlint:enable discouraged_optional_collection
 
+    private static func url(for resource: Resource) -> URL {
+        switch resource.tokenType {
+        case .akamai:
+            return AkamaiURLCoding.encodeUrl(resource.url)
+        default:
+            return resource.url
+        }
+    }
+
     private static func resourceLoaderDelegate(for resource: Resource) -> AVAssetResourceLoaderDelegate? {
         switch resource.tokenType {
         case .akamai:
@@ -35,7 +44,7 @@ public extension PlayerItem {
 
     private static func playerItem(for resource: Resource, automaticallyLoadedAssetKeys: [String]?) -> AVPlayerItem {
         let item = AVPlayerItem.loading(
-            url: resource.url,
+            url: url(for: resource),
             resourceLoaderDelegate: resourceLoaderDelegate(for: resource)
         )
         if resource.streamType == .live {

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -7,9 +7,9 @@
 import AVFoundation
 import Player
 
-public extension PlayerItem {
-    // swiftlint:disable discouraged_optional_collection
+// swiftlint:disable discouraged_optional_collection
 
+public extension PlayerItem {
     /// Create a player item from a URN played in the specified environment.
     /// - Parameters:
     ///   - urn: The URN to play.
@@ -21,8 +21,6 @@ public extension PlayerItem {
             .map { Self.playerItem(for: $0, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys) }
         self.init(publisher: publisher)
     }
-
-    // swiftlint:enable discouraged_optional_collection
 
     private static func url(for resource: Resource) -> URL {
         switch resource.tokenType {
@@ -56,3 +54,5 @@ public extension PlayerItem {
         return item
     }
 }
+
+// swiftlint:enable discouraged_optional_collection

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -18,18 +18,32 @@ public extension PlayerItem {
     ///   - environment: The environment which the URN is played from.
     convenience init(urn: String, automaticallyLoadedAssetKeys: [String]? = nil, environment: Environment = .production) {
         let publisher = DataProvider(environment: environment).recommendedPlayableResource(forUrn: urn)
-            .map { resource in
-                let item = AVPlayerItem(url: resource.url)
-                if resource.streamType == .live {
-                    /// Limit buffering and force the player to return to the live edge when re-buffering. This ensures
-                    /// livestreams cannot be paused and resumed in the past, as requested by business people.
-                    item.automaticallyPreservesTimeOffsetFromLive = true
-                    item.preferredForwardBufferDuration = 1
-                }
-                return item
-            }
+            .map { Self.playerItem(for: $0, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys) }
         self.init(publisher: publisher)
     }
 
     // swiftlint:enable discouraged_optional_collection
+
+    private static func resourceLoaderDelegate(for resource: Resource) -> AVAssetResourceLoaderDelegate? {
+        switch resource.tokenType {
+        case .akamai:
+            return AkamaiResourceLoaderDelegate()
+        default:
+            return nil
+        }
+    }
+
+    private static func playerItem(for resource: Resource, automaticallyLoadedAssetKeys: [String]?) -> AVPlayerItem {
+        let item = AVPlayerItem.loading(
+            url: resource.url,
+            resourceLoaderDelegate: resourceLoaderDelegate(for: resource)
+        )
+        if resource.streamType == .live {
+            /// Limit buffering and force the player to return to the live edge when re-buffering. This ensures
+            /// livestreams cannot be paused and resumed in the past, as requested by business people.
+            item.automaticallyPreservesTimeOffsetFromLive = true
+            item.preferredForwardBufferDuration = 1
+        }
+        return item
+    }
 }

--- a/Sources/CoreBusiness/TokenPayload.swift
+++ b/Sources/CoreBusiness/TokenPayload.swift
@@ -9,10 +9,10 @@ import Foundation
 struct Token: Decodable {
     private let authparams: String
 
-    func queryItems() -> [URLQueryItem]? {
+    func queryItems() -> [URLQueryItem] {
         var components = URLComponents()
         components.query = authparams
-        return components.queryItems
+        return components.queryItems ?? []
     }
 }
 

--- a/Sources/CoreBusiness/TokenPayload.swift
+++ b/Sources/CoreBusiness/TokenPayload.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+struct Token: Decodable {
+    private let authparams: String
+
+    func queryItems() -> [URLQueryItem]? {
+        var components = URLComponents()
+        components.query = authparams
+        return components.queryItems
+    }
+}
+
+struct TokenPayload: Decodable {
+    let token: Token
+}

--- a/Sources/Player/ItemState.swift
+++ b/Sources/Player/ItemState.swift
@@ -50,11 +50,11 @@ enum ItemState: Equatable {
         }
     }
 
-    static func friendlyComment(from comment: String?) -> String? {
+    static func innerComment(from comment: String?) -> String? {
         // For some reason extended delimiters are currently required for compilation to succeed in Swift Packages.
-        let regex = #/.* \(.* -?\d+ - (.*)\)/#
+        let regex = #/[^\(\)]* \([^\(\)]* -?\d+ - (.*)\)/#
         guard let comment, let result = try? regex.wholeMatch(in: comment) else { return comment }
-        return String(result.1)
+        return innerComment(from: String(result.1))
     }
 
     static func localizedError(from error: Error) -> Error {
@@ -72,7 +72,7 @@ enum ItemState: Equatable {
     }
 
     private static func userInfo(for event: AVPlayerItemErrorLogEvent) -> [String: Any] {
-        guard let comment = friendlyComment(from: event.errorComment) else { return [:] }
+        guard let comment = innerComment(from: event.errorComment) else { return [:] }
         return [NSLocalizedDescriptionKey: comment]
     }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -9,6 +9,8 @@ import Combine
 
 private var kIdKey: Void?
 
+// swiftlint:disable discouraged_optional_collection
+
 /// An item which stores its own custom resource loader delegate.
 final class ResourceLoadedPlayerItem: AVPlayerItem {
     private let resourceLoaderDelegate: AVAssetResourceLoaderDelegate
@@ -21,9 +23,11 @@ final class ResourceLoadedPlayerItem: AVPlayerItem {
     }
 }
 
+// swiftlint:enable discouraged_optional_collection
+
 /// An item to be inserted into the player.
 public final class PlayerItem: Equatable {
-    @Published var playerItem: AVPlayerItem = AVPlayerItem.loading
+    @Published var playerItem = AVPlayerItem.loading
     @Published var chunkDuration: CMTime = .invalid
 
     private let id = UUID()
@@ -62,7 +66,16 @@ public final class PlayerItem: Equatable {
     }
 }
 
+// swiftlint:disable discouraged_optional_collection
+
 public extension AVPlayerItem {
+    /// An item which never finishes loading.
+    static var loading: AVPlayerItem {
+        // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
+        let url = URL(string: "pillarbox://loading.m3u8")!
+        return ResourceLoadedPlayerItem(url: url, resourceLoaderDelegate: LoadingResourceLoaderDelegate(), automaticallyLoadedAssetKeys: nil)
+    }
+
     /// Create a player item from a URL.
     /// - Parameters:
     ///   - url: The URL to play.
@@ -70,13 +83,6 @@ public extension AVPlayerItem {
     convenience init(url: URL, automaticallyLoadedAssetKeys: [String]) {
         let asset = AVURLAsset(url: url)
         self.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
-    }
-
-    /// An item which never finishes loading.
-    static var loading: AVPlayerItem {
-        // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
-        let url = URL(string: "pillarbox://loading.m3u8")!
-        return ResourceLoadedPlayerItem(url: url, resourceLoaderDelegate: LoadingResourceLoaderDelegate(), automaticallyLoadedAssetKeys: nil)
     }
 
     /// An item which immediately fails with a specific error.
@@ -109,8 +115,6 @@ public extension AVPlayerItem {
 }
 
 public extension PlayerItem {
-    // swiftlint:disable discouraged_optional_collection
-
     /// Create a player item from a URL.
     /// - Parameters:
     ///   - urn: The URL to play.
@@ -148,9 +152,9 @@ public extension PlayerItem {
             return AVPlayerItem(url: url)
         }
     }
-
-    // swiftlint:enable discouraged_optional_collection
 }
+
+// swiftlint:enable discouraged_optional_collection
 
 extension AVPlayerItem {
     /// An identifier to identify player items delivered by the same pipeline.

--- a/Tests/CoreBusinessTests/AkamaiProviderTests.swift
+++ b/Tests/CoreBusinessTests/AkamaiProviderTests.swift
@@ -16,5 +16,3 @@ final class AkamaiProviderTests: XCTestCase {
         )
     }
 }
-
-

--- a/Tests/CoreBusinessTests/AkamaiProviderTests.swift
+++ b/Tests/CoreBusinessTests/AkamaiProviderTests.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Nimble
+import XCTest
+
+final class AkamaiProviderTests: XCTestCase {
+    func testTokenizeUrl() {
+        expectSuccess(
+            from: AkamaiProvider().tokenizeUrl(URL(string: "https://srgssrch.akamaized.net/hls/live/2022017/srgssr-hls-stream13-ch-dvr/master.m3u8")!)
+        )
+    }
+}
+
+

--- a/Tests/CoreBusinessTests/AkamaiURLCodingTests.swift
+++ b/Tests/CoreBusinessTests/AkamaiURLCodingTests.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import CoreBusiness
+
+import Nimble
+import XCTest
+
+final class AkamaiURLCodingTests: XCTestCase {
+    func testEncoding() {
+        expect(AkamaiURLCoding.encodeUrl(URL(string: "http://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(equal(URL(string: "akamai+http://www.server.com/playlist.m3u8?param1=value1&param2=value2")))
+        expect(AkamaiURLCoding.encodeUrl(URL(string: "https://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(equal(URL(string: "akamai+https://www.server.com/playlist.m3u8?param1=value1&param2=value2")))
+    }
+
+    func testFailedEncoding() {
+        expect(AkamaiURLCoding.encodeUrl(URL(string: "//www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(equal(URL(string: "//www.server.com/playlist.m3u8?param1=value1&param2=value2")))
+    }
+
+    func testDecoding() {
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "akamai+http://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(equal(URL(string: "http://www.server.com/playlist.m3u8?param1=value1&param2=value2")))
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "akamai+https://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(equal(URL(string: "https://www.server.com/playlist.m3u8?param1=value1&param2=value2")))
+    }
+
+    func testFailedDecoding() {
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "http://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(beNil())
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "https://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(beNil())
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "custom://www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(beNil())
+        expect(AkamaiURLCoding.decodeUrl(URL(string: "//www.server.com/playlist.m3u8?param1=value1&param2=value2")!))
+            .to(beNil())
+    }
+}

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -35,4 +35,10 @@ final class DataProviderTests: XCTestCase {
             from: DataProvider().playableMediaComposition(forUrn: "urn:rts:video:13382911")
         )
     }
+
+    func testTokenizeUrl() {
+        expectSuccess(
+            from: DataProvider().tokenizeUrl(URL(string: "https://srgssrch.akamaized.net/hls/live/2022017/srgssr-hls-stream13-ch-dvr/master.m3u8")!)
+        )
+    }
 }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -35,10 +35,4 @@ final class DataProviderTests: XCTestCase {
             from: DataProvider().playableMediaComposition(forUrn: "urn:rts:video:13382911")
         )
     }
-
-    func testTokenizeUrl() {
-        expectSuccess(
-            from: DataProvider().tokenizeUrl(URL(string: "https://srgssrch.akamaized.net/hls/live/2022017/srgssr-hls-stream13-ch-dvr/master.m3u8")!)
-        )
-    }
 }

--- a/Tests/PlayerTests/ItemStateTests.swift
+++ b/Tests/PlayerTests/ItemStateTests.swift
@@ -30,20 +30,25 @@ final class ItemStateTests: XCTestCase {
         expect(ItemState.failed(error: StructError())).to(equal(.failed(error: StructError()), by: ~=))
     }
 
-    func testNoFriendlyComment() {
-        expect(ItemState.friendlyComment(from: "The internet connection appears to be offline"))
+    func testNoInnerComment() {
+        expect(ItemState.innerComment(from: "The internet connection appears to be offline"))
             .to(equal("The internet connection appears to be offline"))
     }
 
-    func testFriendlyComment() {
-        expect(ItemState.friendlyComment(from: "The operation couldn’t be completed. (CoreBusiness.DataError error 1 - This content is not available anymore.)"))
+    func testInnerComment() {
+        expect(ItemState.innerComment(from: "The operation couldn’t be completed. (CoreBusiness.DataError error 1 - This content is not available anymore.)"))
             .to(equal("This content is not available anymore."))
-        expect(ItemState.friendlyComment(from: "The operation couldn’t be completed. (CoreBusiness.DataError error 1 - Not found)"))
+        expect(ItemState.innerComment(from: "The operation couldn’t be completed. (CoreBusiness.DataError error 1 - Not found)"))
             .to(equal("Not found"))
-        expect(ItemState.friendlyComment(from: "The operation couldn't be completed. (CoreMediaErrorDomain error -16839 - Unable to get playlist before long download timer.)"))
+        expect(ItemState.innerComment(from: "The operation couldn't be completed. (CoreMediaErrorDomain error -16839 - Unable to get playlist before long download timer.)"))
             .to(equal("Unable to get playlist before long download timer."))
-        expect(ItemState.friendlyComment(from: "L’opération n’a pas pu s’achever. (CoreBusiness.DataError erreur 1 - Ce contenu n'est plus disponible.)"))
+        expect(ItemState.innerComment(from: "L’opération n’a pas pu s’achever. (CoreBusiness.DataError erreur 1 - Ce contenu n'est plus disponible.)"))
             .to(equal("Ce contenu n'est plus disponible."))
+    }
+
+    func testNestedInnerComments() {
+        expect(ItemState.innerComment(from: "The operation couldn’t be completed. (CoreMediaErrorDomain error -12660 - The operation couldn’t be completed. (CoreMediaErrorDomain error -12660 - HTTP 403: Forbidden))"))
+            .to(equal("HTTP 403: Forbidden"))
     }
 
     func testLocalizedErrorFromLocalizedNSError() {

--- a/Tests/PlayerTests/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItemTests.swift
@@ -23,7 +23,7 @@ final class PlayerItemsTests: XCTestCase {
     }
 
     func testLoadingPlayerItem() {
-        let item = LoadingPlayerItem()
+        let item = AVPlayerItem.loading
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [false],
@@ -33,7 +33,7 @@ final class PlayerItemsTests: XCTestCase {
     }
 
     func testFailingPlayerItem() {
-        let item = FailingPlayerItem(error: StructError())
+        let item = AVPlayerItem.failing(error: StructError())
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [
@@ -102,7 +102,7 @@ final class PlayerItemsTests: XCTestCase {
         let item = PlayerItem(publisher: publisher)
         expectAtLeastSimilarPublished(
             values: [
-                LoadingPlayerItem(),
+                AVPlayerItem.loading,
                 playerItem
             ],
             from: item.$playerItem
@@ -115,8 +115,8 @@ final class PlayerItemsTests: XCTestCase {
         let item = PlayerItem(publisher: publisher)
         expectAtLeastSimilarPublished(
             values: [
-                LoadingPlayerItem(),
-                FailingPlayerItem(error: EnumError.error1)
+                AVPlayerItem.loading,
+                AVPlayerItem.failing(error: EnumError.error1)
             ],
             from: item.$playerItem
         )


### PR DESCRIPTION
# Pull request

## Description

This PR implements Akamai token support. Though Akamai tokens are now seldom used they still are needed for SwissTXT content.

## Changes made

- Implemented Akamai token support.

Some important remarks:

- No example has been added to the demo (short-lived examples, would required performing a media list request first). I created #135 to address this need.
- Almost no unit tests have been written since we need to deliver test data locally first (see #110).
- AirPlay has a lot of issues (see #134).
- Support for 3rd gen Apple TV has not been restored yet (see #133).

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant). _See above_
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
