### PR TITLE
Update Nimble for async await test support

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Pillarbox-Package-NoDebug.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Pillarbox-Package-NoDebug.xcscheme
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Analytics"
+               BuildableName = "Analytics"
+               BlueprintName = "Analytics"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Circumspect"
+               BuildableName = "Circumspect"
+               BlueprintName = "Circumspect"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreBusiness"
+               BuildableName = "CoreBusiness"
+               BlueprintName = "CoreBusiness"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Diagnostics"
+               BuildableName = "Diagnostics"
+               BlueprintName = "Diagnostics"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Player"
+               BuildableName = "Player"
+               BlueprintName = "Player"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UserInterface"
+               BuildableName = "UserInterface"
+               BlueprintName = "UserInterface"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AnalyticsTests"
+               BuildableName = "AnalyticsTests"
+               BlueprintName = "AnalyticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CircumspectTests"
+               BuildableName = "CircumspectTests"
+               BlueprintName = "CircumspectTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreBusinessTests"
+               BuildableName = "CoreBusinessTests"
+               BlueprintName = "CoreBusinessTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DiagnosticsTests"
+               BuildableName = "DiagnosticsTests"
+               BlueprintName = "DiagnosticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PlayerTests"
+               BuildableName = "PlayerTests"
+               BlueprintName = "PlayerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UserInterfaceTests"
+               BuildableName = "UserInterfaceTests"
+               BlueprintName = "UserInterfaceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Core"
+               BuildableName = "Core"
+               BlueprintName = "Core"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = "en"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AnalyticsTests"
+               BuildableName = "AnalyticsTests"
+               BlueprintName = "AnalyticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CircumspectTests"
+               BuildableName = "CircumspectTests"
+               BlueprintName = "CircumspectTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreTests"
+               BuildableName = "CoreTests"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreBusinessTests"
+               BuildableName = "CoreBusinessTests"
+               BlueprintName = "CoreBusinessTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DiagnosticsTests"
+               BuildableName = "DiagnosticsTests"
+               BlueprintName = "DiagnosticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PlayerTests"
+               BuildableName = "PlayerTests"
+               BlueprintName = "PlayerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UserInterfaceTests"
+               BuildableName = "UserInterfaceTests"
+               BlueprintName = "UserInterfaceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "tvOSNimbleThrowAssertionsEnabled"
+            value = "true"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-        "version" : "10.0.0"
+        "revision" : "e669a59a2a82490343885e7c8fc438d45a1101a8",
+        "version" : "11.1.1"
       }
     },
     {

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -10,10 +10,9 @@ import UIKit
 // MARK: Application delegate
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-    // swiftlint:disable discouraged_optional_collection
+    // swiftlint:disable:next discouraged_optional_collection
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         try? AVAudioSession.sharedInstance().setCategory(.playback)
         return true
     }
-    // swiftlint:enable discouraged_optional_collection
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-        "version" : "10.0.0"
+        "revision" : "e669a59a2a82490343885e7c8fc438d45a1101a8",
+        "version" : "11.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/SRGSSR/TCServerSide-xcframework-apple.git", .upToNextMinor(from: "5.1.2")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", .upToNextMajor(from: "1.0.1")),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0")),
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "11.1.1")),
         .package(url: "https://github.com/icanzilb/TimelaneCombine.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -8,8 +8,6 @@ import Combine
 import Difference
 import XCTest
 
-// swiftlint:disable prefer_nimble
-
 public extension XCTestCase {
     /// Wait for a publisher to emit at least a list of expected values.
     func expectAtLeastPublished<P: Publisher>(
@@ -166,6 +164,7 @@ public extension XCTestCase {
             guard actualValues.count == values.count else { return false }
             return zip(actualValues, values).allSatisfy { satisfy($0, $1) }
         }()
+        // swiftlint:disable:next prefer_nimble
         XCTAssert(
             assertExpression,
             diff(values, actualValues).joined(separator: ", "),
@@ -331,6 +330,7 @@ public extension XCTestCase {
             guard actualValues.count == values.count else { return false }
             return zip(actualValues, values).allSatisfy { satisfy($0, $1) }
         }()
+        // swiftlint:disable:next prefer_nimble
         XCTAssert(
             assertExpression,
             diff(values, actualValues).joined(separator: ", "),
@@ -493,6 +493,7 @@ public extension XCTestCase {
             guard actualValues.count == values.count else { return false }
             return zip(actualValues, values).allSatisfy { satisfy($0, $1) }
         }()
+        // swiftlint:disable:next prefer_nimble
         XCTAssert(
             assertExpression,
             diff(values, actualValues).joined(separator: ", "),
@@ -551,6 +552,7 @@ public extension XCTestCase {
         if next, !actualValues.isEmpty {
             actualValues.removeFirst()
         }
+        // swiftlint:disable:next prefer_nimble
         XCTAssertTrue(
             actualValues.isEmpty,
             "expected no values but got \(actualValues)",
@@ -607,6 +609,7 @@ public extension XCTestCase {
                 XCTFail("The publisher incorrectly succeeded", file: file, line: line)
             case let .failure(actualError):
                 if let error {
+                    // swiftlint:disable:next prefer_nimble
                     XCTAssertEqual(error as NSError, actualError as NSError, file: file, line: line)
                 }
             }
@@ -697,5 +700,3 @@ public extension XCTestCase {
         )
     }
 }
-
-// swiftlint:enable prefer_nimble

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -7,8 +7,6 @@
 import AVFoundation
 import Player
 
-// swiftlint:disable discouraged_optional_collection
-
 public extension PlayerItem {
     /// Create a player item from a URN played in the specified environment.
     /// - Parameters:
@@ -17,6 +15,7 @@ public extension PlayerItem {
     ///     keys are loaded.
     ///   - environment: The environment which the URN is played from.
     convenience init(urn: String, automaticallyLoadedAssetKeys: [String]? = nil, environment: Environment = .production) {
+        // swiftlint:disable:previous discouraged_optional_collection
         let publisher = DataProvider(environment: environment).recommendedPlayableResource(forUrn: urn)
             .map { Self.playerItem(for: $0, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys) }
         self.init(publisher: publisher)
@@ -41,6 +40,7 @@ public extension PlayerItem {
     }
 
     private static func playerItem(for resource: Resource, automaticallyLoadedAssetKeys: [String]?) -> AVPlayerItem {
+        // swiftlint:disable:previous discouraged_optional_collection
         let item = AVPlayerItem.loading(
             url: url(for: resource),
             resourceLoaderDelegate: resourceLoaderDelegate(for: resource)
@@ -54,5 +54,3 @@ public extension PlayerItem {
         return item
     }
 }
-
-// swiftlint:enable discouraged_optional_collection

--- a/Sources/Player/AssetPublishers.swift
+++ b/Sources/Player/AssetPublishers.swift
@@ -7,8 +7,6 @@
 import AVFoundation
 import Combine
 
-// swiftlint:disable large_tuple
-
 public extension AVAsset {
     /// Produce a given asset property.
     func propertyPublisher<T>(_ property: AVAsyncProperty<AVAsset, T>) -> AnyPublisher<T, Error> {
@@ -51,6 +49,7 @@ public extension AVAsset {
         _ propertyB: AVAsyncProperty<AVAsset, B>,
         _ propertyC: AVAsyncProperty<AVAsset, C>
     ) -> AnyPublisher<(A, B, C), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -72,6 +71,7 @@ public extension AVAsset {
         _ propertyC: AVAsyncProperty<AVAsset, C>,
         _ propertyD: AVAsyncProperty<AVAsset, D>
     ) -> AnyPublisher<(A, B, C, D), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -94,6 +94,7 @@ public extension AVAsset {
         _ propertyD: AVAsyncProperty<AVAsset, D>,
         _ propertyE: AVAsyncProperty<AVAsset, E>
     ) -> AnyPublisher<(A, B, C, D, E), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -117,6 +118,7 @@ public extension AVAsset {
         _ propertyE: AVAsyncProperty<AVAsset, E>,
         _ propertyF: AVAsyncProperty<AVAsset, F>
     ) -> AnyPublisher<(A, B, C, D, E, F), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -141,6 +143,7 @@ public extension AVAsset {
         _ propertyF: AVAsyncProperty<AVAsset, F>,
         _ propertyG: AVAsyncProperty<AVAsset, G>
     ) -> AnyPublisher<(A, B, C, D, E, F, G), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -168,6 +171,7 @@ public extension AVAsset {
         _ propertyG: AVAsyncProperty<AVAsset, G>,
         _ propertyH: AVAsyncProperty<AVAsset, H>
     ) -> AnyPublisher<(A, B, C, D, E, F, G, H), Error> {
+        // swiftlint:disable:previous large_tuple
         Future { promise in
             Task {
                 do {
@@ -184,5 +188,3 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 }
-
-// swiftlint:enable large_tuple

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -256,11 +256,13 @@ public final class Player: ObservableObject {
     @discardableResult
     public func skipToLive() async -> Bool {
         guard canSkipToLive(), let pulse else { return false }
-        return await rawPlayer.seek(
+        let seeked = await rawPlayer.seek(
             to: pulse.timeRange.end,
             toleranceBefore: .positiveInfinity,
             toleranceAfter: .positiveInfinity
         )
+        rawPlayer.play()
+        return seeked
     }
 
     /// Return a publisher periodically emitting the current time while the player is active.

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -9,21 +9,18 @@ import Combine
 
 private var kIdKey: Void?
 
-// swiftlint:disable discouraged_optional_collection
-
 /// An item which stores its own custom resource loader delegate.
 final class ResourceLoadedPlayerItem: AVPlayerItem {
     private let resourceLoaderDelegate: AVAssetResourceLoaderDelegate
 
     init(url: URL, resourceLoaderDelegate: AVAssetResourceLoaderDelegate, automaticallyLoadedAssetKeys: [String]?) {
+        // swiftlint:disable:previous discouraged_optional_collection
         self.resourceLoaderDelegate = resourceLoaderDelegate
         let asset = AVURLAsset(url: url)
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: .global(qos: .userInitiated))
         super.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
     }
 }
-
-// swiftlint:enable discouraged_optional_collection
 
 /// An item to be inserted into the player.
 public final class PlayerItem: Equatable {
@@ -66,8 +63,6 @@ public final class PlayerItem: Equatable {
     }
 }
 
-// swiftlint:disable discouraged_optional_collection
-
 public extension AVPlayerItem {
     /// An item which never finishes loading.
     static var loading: AVPlayerItem {
@@ -97,6 +92,7 @@ public extension AVPlayerItem {
         url: URL,
         resourceLoaderDelegate: AVAssetResourceLoaderDelegate? = nil,
         automaticallyLoadedAssetKeys: [String]? = nil
+        // swiftlint:disable:previous discouraged_optional_collection
     ) -> AVPlayerItem {
         if let resourceLoaderDelegate {
             return ResourceLoadedPlayerItem(
@@ -121,6 +117,7 @@ public extension PlayerItem {
     ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play. If `nil` default
     ///     keys are loaded.
     convenience init(url: URL, automaticallyLoadedAssetKeys: [String]? = nil) {
+        // swiftlint:disable:previous discouraged_optional_collection
         let item = Self.item(url: url, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
         self.init(item)
     }
@@ -131,6 +128,7 @@ public extension PlayerItem {
     ///   - automaticallyLoadedAssetKeys: The asset keys to load before the item is ready to play. If `nil` default
     ///     keys are loaded.
     convenience init(asset: AVAsset, automaticallyLoadedAssetKeys: [String]? = nil) {
+        // swiftlint:disable:previous discouraged_optional_collection
         let item = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
         self.init(item)
     }
@@ -145,6 +143,7 @@ public extension PlayerItem {
     }
 
     private static func item(url: URL, automaticallyLoadedAssetKeys: [String]?) -> AVPlayerItem {
+        // swiftlint:disable:previous discouraged_optional_collection
         if let automaticallyLoadedAssetKeys {
             return AVPlayerItem(url: url, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
         }
@@ -153,8 +152,6 @@ public extension PlayerItem {
         }
     }
 }
-
-// swiftlint:enable discouraged_optional_collection
 
 extension AVPlayerItem {
     /// An identifier to identify player items delivered by the same pipeline.

--- a/Tests/CoreTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/CoreTests/RangeReplaceableCollectionTests.swift
@@ -36,12 +36,14 @@ final class RangeReplaceableCollectionTests: XCTestCase {
     }
 
     func testMoveFromInvalidIndex() {
+        guard nimbleThrowAssertionsEnabled() else { return }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: -1, to: 2)).to(throwAssertion())
         expect(array.move(from: 8, to: 2)).to(throwAssertion())
     }
 
     func testMoveToInvalidIndex() {
+        guard nimbleThrowAssertionsEnabled() else { return }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: 2, to: -1)).to(throwAssertion())
         expect(array.move(from: 2, to: 8)).to(throwAssertion())

--- a/Tests/CoreTests/Tools.swift
+++ b/Tests/CoreTests/Tools.swift
@@ -6,6 +6,18 @@
 
 import Foundation
 
+/// Use before tests using Nimble `throwAssertion()` which lead to crashes on tvOS if a debugger is attached, but
+/// also to tests never finishing in general.
+func nimbleThrowAssertionsEnabled() -> Bool {
+    if ProcessInfo.processInfo.environment["tvOSNimbleThrowAssertionsEnabled"] == "true" {
+        print("[INFO] This test contains Nimble throwing assertions and has been disabled.")
+        return true
+    }
+    else {
+        return false
+    }
+}
+
 // swiftlint:disable file_types_order
 
 final class TestNSObject: NSObject {

--- a/Tests/CoreTests/Tools.swift
+++ b/Tests/CoreTests/Tools.swift
@@ -18,8 +18,7 @@ func nimbleThrowAssertionsEnabled() -> Bool {
     }
 }
 
-// swiftlint:disable file_types_order
-
+// swiftlint:disable:next file_types_order
 final class TestNSObject: NSObject {
     let identifier: String
 
@@ -39,5 +38,3 @@ final class TestObject {
 extension Notification.Name {
     static let testNotification = Notification.Name("TestNotification")
 }
-
-// swiftlint:enable file_types_order

--- a/Tests/PlayerTests/PlayerSkipToLiveTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToLiveTests.swift
@@ -11,8 +11,6 @@ import CoreMedia
 import Nimble
 import XCTest
 
-// TODO: Write tests for async API once Nimble has been updated with async / await support (version 11).
-
 @MainActor
 final class PlayerSkipToLiveTests: XCTestCase {
     func testCannotSkipToLiveWhenEmpty() {
@@ -52,6 +50,15 @@ final class PlayerSkipToLiveTests: XCTestCase {
         }
 
         expect(player.canSkipToLive()).toAlways(beTrue())
+    }
+
+    func testCanSkipToLiveForDvrInPastConditionsAsync() async {
+        let item = PlayerItem(url: Stream.dvr.url)
+        let player = Player(item: item)
+        await expect(player.time).toNotEventually(equal(.zero))
+        let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+        await expect(seeked).to(beTrue())
+        await expect(player.canSkipToLive()).toAlways(beTrue())
     }
 
     func testSkipToLiveWhenEmpty() {
@@ -112,5 +119,17 @@ final class PlayerSkipToLiveTests: XCTestCase {
 
         expect(player.canSkipToLive()).toAlways(beFalse())
         expect(player.playbackState).to(equal(.playing))
+    }
+
+    func testSkipToLiveForDvrInPastConditionsAsync() async {
+        let item = PlayerItem(url: Stream.dvr.url)
+        let player = Player(item: item)
+        await expect(player.time).toNotEventually(equal(.zero))
+        let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+        await expect(seeked).to(beTrue())
+        let skipped = await player.skipToLive()
+        await expect(skipped).to(beTrue())
+        await expect(player.canSkipToLive()).toAlways(beFalse())
+        await expect(player.playbackState).to(equal(.playing))
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -228,7 +228,7 @@ def run_package_tests(platform_id, scheme_name)
 end
 
 def run_all_tests(platform_id)
-  run_package_tests(platform_id, 'Pillarbox-Package')
+  run_package_tests(platform_id, 'Pillarbox-Package-NoDebug')
 end
 
 # -- GitHub comment builders


### PR DESCRIPTION
# Pull request

## Description

This PR updates Nimble to version 11.1.0 which adds support for async / await testing.

## Changes made

- Update Nimble.
- Fix a bug with `skipToLive()` async method.
- Disable Swift linter in a better way.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
