### PR TITLE
Integrate Pillarbox with Apple VideoPlayer

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324B29506969002E49DC /* PlaylistView.swift */; };
 		0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324E29630130002E49DC /* PlaylistViewModel.swift */; };
+		6F016D9B296C960000C4148E /* SystemRawPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */; };
 		6F36C62D28910538000DD160 /* CoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6F36C62C28910538000DD160 /* CoreBusiness */; };
 		6F3F15A728CEEC6900CA2BD1 /* ShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */; };
 		6F48A5DD2932673A00B80393 /* DeveloperTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F48A5DC2932673A00B80393 /* DeveloperTools.swift */; };
@@ -46,6 +47,7 @@
 		0EEB324B29506969002E49DC /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		0EEB324E29630130002E49DC /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemRawPlayerView.swift; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowcaseView.swift; sourceTree = "<group>"; };
 		6F45DB9A2893B773008ACCE6 /* Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Application.xcconfig; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				6F5FEDCF28CF328600B88EC0 /* StoriesViewModel.swift */,
 				6FD6CE91291D36F70015FC03 /* Story.swift */,
 				6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */,
+				6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */,
 				6FA83B7F296834F8001578DB /* Template.swift */,
 				6F9B5BCA28D03E1E0074B9E0 /* TwinsView.swift */,
 				6FCA474A292CC2AA008C2812 /* UserDefaults.swift */,
@@ -314,6 +317,7 @@
 				6F7750D628EABD5100E80196 /* SimplePlayerView.swift in Sources */,
 				0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */,
 				6F9B5BCB28D03E1E0074B9E0 /* TwinsView.swift in Sources */,
+				6F016D9B296C960000C4148E /* SystemRawPlayerView.swift in Sources */,
 				6FD1F3A128D0490200DF8CF1 /* MultiView.swift in Sources */,
 				6F3F15A728CEEC6900CA2BD1 /* ShowcaseView.swift in Sources */,
 				6F65FA2128D0CE8A0081ACD1 /* PlaybackView.swift in Sources */,

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324B29506969002E49DC /* PlaylistView.swift */; };
 		0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324E29630130002E49DC /* PlaylistViewModel.swift */; };
-		6F016D9B296C960000C4148E /* SystemRawPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */; };
+		6F016D9B296C960000C4148E /* VanillaPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* VanillaPlayerView.swift */; };
 		6F36C62D28910538000DD160 /* CoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6F36C62C28910538000DD160 /* CoreBusiness */; };
 		6F3F15A728CEEC6900CA2BD1 /* ShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */; };
 		6F48A5DD2932673A00B80393 /* DeveloperTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F48A5DC2932673A00B80393 /* DeveloperTools.swift */; };
@@ -47,7 +47,7 @@
 		0EEB324B29506969002E49DC /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		0EEB324E29630130002E49DC /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemRawPlayerView.swift; sourceTree = "<group>"; };
+		6F016D9A296C960000C4148E /* VanillaPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VanillaPlayerView.swift; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowcaseView.swift; sourceTree = "<group>"; };
 		6F45DB9A2893B773008ACCE6 /* Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Application.xcconfig; sourceTree = "<group>"; };
@@ -191,10 +191,10 @@
 				6F5FEDCF28CF328600B88EC0 /* StoriesViewModel.swift */,
 				6FD6CE91291D36F70015FC03 /* Story.swift */,
 				6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */,
-				6F016D9A296C960000C4148E /* SystemRawPlayerView.swift */,
 				6FA83B7F296834F8001578DB /* Template.swift */,
 				6F9B5BCA28D03E1E0074B9E0 /* TwinsView.swift */,
 				6FCA474A292CC2AA008C2812 /* UserDefaults.swift */,
+				6F016D9A296C960000C4148E /* VanillaPlayerView.swift */,
 				6FD1F3AA28D0655800DF8CF1 /* WrappedView.swift */,
 				6FD1F3AC28D0657300DF8CF1 /* WrappedViewModel.swift */,
 			);
@@ -317,7 +317,7 @@
 				6F7750D628EABD5100E80196 /* SimplePlayerView.swift in Sources */,
 				0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */,
 				6F9B5BCB28D03E1E0074B9E0 /* TwinsView.swift in Sources */,
-				6F016D9B296C960000C4148E /* SystemRawPlayerView.swift in Sources */,
+				6F016D9B296C960000C4148E /* VanillaPlayerView.swift in Sources */,
 				6FD1F3A128D0490200DF8CF1 /* MultiView.swift in Sources */,
 				6F3F15A728CEEC6900CA2BD1 /* ShowcaseView.swift in Sources */,
 				6F65FA2128D0CE8A0081ACD1 /* PlaybackView.swift in Sources */,

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		6FA83B80296834F8001578DB /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA83B7F296834F8001578DB /* Template.swift */; };
 		6FA83B82296834FE001578DB /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA83B81296834FE001578DB /* Playlist.swift */; };
 		6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB553B128C3AF020067CFC4 /* StoriesView.swift */; };
+		6FBD8F1B296C2A6E0051ABEB /* SystemPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */; };
 		6FBEFCEB289132DB004BE625 /* UserInterface in Frameworks */ = {isa = PBXBuildFile; productRef = 6FBEFCEA289132DB004BE625 /* UserInterface */; };
 		6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6FCA4746292CBEC7008C2812 /* ShowTime */; };
 		6FCA4749292CC101008C2812 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCA4748292CC101008C2812 /* SettingsView.swift */; };
@@ -66,6 +67,7 @@
 		6FA83B7F296834F8001578DB /* Template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
 		6FA83B81296834FE001578DB /* Playlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
 		6FB553B128C3AF020067CFC4 /* StoriesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
+		6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPlayerView.swift; sourceTree = "<group>"; };
 		6FCA4748292CC101008C2812 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6FCA474A292CC2AA008C2812 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		6FCA8D7B28AD2AB900CF75FB /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				6FB553B128C3AF020067CFC4 /* StoriesView.swift */,
 				6F5FEDCF28CF328600B88EC0 /* StoriesViewModel.swift */,
 				6FD6CE91291D36F70015FC03 /* Story.swift */,
+				6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */,
 				6FA83B7F296834F8001578DB /* Template.swift */,
 				6F9B5BCA28D03E1E0074B9E0 /* TwinsView.swift */,
 				6FCA474A292CC2AA008C2812 /* UserDefaults.swift */,
@@ -321,6 +324,7 @@
 				6FA83B82296834FE001578DB /* Playlist.swift in Sources */,
 				6FD1F3AB28D0655800DF8CF1 /* WrappedView.swift in Sources */,
 				6FD6CE92291D36F70015FC03 /* Story.swift in Sources */,
+				6FBD8F1B296C2A6E0051ABEB /* SystemPlayerView.swift in Sources */,
 				6FA83B80296834F8001578DB /* Template.swift in Sources */,
 				6FCA4749292CC101008C2812 /* SettingsView.swift in Sources */,
 				6FA83B7E296831D5001578DB /* BasicPlaybackView.swift in Sources */,

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -43,6 +43,9 @@ struct ShowcaseView: View {
             Cell(title: "Simple") {
                 SimplePlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
             }
+            Cell(title: "System") {
+                SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
+            }
             Cell(title: "Stories") {
                 StoriesView()
             }

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -68,7 +68,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func systemSection() -> some View {
-        Section("System player") {
+        Section("System player (using Pillarbox)") {
             Cell(title: "Video URL") {
                 SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
             }
@@ -83,7 +83,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func vanillaPlayerSection() -> some View {
-        Section("Vanilla player") {
+        Section("System player (using AVPlayer)") {
             Cell(title: "Video URL") {
                 VanillaPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
             }

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -33,6 +33,8 @@ struct ShowcaseView: View {
             layoutsSection()
             playlistsSection()
             embeddingsSection()
+            systemPlayerSection()
+            systemRawPlayerSection()
         }
         .navigationTitle("Showcase")
     }
@@ -43,11 +45,50 @@ struct ShowcaseView: View {
             Cell(title: "Simple") {
                 SimplePlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
             }
-            Cell(title: "System") {
-                SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
-            }
             Cell(title: "Stories") {
                 StoriesView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func systemPlayerSection() -> some View {
+        Section("System") {
+            Cell(title: "Video URL") {
+                SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
+            }
+            Cell(title: "Video URN") {
+                SystemPlayerView(media: Media(from: URNTemplate.onDemandHorizontalVideo))
+            }
+            Cell(title: "Unknown") {
+                SystemPlayerView(media: Media(from: URNTemplate.unknown))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func systemSection() -> some View {
+        Section("System player") {
+            Cell(title: "Video URL") {
+                SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
+            }
+            Cell(title: "Video URN") {
+                SystemPlayerView(media: Media(from: URNTemplate.dvrVideo))
+            }
+            Cell(title: "Unknown") {
+                SystemPlayerView(media: Media(from: URNTemplate.unknown))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func systemRawPlayerSection() -> some View {
+        Section("Raw system player") {
+            Cell(title: "Video URL") {
+                SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
+            }
+            Cell(title: "Unknown") {
+                SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.unknown)!)
             }
         }
     }

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -34,7 +34,7 @@ struct ShowcaseView: View {
             playlistsSection()
             embeddingsSection()
             systemPlayerSection()
-            systemRawPlayerSection()
+            vanillaPlayerSection()
         }
         .navigationTitle("Showcase")
     }
@@ -82,13 +82,13 @@ struct ShowcaseView: View {
     }
 
     @ViewBuilder
-    private func systemRawPlayerSection() -> some View {
-        Section("Raw system player") {
+    private func vanillaPlayerSection() -> some View {
+        Section("Vanilla player") {
             Cell(title: "Video URL") {
-                SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
+                VanillaPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
             }
             Cell(title: "Unknown") {
-                SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.unknown)!)
+                VanillaPlayerView(item: Template.playerItem(from: URLTemplate.unknown)!)
             }
         }
     }

--- a/Demo/Sources/ShowcaseView.swift
+++ b/Demo/Sources/ShowcaseView.swift
@@ -53,21 +53,6 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func systemPlayerSection() -> some View {
-        Section("System") {
-            Cell(title: "Video URL") {
-                SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
-            }
-            Cell(title: "Video URN") {
-                SystemPlayerView(media: Media(from: URNTemplate.onDemandHorizontalVideo))
-            }
-            Cell(title: "Unknown") {
-                SystemPlayerView(media: Media(from: URNTemplate.unknown))
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func systemSection() -> some View {
         Section("System player (using Pillarbox)") {
             Cell(title: "Video URL") {
                 SystemPlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))

--- a/Demo/Sources/SystemPlayerView.swift
+++ b/Demo/Sources/SystemPlayerView.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+import Player
+import SwiftUI
+
+// Behavior: h-exp, v-exp
+struct SystemPlayerView: View {
+    let media: Media
+
+    @StateObject private var player = Player()
+
+    var body: some View {
+        SystemVideoView(player: player)
+            .ignoresSafeArea()
+            .onAppear {
+                play()
+            }
+    }
+
+    private func play() {
+        player.append(media.playerItem())
+        player.play()
+    }
+}
+
+struct SystemPlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        SystemPlayerView(media: Media(from: URLTemplate.onDemandVideoLocalHLS))
+    }
+}

--- a/Demo/Sources/SystemRawPlayerView.swift
+++ b/Demo/Sources/SystemRawPlayerView.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVKit
+import SwiftUI
+
+// Behavior: h-exp, v-exp
+struct SystemRawPlayerView: View {
+    let item: AVPlayerItem
+
+    @State private var player = AVQueuePlayer()
+
+    var body: some View {
+        VideoPlayer(player: player)
+            .ignoresSafeArea()
+            .onAppear {
+                play()
+            }
+    }
+
+    private func play() {
+        player.insert(item, after: nil)
+        player.play()
+    }
+}
+
+struct SystemRawPlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
+    }
+}

--- a/Demo/Sources/Template.swift
+++ b/Demo/Sources/Template.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import CoreBusiness
 import Foundation
 
@@ -210,5 +211,21 @@ struct Template: Hashable {
 
     static func medias(from templates: [Template]) -> [Media] {
         templates.map { Media(from: $0) }
+    }
+}
+
+extension Template {
+    static func playerItem(from template: Template) -> AVPlayerItem? {
+        switch template.type {
+        case let .url(url):
+            return AVPlayerItem(url: url)
+        case let .unbufferedUrl(url):
+            let item = AVPlayerItem(url: url)
+            item.automaticallyPreservesTimeOffsetFromLive = true
+            item.preferredForwardBufferDuration = 1
+            return item
+        case .urn:
+            return nil
+        }
     }
 }

--- a/Demo/Sources/VanillaPlayerView.swift
+++ b/Demo/Sources/VanillaPlayerView.swift
@@ -8,7 +8,7 @@ import AVKit
 import SwiftUI
 
 // Behavior: h-exp, v-exp
-struct SystemRawPlayerView: View {
+struct VanillaPlayerView: View {
     let item: AVPlayerItem
 
     @State private var player = AVQueuePlayer()
@@ -27,8 +27,8 @@ struct SystemRawPlayerView: View {
     }
 }
 
-struct SystemRawPlayerView_Previews: PreviewProvider {
+struct VanillaPlayerView_Previews: PreviewProvider {
     static var previews: some View {
-        SystemRawPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
+        VanillaPlayerView(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
     }
 }

--- a/Sources/Player/SystemVideoView.swift
+++ b/Sources/Player/SystemVideoView.swift
@@ -8,6 +8,9 @@ import AVKit
 import SwiftUI
 
 /// A video view with standard system user experience.
+///
+/// Remark: A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback
+/// button. This issue has been reported to Apple as FB11934227.
 public struct SystemVideoView: View {
     @ObservedObject private var player: Player
 

--- a/Sources/Player/SystemVideoView.swift
+++ b/Sources/Player/SystemVideoView.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVKit
+import SwiftUI
+
+/// A video view with standard system user experience.
+public struct SystemVideoView: View {
+    @ObservedObject private var player: Player
+
+    public var body: some View {
+        VideoPlayer(player: player.rawPlayer)
+    }
+
+    public init(player: Player) {
+        self.player = player
+    }
+}

--- a/Sources/Player/VideoView.swift
+++ b/Sources/Player/VideoView.swift
@@ -26,7 +26,7 @@ public final class VideoLayerView: UIView {
 /// A view displaying video content provided by an associated player.
 /// Behavior: h-exp, v-exp
 public struct VideoView: UIViewRepresentable {
-    @ObservedObject private(set) var player: Player
+    @ObservedObject private var player: Player
     private let gravity: AVLayerVideoGravity
 
     public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect) {

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -53,6 +53,11 @@ struct PlayerView: View {
 }
 ```
 
+The system default playback user experience is provided as well. Just use `SystemVideoView` instead of `VideoView`.
+
+> **Warning**
+> A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button. This issue has been reported to Apple as FB11934227.
+
 ## Advanced view layouts
 
 Pillarbox currently does not provide any standard playback view you can use but you can build one yourself. Since `Player` is an `ObservableObject`, though, implementation of a playback view can be achieved in the same was as for any usual SwiftUI view.


### PR DESCRIPTION
# Pull request

## Description

This PR provides a way to integrate the standard Apple player experience with Pillarbox.

## Changes made

- Add dedicated system player view.
- Add corresponding demo entry.

A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button. This issue has been reported to Apple as FB11934227. Having the system player integrated in the meantime is still useful, though.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
