### PR TITLE
Use local private types instead of private extensions

### DIFF
--- a/Demo/Pillarbox.playground/Contents.swift
+++ b/Demo/Pillarbox.playground/Contents.swift
@@ -19,6 +19,19 @@ import SwiftUI
 */
 
 // Behavior: h-exp, v-exp
+private struct TimeSlider: View {
+    @ObservedObject var player: Player
+    @StateObject private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 10))
+
+    var body: some View {
+        Slider(progressTracker: progressTracker)
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .bind(progressTracker, to: player)
+    }
+}
+
+// Behavior: h-exp, v-exp
 struct PlayerView: View {
     @StateObject private var player = Player(
         item: PlayerItem(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
@@ -49,21 +62,6 @@ struct PlayerView: View {
         }
         .onAppear {
             player.play()
-        }
-    }
-}
-
-extension PlayerView {
-    // Behavior: h-exp, v-exp
-    struct TimeSlider: View {
-        @ObservedObject var player: Player
-        @StateObject private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 10))
-
-        var body: some View {
-            Slider(progressTracker: progressTracker)
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-                .bind(progressTracker, to: player)
         }
     }
 }

--- a/Demo/Sources/DemoApp.swift
+++ b/Demo/Sources/DemoApp.swift
@@ -6,6 +6,41 @@
 
 import SwiftUI
 
+// MARK: Tabs
+
+private struct MediasTab: View {
+    var body: some View {
+        Navigation {
+            ExamplesView()
+        }
+        .tabItem {
+            Label("Examples", systemImage: "list.and.film")
+        }
+    }
+}
+
+private struct SettingsTab: View {
+    var body: some View {
+        Navigation {
+            SettingsView()
+        }
+        .tabItem {
+            Label("Settings", systemImage: "gearshape.fill")
+        }
+    }
+}
+
+private struct ShowcaseTab: View {
+    var body: some View {
+        Navigation {
+            ShowcaseView()
+        }
+        .tabItem {
+            Label("Showcase", systemImage: "text.book.closed")
+        }
+    }
+}
+
 // MARK: Application
 
 @main
@@ -18,43 +53,6 @@ struct DemoApp: App {
                 MediasTab()
                 ShowcaseTab()
                 SettingsTab()
-            }
-        }
-    }
-}
-
-// MARK: Tabs
-
-private extension DemoApp {
-    struct MediasTab: View {
-        var body: some View {
-            Navigation {
-                ExamplesView()
-            }
-            .tabItem {
-                Label("Examples", systemImage: "list.and.film")
-            }
-        }
-    }
-
-    struct SettingsTab: View {
-        var body: some View {
-            Navigation {
-                SettingsView()
-            }
-            .tabItem {
-                Label("Settings", systemImage: "gearshape.fill")
-            }
-        }
-    }
-
-    struct ShowcaseTab: View {
-        var body: some View {
-            Navigation {
-                ShowcaseView()
-            }
-            .tabItem {
-                Label("Showcase", systemImage: "text.book.closed")
             }
         }
     }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -6,6 +6,161 @@
 
 import SwiftUI
 
+// MARK: Types
+
+private struct Example: Identifiable {
+    static let examples: [Self] = [
+        .init(
+            title: "VOD - HLS",
+            description: "Switzerland says sorry! The fondue invasion",
+            media: MediaURL.onDemandVideoHLS
+        ),
+        .init(
+            title: "VOD - HLS (short)",
+            description: "Des violents orages ont touché Ajaccio, chef-lieu de la Corse, jeudi",
+            media: MediaURL.shortOnDemandVideoHLS
+        ),
+        .init(
+            title: "VOD - MP4",
+            description: "The dig",
+            media: MediaURL.onDemandVideoMP4
+        ),
+        .init(
+            title: "Video livestream - HLS",
+            description: "Couleur 3 en vidéo",
+            media: MediaURL.liveVideoHLS
+        ),
+        .init(
+            title: "Video livestream with DVR - HLS",
+            description: "Couleur 3 en vidéo",
+            media: MediaURL.dvrVideoHLS
+        ),
+        .init(
+            title: "Video livestream with DVR and timestamps - HLS",
+            description: "Tageschau",
+            media: MediaURL.liveTimestampVideoHLS
+        ),
+        .init(
+            title: "AOD - MP3",
+            description: "On en parle",
+            media: MediaURL.onDemandAudioMP3
+        ),
+        .init(
+            title: "Audio livestream - MP3",
+            description: "Couleur 3",
+            media: MediaURL.dvrAudioHLS
+        ),
+        .init(
+            title: "VOD 16:9 - HLS (URN)",
+            description: "Le 19h30",
+            media: MediaURN.onDemandHorizontalVideo
+        ),
+        .init(
+            title: "VOD 1:1 - HLS (URN)",
+            description: "Test carré",
+            media: MediaURN.onDemandSquareVideo
+        ),
+        .init(
+            title: "VOD 9:16 - HLS (URN)",
+            description: "Test 9:16",
+            media: MediaURN.onDemandVerticalVideo
+        ),
+        .init(
+            title: "Video livestream - HLS (URN)",
+            description: "SRF 1",
+            media: MediaURN.liveVideo
+        ),
+        .init(
+            title: "Video livestream with DVR - HLS (URN)",
+            description: "RTS 1",
+            media: MediaURN.dvrVideo
+        ),
+        .init(
+            title: "Audio livestream with DVR - HLS (URN)",
+            description: "Couleur 3 en direct",
+            media: MediaURN.dvrAudio
+        ),
+        .init(
+            title: "AOD - MP3 (URN)",
+            description: "Il lavoro di TerraProject per una fotografia documentaria",
+            media: MediaURN.onDemandAudio
+        ),
+        .init(
+            title: "Apple Basic 4:3",
+            description: "4x3 aspect ratio, H.264 @ 30Hz",
+            media: MediaURL.appleBasic_4_3_HLS
+        ),
+        .init(
+            title: "Apple Basic 16:9",
+            description: "16x9 aspect ratio, H.264 @ 30Hz",
+            media: MediaURL.appleBasic_16_9_TS_HLS
+        ),
+        .init(
+            title: "Apple Advanced 16:9 (TS)",
+            description: "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Transport stream",
+            media: MediaURL.appleAdvanced_16_9_TS_HLS
+        ),
+        .init(
+            title: "Apple Advanced 16:9 (fMP4)",
+            description: "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Fragmented MP4",
+            media: MediaURL.appleAdvanced_16_9_fMP4_HLS
+        ),
+        .init(
+            title: "Apple Advanced 16:9 (HEVC/H.264)",
+            description: "16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz",
+            media: MediaURL.appleAdvanced_16_9_HEVC_h264_HLS
+        ),
+        .init(
+            title: "Expired content",
+            description: "This content is not available anymore",
+            media: MediaURN.expired
+        ),
+        .init(
+            title: "Unknown content",
+            description: "This content does not exist",
+            media: MediaURN.unknown
+        ),
+        .init(
+            title: "Empty",
+            description: "No content is provided",
+            media: .empty
+        )
+    ]
+
+    let id = UUID()
+    let title: String
+    let description: String
+    let media: Media
+}
+
+// MARK: Cells
+
+// Behavior: h-hug, v-hug
+private struct ExampleCell: View {
+    let example: Example
+
+    @State var isPlayerPresented = false
+
+    var body: some View {
+        Button(action: play) {
+            VStack(alignment: .leading) {
+                Text(example.title)
+                    .foregroundColor(.primary)
+                Text(example.description)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .sheet(isPresented: $isPlayerPresented) {
+            PlayerView(media: example.media)
+        }
+    }
+
+    private func play() {
+        isPlayerPresented.toggle()
+    }
+}
+
 // MARK: View
 
 // Behavior: h-exp, v-exp
@@ -15,165 +170,6 @@ struct ExamplesView: View {
             ExampleCell(example: example)
         }
         .navigationTitle("Examples")
-    }
-}
-
-// MARK: Cells
-
-private extension ExamplesView {
-    // Behavior: h-hug, v-hug
-    struct ExampleCell: View {
-        let example: Example
-
-        @State var isPlayerPresented = false
-
-        var body: some View {
-            Button(action: play) {
-                VStack(alignment: .leading) {
-                    Text(example.title)
-                        .foregroundColor(.primary)
-                    Text(example.description)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .sheet(isPresented: $isPlayerPresented) {
-                PlayerView(media: example.media)
-            }
-        }
-
-        private func play() {
-            isPlayerPresented.toggle()
-        }
-    }
-}
-
-// MARK: Types
-
-private extension ExamplesView {
-    struct Example: Identifiable {
-        static let examples: [Self] = [
-            .init(
-                title: "VOD - HLS",
-                description: "Switzerland says sorry! The fondue invasion",
-                media: MediaURL.onDemandVideoHLS
-            ),
-            .init(
-                title: "VOD - HLS (short)",
-                description: "Des violents orages ont touché Ajaccio, chef-lieu de la Corse, jeudi",
-                media: MediaURL.shortOnDemandVideoHLS
-            ),
-            .init(
-                title: "VOD - MP4",
-                description: "The dig",
-                media: MediaURL.onDemandVideoMP4
-            ),
-            .init(
-                title: "Video livestream - HLS",
-                description: "Couleur 3 en vidéo",
-                media: MediaURL.liveVideoHLS
-            ),
-            .init(
-                title: "Video livestream with DVR - HLS",
-                description: "Couleur 3 en vidéo",
-                media: MediaURL.dvrVideoHLS
-            ),
-            .init(
-                title: "Video livestream with DVR and timestamps - HLS",
-                description: "Tageschau",
-                media: MediaURL.liveTimestampVideoHLS
-            ),
-            .init(
-                title: "AOD - MP3",
-                description: "On en parle",
-                media: MediaURL.onDemandAudioMP3
-            ),
-            .init(
-                title: "Audio livestream - MP3",
-                description: "Couleur 3",
-                media: MediaURL.dvrAudioHLS
-            ),
-            .init(
-                title: "VOD 16:9 - HLS (URN)",
-                description: "Le 19h30",
-                media: MediaURN.onDemandHorizontalVideo
-            ),
-            .init(
-                title: "VOD 1:1 - HLS (URN)",
-                description: "Test carré",
-                media: MediaURN.onDemandSquareVideo
-            ),
-            .init(
-                title: "VOD 9:16 - HLS (URN)",
-                description: "Test 9:16",
-                media: MediaURN.onDemandVerticalVideo
-            ),
-            .init(
-                title: "Video livestream - HLS (URN)",
-                description: "SRF 1",
-                media: MediaURN.liveVideo
-            ),
-            .init(
-                title: "Video livestream with DVR - HLS (URN)",
-                description: "RTS 1",
-                media: MediaURN.dvrVideo
-            ),
-            .init(
-                title: "Audio livestream with DVR - HLS (URN)",
-                description: "Couleur 3 en direct",
-                media: MediaURN.dvrAudio
-            ),
-            .init(
-                title: "AOD - MP3 (URN)",
-                description: "Il lavoro di TerraProject per una fotografia documentaria",
-                media: MediaURN.onDemandAudio
-            ),
-            .init(
-                title: "Apple Basic 4:3",
-                description: "4x3 aspect ratio, H.264 @ 30Hz",
-                media: MediaURL.appleBasic_4_3_HLS
-            ),
-            .init(
-                title: "Apple Basic 16:9",
-                description: "16x9 aspect ratio, H.264 @ 30Hz",
-                media: MediaURL.appleBasic_16_9_TS_HLS
-            ),
-            .init(
-                title: "Apple Advanced 16:9 (TS)",
-                description: "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Transport stream",
-                media: MediaURL.appleAdvanced_16_9_TS_HLS
-            ),
-            .init(
-                title: "Apple Advanced 16:9 (fMP4)",
-                description: "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Fragmented MP4",
-                media: MediaURL.appleAdvanced_16_9_fMP4_HLS
-            ),
-            .init(
-                title: "Apple Advanced 16:9 (HEVC/H.264)",
-                description: "16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz",
-                media: MediaURL.appleAdvanced_16_9_HEVC_h264_HLS
-            ),
-            .init(
-                title: "Expired content",
-                description: "This content is not available anymore",
-                media: MediaURN.expired
-            ),
-            .init(
-                title: "Unknown content",
-                description: "This content does not exist",
-                media: MediaURN.unknown
-            ),
-            .init(
-                title: "Empty",
-                description: "No content is provided",
-                media: .empty
-            )
-        ]
-
-        let id = UUID()
-        let title: String
-        let description: String
-        let media: Media
     }
 }
 

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -11,8 +11,262 @@ import SwiftUI
 // MARK: View
 
 // Behavior: h-exp, v-exp
+private struct ContentView: View {
+    @ObservedObject var player: Player
+    @State private var isUserInterfaceHidden = false
+
+    var body: some View {
+        ZStack {
+            Group {
+                VideoView(player: player)
+                ControlsView(player: player, isUserInterfaceHidden: isUserInterfaceHidden)
+            }
+            .onTapGesture {
+                isUserInterfaceHidden.toggle()
+            }
+            .accessibilityAddTraits(.isButton)
+            .ignoresSafeArea()
+#if os(iOS)
+            TimeBar(player: player, isUserInterfaceHidden: isUserInterfaceHidden)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+#endif
+        }
+        .animation(.easeInOut(duration: 0.2), value: isUserInterfaceHidden)
+    }
+}
+
+// Behavior: h-exp, v-exp
+private struct ControlsView: View {
+    @ObservedObject var player: Player
+    let isUserInterfaceHidden: Bool
+
+    var body: some View {
+        ZStack {
+            if !isUserInterfaceHidden {
+                Color(white: 0, opacity: 0.3)
+                HStack(spacing: 40) {
+                    PreviousButton(player: player)
+                    PlaybackButton(player: player)
+                    NextButton(player: player)
+                }
+            }
+            if player.isBuffering {
+                ProgressView()
+            }
+        }
+        .tint(.white)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
+        .debugBodyCounter()
+    }
+}
+
+// Behavior: h-exp, v-exp
+private struct MessageView: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .multilineTextAlignment(.center)
+            .foregroundColor(.white)
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// Behavior: h-hug, v-hug
+private struct NextButton: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        Group {
+            if player.canAdvanceToNextItem() {
+                Button(action: { player.advanceToNextItem() }) {
+                    Image(systemName: "arrow.right.circle.fill")
+                        .resizable()
+                }
+            }
+            else {
+                Color.clear
+            }
+        }
+        .frame(width: 45, height: 45)
+    }
+}
+
+// Behavior: h-hug, v-hug
+private struct PlaybackButton: View {
+    @ObservedObject var player: Player
+
+    private var playbackButtonImageName: String {
+        switch player.playbackState {
+        case .playing:
+            return "pause.circle.fill"
+        default:
+            return "play.circle.fill"
+        }
+    }
+
+    var body: some View {
+        Button(action: { player.togglePlayPause() }) {
+            Image(systemName: playbackButtonImageName)
+                .resizable()
+        }
+        .opacity(player.isBuffering ? 0 : 1)
+        .frame(width: 90, height: 90)
+        .debugBodyCounter(color: .green)
+    }
+}
+
+// Behavior: h-hug, v-hug
+private struct PreviousButton: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        Group {
+            if player.canReturnToPreviousItem() {
+                Button(action: { player.returnToPreviousItem() }) {
+                    Image(systemName: "arrow.left.circle.fill")
+                        .resizable()
+                }
+            }
+            else {
+                Color.clear
+            }
+        }
+        .frame(width: 45, height: 45)
+    }
+}
+
+// Behavior: h-hug, v-hug
+private struct LiveLabel: View {
+    @ObservedObject var player: Player
+    @ObservedObject var progressTracker: ProgressTracker
+
+    private var canSkipToLive: Bool {
+        player.canSkipToLive(from: progressTracker.time ?? player.time)
+    }
+
+    var body: some View {
+        if player.streamType == .dvr || player.streamType == .live {
+            Button(action: { player.skipToLive() }) {
+                Text("LIVE")
+                    .foregroundColor(.white)
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 6)
+                    .background(canSkipToLive ? .gray : .red)
+                    .cornerRadius(4)
+            }
+            .disabled(!canSkipToLive)
+        }
+    }
+}
+
+// Behavior: h-exp, v-hug
+@available(tvOS, unavailable)
+private struct TimeBar: View {
+    @ObservedObject var player: Player
+    let isUserInterfaceHidden: Bool
+
+    @StateObject private var progressTracker = ProgressTracker(
+        interval: CMTime(value: 1, timescale: 10),
+        seekBehavior: UserDefaults.standard.seekBehavior
+    )
+
+    var body: some View {
+        HStack(spacing: 0) {
+            TimeSlider(player: player, progressTracker: progressTracker)
+            LiveLabel(player: player, progressTracker: progressTracker)
+        }
+        .opacity(isUserInterfaceHidden ? 0 : 1)
+        .padding(.horizontal, 6)
+        .bind(progressTracker, to: player)
+    }
+}
+
+// Behavior: h-exp, v-hug
+@available(tvOS, unavailable)
+private struct TimeSlider: View {
+    private static let blankFormattedTime = "--:--"
+
+    private static let shortFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.second, .minute]
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
+    }()
+
+    private static let longFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.second, .minute, .hour]
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
+    }()
+
+    @ObservedObject var player: Player
+    @ObservedObject var progressTracker: ProgressTracker
+
+    private var timeRange: CMTimeRange {
+        player.timeRange
+    }
+
+    private var formattedElapsedTime: String {
+        guard timeRange.isValid else { return Self.blankFormattedTime }
+        let time = progressTracker.time ?? player.time
+        guard time.isValid else { return Self.blankFormattedTime }
+        return Self.formattedDuration((time - timeRange.start).seconds)
+    }
+
+    private var formattedTotalTime: String {
+        guard timeRange.isValid else { return Self.blankFormattedTime }
+        return Self.formattedDuration((timeRange.duration).seconds)
+    }
+
+    var body: some View {
+        Group {
+            switch player.streamType {
+            case .onDemand:
+                Slider(
+                    progressTracker: progressTracker,
+                    label: {
+                        Text("Progress")
+                    },
+                    minimumValueLabel: {
+                        Text(formattedElapsedTime)
+                    },
+                    maximumValueLabel: {
+                        Text(formattedTotalTime)
+                    }
+                )
+            case .unknown:
+                // `EmptyView` has h-hug, v-hug behavior.
+                EmptyView()
+                    .frame(maxWidth: .infinity)
+            default:
+                Slider(progressTracker: progressTracker) {
+                    Text("Progress")
+                }
+            }
+        }
+        .foregroundColor(.white)
+        .tint(.white)
+        .padding()
+        .debugBodyCounter(color: .blue)
+    }
+
+    private static func formattedDuration(_ duration: TimeInterval) -> String {
+        if duration < 60 * 60 {
+            return shortFormatter.string(from: duration)!
+        }
+        else {
+            return longFormatter.string(from: duration)!
+        }
+    }
+}
+
+// Behavior: h-exp, v-exp
 struct PlayerView: View {
-    let medias: [Media]
+    private let medias: [Media]
 
     @StateObject private var player = Player()
 
@@ -47,262 +301,6 @@ struct PlayerView: View {
     private func play() {
         player.items = medias.compactMap(\.playerItem)
         player.play()
-    }
-}
-
-private extension PlayerView {
-    // Behavior: h-exp, v-exp
-    struct ContentView: View {
-        @ObservedObject var player: Player
-        @State private var isUserInterfaceHidden = false
-
-        var body: some View {
-            ZStack {
-                Group {
-                    VideoView(player: player)
-                    ControlsView(player: player, isUserInterfaceHidden: isUserInterfaceHidden)
-                }
-                .onTapGesture {
-                    isUserInterfaceHidden.toggle()
-                }
-                .accessibilityAddTraits(.isButton)
-                .ignoresSafeArea()
-#if os(iOS)
-                TimeBar(player: player, isUserInterfaceHidden: isUserInterfaceHidden)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-#endif
-            }
-            .animation(.easeInOut(duration: 0.2), value: isUserInterfaceHidden)
-        }
-    }
-
-    // Behavior: h-exp, v-exp
-    struct ControlsView: View {
-        @ObservedObject var player: Player
-        let isUserInterfaceHidden: Bool
-
-        var body: some View {
-            ZStack {
-                if !isUserInterfaceHidden {
-                    Color(white: 0, opacity: 0.3)
-                    HStack(spacing: 40) {
-                        PreviousButton(player: player)
-                        PlaybackButton(player: player)
-                        NextButton(player: player)
-                    }
-                }
-                if player.isBuffering {
-                    ProgressView()
-                }
-            }
-            .tint(.white)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
-            .debugBodyCounter()
-        }
-    }
-
-    // Behavior: h-exp, v-exp
-    struct MessageView: View {
-        let message: String
-
-        var body: some View {
-            Text(message)
-                .multilineTextAlignment(.center)
-                .foregroundColor(.white)
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    // Behavior: h-hug, v-hug
-    struct NextButton: View {
-        @ObservedObject var player: Player
-
-        var body: some View {
-            Group {
-                if player.canAdvanceToNextItem() {
-                    Button(action: { player.advanceToNextItem() }) {
-                        Image(systemName: "arrow.right.circle.fill")
-                            .resizable()
-                    }
-                }
-                else {
-                    Color.clear
-                }
-            }
-            .frame(width: 45, height: 45)
-        }
-    }
-
-    // Behavior: h-hug, v-hug
-    struct PlaybackButton: View {
-        @ObservedObject var player: Player
-
-        private var playbackButtonImageName: String {
-            switch player.playbackState {
-            case .playing:
-                return "pause.circle.fill"
-            default:
-                return "play.circle.fill"
-            }
-        }
-
-        var body: some View {
-            Button(action: { player.togglePlayPause() }) {
-                Image(systemName: playbackButtonImageName)
-                    .resizable()
-            }
-            .opacity(player.isBuffering ? 0 : 1)
-            .frame(width: 90, height: 90)
-            .debugBodyCounter(color: .green)
-        }
-    }
-
-    // Behavior: h-hug, v-hug
-    struct PreviousButton: View {
-        @ObservedObject var player: Player
-
-        var body: some View {
-            Group {
-                if player.canReturnToPreviousItem() {
-                    Button(action: { player.returnToPreviousItem() }) {
-                        Image(systemName: "arrow.left.circle.fill")
-                            .resizable()
-                    }
-                }
-                else {
-                    Color.clear
-                }
-            }
-            .frame(width: 45, height: 45)
-        }
-    }
-
-    // Behavior: h-hug, v-hug
-    struct LiveLabel: View {
-        @ObservedObject var player: Player
-        @ObservedObject var progressTracker: ProgressTracker
-
-        private var canSkipToLive: Bool {
-            player.canSkipToLive(from: progressTracker.time ?? player.time)
-        }
-
-        var body: some View {
-            if player.streamType == .dvr || player.streamType == .live {
-                Button(action: { player.skipToLive() }) {
-                    Text("LIVE")
-                        .foregroundColor(.white)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 6)
-                        .background(canSkipToLive ? .gray : .red)
-                        .cornerRadius(4)
-                }
-                .disabled(!canSkipToLive)
-            }
-        }
-    }
-
-    // Behavior: h-exp, v-hug
-    @available(tvOS, unavailable)
-    struct TimeBar: View {
-        @ObservedObject var player: Player
-        let isUserInterfaceHidden: Bool
-
-        @StateObject private var progressTracker = ProgressTracker(
-            interval: CMTime(value: 1, timescale: 10),
-            seekBehavior: UserDefaults.standard.seekBehavior
-        )
-
-        var body: some View {
-            HStack(spacing: 0) {
-                TimeSlider(player: player, progressTracker: progressTracker)
-                LiveLabel(player: player, progressTracker: progressTracker)
-            }
-            .opacity(isUserInterfaceHidden ? 0 : 1)
-            .padding(.horizontal, 6)
-            .bind(progressTracker, to: player)
-        }
-    }
-
-    // Behavior: h-exp, v-hug
-    @available(tvOS, unavailable)
-    struct TimeSlider: View {
-        private static let blankFormattedTime = "--:--"
-
-        private static let shortFormatter: DateComponentsFormatter = {
-            let formatter = DateComponentsFormatter()
-            formatter.allowedUnits = [.second, .minute]
-            formatter.zeroFormattingBehavior = .pad
-            return formatter
-        }()
-
-        private static let longFormatter: DateComponentsFormatter = {
-            let formatter = DateComponentsFormatter()
-            formatter.allowedUnits = [.second, .minute, .hour]
-            formatter.zeroFormattingBehavior = .pad
-            return formatter
-        }()
-
-        @ObservedObject var player: Player
-        @ObservedObject var progressTracker: ProgressTracker
-
-        private var timeRange: CMTimeRange {
-            player.timeRange
-        }
-
-        private var formattedElapsedTime: String {
-            guard timeRange.isValid else { return Self.blankFormattedTime }
-            let time = progressTracker.time ?? player.time
-            guard time.isValid else { return Self.blankFormattedTime }
-            return Self.formattedDuration((time - timeRange.start).seconds)
-        }
-
-        private var formattedTotalTime: String {
-            guard timeRange.isValid else { return Self.blankFormattedTime }
-            return Self.formattedDuration((timeRange.duration).seconds)
-        }
-
-        var body: some View {
-            Group {
-                switch player.streamType {
-                case .onDemand:
-                    Slider(
-                        progressTracker: progressTracker,
-                        label: {
-                            Text("Progress")
-                        },
-                        minimumValueLabel: {
-                            Text(formattedElapsedTime)
-                        },
-                        maximumValueLabel: {
-                            Text(formattedTotalTime)
-                        }
-                    )
-                case .unknown:
-                    // `EmptyView` has h-hug, v-hug behavior.
-                    EmptyView()
-                        .frame(maxWidth: .infinity)
-                default:
-                    Slider(progressTracker: progressTracker) {
-                        Text("Progress")
-                    }
-                }
-            }
-            .foregroundColor(.white)
-            .tint(.white)
-            .padding()
-            .debugBodyCounter(color: .blue)
-        }
-
-        private static func formattedDuration(_ duration: TimeInterval) -> String {
-            if duration < 60 * 60 {
-                return shortFormatter.string(from: duration)!
-            }
-            else {
-                return longFormatter.string(from: duration)!
-            }
-        }
     }
 }
 

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -6,6 +6,28 @@
 
 import SwiftUI
 
+// MARK: Cells
+
+// Behavior: h-hug, v-hug
+private struct Cell<Presented: View>: View {
+    let title: String
+
+    @ViewBuilder var presented: () -> Presented
+    @State private var isPresented = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .foregroundColor(.primary)
+        }
+        .sheet(isPresented: $isPresented, content: presented)
+    }
+
+    private func action() {
+        isPresented.toggle()
+    }
+}
+
 // MARK: View
 
 // Behavior: h-exp, v-exp
@@ -58,30 +80,6 @@ struct ShowcaseView: View {
             }
         }
         .navigationTitle("Showcase")
-    }
-}
-
-// MARK: View
-
-private extension ShowcaseView {
-    // Behavior: h-hug, v-hug
-    struct Cell<Presented: View>: View {
-        let title: String
-
-        @ViewBuilder var presented: () -> Presented
-        @State private var isPresented = false
-
-        var body: some View {
-            Button(action: action) {
-                Text(title)
-                    .foregroundColor(.primary)
-            }
-            .sheet(isPresented: $isPresented, content: presented)
-        }
-
-        private func action() {
-            isPresented.toggle()
-        }
     }
 }
 

--- a/Demo/Sources/StoriesView.swift
+++ b/Demo/Sources/StoriesView.swift
@@ -11,6 +11,44 @@ import SwiftUI
 // MARK: View
 
 // Behavior: h-exp, v-exp
+private struct StoryView: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        ZStack {
+            VideoView(player: player, gravity: .resizeAspectFill)
+                .ignoresSafeArea()
+            if player.isBuffering {
+                // Ensure the animation is applied by setting its zIndex
+                // See https://sarunw.com/posts/how-to-fix-zstack-transition-animation-in-swiftui/
+                ProgressView()
+                    .zIndex(1)
+            }
+            TimeProgress(player: player)
+        }
+        .tint(.white)
+        .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
+    }
+}
+
+// Behavior: h-exp, v-exp
+private struct TimeProgress: View {
+    @ObservedObject var player: Player
+    @StateObject private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 10))
+
+    var body: some View {
+        ZStack {
+            if let progress = progressTracker.progress {
+                ProgressView(value: progress)
+                    .padding()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .bind(progressTracker, to: player)
+    }
+}
+
+// Behavior: h-exp, v-exp
 struct StoriesView: View {
     @StateObject private var model = StoriesViewModel(stories: Story.stories(from: MediaURLPlaylist.videos))
 
@@ -24,46 +62,6 @@ struct StoriesView: View {
         .background(.black)
         .tabViewStyle(.page)
         .ignoresSafeArea()
-    }
-}
-
-private extension StoriesView {
-    // Behavior: h-exp, v-exp
-    struct StoryView: View {
-        @ObservedObject var player: Player
-
-        var body: some View {
-            ZStack {
-                VideoView(player: player, gravity: .resizeAspectFill)
-                    .ignoresSafeArea()
-                if player.isBuffering {
-                    // Ensure the animation is applied by setting its zIndex
-                    // See https://sarunw.com/posts/how-to-fix-zstack-transition-animation-in-swiftui/
-                    ProgressView()
-                        .zIndex(1)
-                }
-                TimeProgress(player: player)
-            }
-            .tint(.white)
-            .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
-        }
-    }
-
-    // Behavior: h-exp, v-exp
-    struct TimeProgress: View {
-        @ObservedObject var player: Player
-        @StateObject private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 10))
-
-        var body: some View {
-            ZStack {
-                if let progress = progressTracker.progress {
-                    ProgressView(value: progress)
-                        .padding()
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .bind(progressTracker, to: player)
-        }
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR removes private extensions defining local scopes, replacing them with private types directly.

## Changes made

- Removed private extensions from view files (only ones where they were in use).
- Shuffled code around to satisfy linter settings. No significant code change made. I just marked `PlayerView.medias` private but that's all.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
