### PR TITLE
Fix incorrect stream type shortly reported when playing an on-demand stream

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -44,7 +44,7 @@ public final class Player: ObservableObject, Equatable {
 
     /// The type of stream currently played.
     public var streamType: StreamType {
-        guard timeRange.isValid else { return .unknown }
+        guard timeRange.isValid, itemDuration.isValid else { return .unknown }
         if timeRange.isEmpty {
             return .live
         }
@@ -77,7 +77,7 @@ public final class Player: ObservableObject, Equatable {
             .lane("player_time_range")
             .assign(to: &$timeRange)
 
-        rawPlayer.itemDurationPublisher()
+        rawPlayer.currentItemDurationPublisher()
             .receiveOnMainThread()
             .lane("player_item_duration")
             .assign(to: &$itemDuration)
@@ -261,7 +261,9 @@ public final class Player: ObservableObject, Equatable {
     /// - Returns: `true` if skipping to live conditions is possible.
     @discardableResult
     public func skipToLive() async -> Bool {
-        guard canSkipToLive(), timeRange.isValid else { return false }
+        guard canSkipToLive(), timeRange.isValid else {
+            return false
+        }
         let seeked = await rawPlayer.seek(
             to: timeRange.end,
             toleranceBefore: .positiveInfinity,

--- a/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
@@ -17,12 +17,12 @@ final class ItemDurationPublisherQueueTests: XCTestCase {
         let player = AVQueuePlayer(items: [item1, item2])
         expectPublished(
             values: [
-                .indefinite,
+                .invalid,
                 Stream.shortOnDemand.duration,
                 // Next media can be prepared and is immediately ready
                 Stream.onDemand.duration
             ],
-            from: player.itemDurationPublisher()
+            from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
             to: beClose(within: 1),
             during: 4
@@ -38,13 +38,13 @@ final class ItemDurationPublisherQueueTests: XCTestCase {
         let player = AVQueuePlayer(items: [item1, item2, item3])
         expectPublished(
             values: [
-                .indefinite,
+                .invalid,
                 Stream.shortOnDemand.duration,
                 // Next media cannot be prepared because of the failure
-                .indefinite,
+                .invalid,
                 Stream.onDemand.duration
             ],
-            from: player.itemDurationPublisher()
+            from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
             to: beClose(within: 1),
             during: 4

--- a/Tests/PlayerTests/ItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherTests.swift
@@ -15,8 +15,8 @@ final class ItemDurationPublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
-            values: [.indefinite, Stream.onDemand.duration],
-            from: player.itemDurationPublisher(),
+            values: [.invalid, Stream.onDemand.duration],
+            from: player.currentItemDurationPublisher(),
             to: beClose(within: 1),
             timeout: 20
         )

--- a/Tests/PlayerTests/PlayerSkipToLiveTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToLiveTests.swift
@@ -40,7 +40,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     func testCanSkipToLiveForDvrInPastConditions() {
         let item = PlayerItem(url: Stream.dvr.url)
         let player = Player(item: item)
-        expect(player.time).toEventuallyNot(equal(.zero))
+        expect(player.streamType).toEventually(equal(.dvr))
 
         waitUntil { done in
             player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { finished in
@@ -55,7 +55,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     func testCanSkipToLiveForDvrInPastConditionsAsync() async {
         let item = PlayerItem(url: Stream.dvr.url)
         let player = Player(item: item)
-        await expect(player.time).toEventuallyNot(equal(.zero))
+        await expect(player.streamType).toEventually(equal(.dvr))
         let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
         await expect(seeked).to(beTrue())
         await expect(player.canSkipToLive()).toAlways(beTrue())
@@ -100,7 +100,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     func testSkipToLiveForDvrInPastConditions() {
         let item = PlayerItem(url: Stream.dvr.url)
         let player = Player(item: item)
-        expect(player.time).toEventuallyNot(equal(.zero))
+        expect(player.streamType).toEventually(equal(.dvr))
 
         waitUntil { done in
             player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { finished in
@@ -124,7 +124,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     func testSkipToLiveForDvrInPastConditionsAsync() async {
         let item = PlayerItem(url: Stream.dvr.url)
         let player = Player(item: item)
-        await expect(player.time).toEventuallyNot(equal(.zero))
+        await expect(player.streamType).toEventually(equal(.dvr))
         let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
         await expect(seeked).to(beTrue())
         let skipped = await player.skipToLive()

--- a/Tests/PlayerTests/PlayerStreamTypeTests.swift
+++ b/Tests/PlayerTests/PlayerStreamTypeTests.swift
@@ -33,4 +33,10 @@ final class PlayerStreamTypeTests: XCTestCase {
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.dvr))
     }
+
+    func testStabilityAtStart() {
+        let item = PlayerItem(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        expect(player.streamType).toNever(equal(.dvr), pollInterval: .microseconds(1))
+    }
 }

--- a/Tests/PlayerTests/PlayerStreamTypeTests.swift
+++ b/Tests/PlayerTests/PlayerStreamTypeTests.swift
@@ -39,4 +39,10 @@ final class PlayerStreamTypeTests: XCTestCase {
         let player = Player(item: item)
         expect(player.streamType).toNever(equal(.dvr), pollInterval: .microseconds(1))
     }
+
+    func testStabilityAtStartWithoutAutomaticallyLoadedAssetKeys() {
+        let item = PlayerItem(url: Stream.onDemand.url, automaticallyLoadedAssetKeys: [])
+        let player = Player(item: item)
+        expect(player.streamType).toNever(equal(.dvr), pollInterval: .microseconds(1))
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR fixes an issue with stream type stability when starting on-demand stream playback.

## Changes made

- Add corresponding unit tests and make them pass.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
