### PR TITLE
AirPlay player configuration

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E8C362A296DB14600707FA5 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C3629296DB14600707FA5 /* Settings.swift */; };
 		0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324B29506969002E49DC /* PlaylistView.swift */; };
 		0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324E29630130002E49DC /* PlaylistViewModel.swift */; };
 		6F016D9B296C960000C4148E /* VanillaPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* VanillaPlayerView.swift */; };
@@ -44,6 +45,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E8C3629296DB14600707FA5 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		0EEB324B29506969002E49DC /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		0EEB324E29630130002E49DC /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				0EEB324B29506969002E49DC /* PlaylistView.swift */,
 				0EEB324E29630130002E49DC /* PlaylistViewModel.swift */,
 				6FCA4748292CC101008C2812 /* SettingsView.swift */,
+				0E8C3629296DB14600707FA5 /* Settings.swift */,
 				6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */,
 				6F7750D528EABD5100E80196 /* SimplePlayerView.swift */,
 				6FB553B128C3AF020067CFC4 /* StoriesView.swift */,
@@ -307,6 +310,7 @@
 			files = (
 				6F48A5DD2932673A00B80393 /* DeveloperTools.swift in Sources */,
 				6FCA8D7C28AD2AB900CF75FB /* AppDelegate.swift in Sources */,
+				0E8C362A296DB14600707FA5 /* Settings.swift in Sources */,
 				6FD1F3A328D04AE200DF8CF1 /* LinkView.swift in Sources */,
 				6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */,
 				6FD1F3A728D0646200DF8CF1 /* Navigation.swift in Sources */,

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0E8C362A296DB14600707FA5 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C3629296DB14600707FA5 /* Settings.swift */; };
+		0E8C362A296DB14600707FA5 /* PlayerContfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C3629296DB14600707FA5 /* PlayerContfiguration.swift */; };
 		0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324B29506969002E49DC /* PlaylistView.swift */; };
 		0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324E29630130002E49DC /* PlaylistViewModel.swift */; };
 		6F016D9B296C960000C4148E /* VanillaPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* VanillaPlayerView.swift */; };
@@ -45,7 +45,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0E8C3629296DB14600707FA5 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		0E8C3629296DB14600707FA5 /* PlayerContfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerContfiguration.swift; sourceTree = "<group>"; };
 		0EEB324B29506969002E49DC /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		0EEB324E29630130002E49DC /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -182,12 +182,12 @@
 				6FD1F3A028D0490200DF8CF1 /* MultiView.swift */,
 				6FD1F3A628D0646200DF8CF1 /* Navigation.swift */,
 				6F65FA2028D0CE8A0081ACD1 /* PlaybackView.swift */,
+				0E8C3629296DB14600707FA5 /* PlayerContfiguration.swift */,
 				6FCD6A1828AD158E00FCE4EA /* PlayerView.swift */,
 				6FA83B81296834FE001578DB /* Playlist.swift */,
 				0EEB324B29506969002E49DC /* PlaylistView.swift */,
 				0EEB324E29630130002E49DC /* PlaylistViewModel.swift */,
 				6FCA4748292CC101008C2812 /* SettingsView.swift */,
-				0E8C3629296DB14600707FA5 /* Settings.swift */,
 				6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */,
 				6F7750D528EABD5100E80196 /* SimplePlayerView.swift */,
 				6FB553B128C3AF020067CFC4 /* StoriesView.swift */,
@@ -310,7 +310,7 @@
 			files = (
 				6F48A5DD2932673A00B80393 /* DeveloperTools.swift in Sources */,
 				6FCA8D7C28AD2AB900CF75FB /* AppDelegate.swift in Sources */,
-				0E8C362A296DB14600707FA5 /* Settings.swift in Sources */,
+				0E8C362A296DB14600707FA5 /* PlayerContfiguration.swift in Sources */,
 				6FD1F3A328D04AE200DF8CF1 /* LinkView.swift in Sources */,
 				6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */,
 				6FD1F3A728D0646200DF8CF1 /* Navigation.swift in Sources */,

--- a/Demo/Sources/LinkView.swift
+++ b/Demo/Sources/LinkView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct LinkView: View {
     let media: Media
 
-    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @StateObject private var player = Player(configuration: .externalPlaybackDisabled)
     @State private var isDisplayed = true
 
     var body: some View {

--- a/Demo/Sources/LinkView.swift
+++ b/Demo/Sources/LinkView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct LinkView: View {
     let media: Media
 
-    @StateObject private var player = Player()
+    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
     @State private var isDisplayed = true
 
     var body: some View {

--- a/Demo/Sources/MultiView.swift
+++ b/Demo/Sources/MultiView.swift
@@ -12,8 +12,8 @@ struct MultiView: View {
     let media1: Media
     let media2: Media
 
-    @StateObject private var topPlayer = Player()
-    @StateObject private var bottomPlayer = Player()
+    @StateObject private var topPlayer = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @StateObject private var bottomPlayer = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
 
     var body: some View {
         VStack(spacing: 10) {

--- a/Demo/Sources/MultiView.swift
+++ b/Demo/Sources/MultiView.swift
@@ -12,8 +12,8 @@ struct MultiView: View {
     let media1: Media
     let media2: Media
 
-    @StateObject private var topPlayer = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
-    @StateObject private var bottomPlayer = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @StateObject private var topPlayer = Player(configuration: .externalPlaybackDisabled)
+    @StateObject private var bottomPlayer = Player(configuration: .externalPlaybackDisabled)
 
     var body: some View {
         VStack(spacing: 10) {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -122,13 +122,20 @@ private struct TimeBar: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            RoutePickerView()
-                .frame(width: 45, height: 45)
+            routePickerView()
             TimeSlider(player: player, progressTracker: progressTracker)
             LiveLabel(player: player, progressTracker: progressTracker)
         }
         .padding(.horizontal, 6)
         .bind(progressTracker, to: player)
+    }
+
+    @ViewBuilder
+    private func routePickerView() -> some View {
+        if player.configuration.allowsExternalPlayback {
+            RoutePickerView()
+                .frame(width: 45, height: 45)
+        }
     }
 }
 

--- a/Demo/Sources/PlayerContfiguration.swift
+++ b/Demo/Sources/PlayerContfiguration.swift
@@ -7,15 +7,15 @@
 import Foundation
 import Player
 
-enum Settings {
-    static func playerConfiguration() -> PlayerConfiguration {
+extension PlayerConfiguration {
+    static var standard: Self {
         PlayerConfiguration(
             allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
             usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
         )
     }
 
-    static func playerConfigurationWithAirplayDisabled() -> PlayerConfiguration {
+    static var externalPlaybackDisabled: Self {
         PlayerConfiguration(
             allowsExternalPlayback: false
         )

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -14,7 +14,7 @@ struct PlayerView: View {
     let media: Media
     @StateObject private var player = Player(configuration: .init(
         allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
-        usesExternalPlaybackWhileExternalScreenIsActive: !UserDefaults.standard.presenterModeEnabled
+        usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
     ))
 
     var body: some View {

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Behavior: h-exp, v-exp
 struct PlayerView: View {
     let media: Media
-    @StateObject private var player = Player(configuration: Settings.playerConfiguration())
+    @StateObject private var player = Player(configuration: .standard)
 
     var body: some View {
         PlaybackView(player: player)

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -12,10 +12,7 @@ import SwiftUI
 /// Behavior: h-exp, v-exp
 struct PlayerView: View {
     let media: Media
-    @StateObject private var player = Player(configuration: .init(
-        allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
-        usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
-    ))
+    @StateObject private var player = Player(configuration: Settings.playerConfiguration())
 
     var body: some View {
         PlaybackView(player: player)

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -12,7 +12,10 @@ import SwiftUI
 /// Behavior: h-exp, v-exp
 struct PlayerView: View {
     let media: Media
-    @StateObject private var player = Player(configuration: .init(allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled))
+    @StateObject private var player = Player(configuration: .init(
+        allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
+        usesExternalPlaybackWhileExternalScreenIsActive: !UserDefaults.standard.presenterModeEnabled
+    ))
 
     var body: some View {
         PlaybackView(player: player)

--- a/Demo/Sources/PlayerView.swift
+++ b/Demo/Sources/PlayerView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Behavior: h-exp, v-exp
 struct PlayerView: View {
     let media: Media
-    @StateObject private var player = Player()
+    @StateObject private var player = Player(configuration: .init(allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled))
 
     var body: some View {
         PlaybackView(player: player)

--- a/Demo/Sources/PlaylistViewModel.swift
+++ b/Demo/Sources/PlaylistViewModel.swift
@@ -5,7 +5,6 @@
 //
 
 import Combine
-import Foundation
 import OrderedCollections
 import Player
 
@@ -51,7 +50,7 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    let player = Player(configuration: Settings.playerConfiguration())
+    let player = Player(configuration: .standard)
 
     var medias: [Media] {
         get {

--- a/Demo/Sources/PlaylistViewModel.swift
+++ b/Demo/Sources/PlaylistViewModel.swift
@@ -51,10 +51,7 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    let player = Player(configuration: .init(
-        allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
-        usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
-    ))
+    let player = Player(configuration: Settings.playerConfiguration())
 
     var medias: [Media] {
         get {

--- a/Demo/Sources/PlaylistViewModel.swift
+++ b/Demo/Sources/PlaylistViewModel.swift
@@ -51,7 +51,10 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    let player = Player(configuration: .init(allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled))
+    let player = Player(configuration: .init(
+        allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
+        usesExternalPlaybackWhileExternalScreenIsActive: !UserDefaults.standard.presenterModeEnabled
+    ))
 
     var medias: [Media] {
         get {

--- a/Demo/Sources/PlaylistViewModel.swift
+++ b/Demo/Sources/PlaylistViewModel.swift
@@ -53,7 +53,7 @@ final class PlaylistViewModel: ObservableObject {
 
     let player = Player(configuration: .init(
         allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
-        usesExternalPlaybackWhileExternalScreenIsActive: !UserDefaults.standard.presenterModeEnabled
+        usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
     ))
 
     var medias: [Media] {

--- a/Demo/Sources/PlaylistViewModel.swift
+++ b/Demo/Sources/PlaylistViewModel.swift
@@ -5,6 +5,7 @@
 //
 
 import Combine
+import Foundation
 import OrderedCollections
 import Player
 
@@ -50,7 +51,7 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    let player = Player()
+    let player = Player(configuration: .init(allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled))
 
     var medias: [Media] {
         get {

--- a/Demo/Sources/Settings.swift
+++ b/Demo/Sources/Settings.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+import Player
+
+enum Settings {
+    static func playerConfiguration() -> PlayerConfiguration {
+        PlayerConfiguration(
+            allowsExternalPlayback: UserDefaults.standard.allowsExternalPlaybackEnabled,
+            usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled
+        )
+    }
+
+    static func playerConfigurationWithAirplayDisabled() -> PlayerConfiguration {
+        PlayerConfiguration(
+            allowsExternalPlayback: false
+        )
+    }
+}

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.presenterModeEnabledKey) private var isPresentedModeEnabled = false
     @AppStorage(UserDefaults.bodyCountersEnabledKey) private var areBodyCountersEnabled = false
     @AppStorage(UserDefaults.seekBehaviorSettingKey) private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
+    @AppStorage(UserDefaults.allowsExternalPlaybackSettingKey) private var allowsExternalPlaybackSetting = true
 
     var body: some View {
         List {
@@ -19,6 +20,7 @@ struct SettingsView: View {
                 Text("Immediate").tag(SeekBehaviorSetting.immediate)
                 Text("Deferred").tag(SeekBehaviorSetting.deferred)
             }
+            Toggle("Allows external playback", isOn: $allowsExternalPlaybackSetting)
 #if os(tvOS)
             .pickerStyle(.inline)
 #else

--- a/Demo/Sources/SimplePlayerView.swift
+++ b/Demo/Sources/SimplePlayerView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct SimplePlayerView: View {
     let media: Media
 
-    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @StateObject private var player = Player(configuration: .externalPlaybackDisabled)
 
     var body: some View {
         ZStack {

--- a/Demo/Sources/SimplePlayerView.swift
+++ b/Demo/Sources/SimplePlayerView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct SimplePlayerView: View {
     let media: Media
 
-    @StateObject private var player = Player()
+    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
 
     var body: some View {
         ZStack {

--- a/Demo/Sources/StoriesViewModel.swift
+++ b/Demo/Sources/StoriesViewModel.swift
@@ -33,7 +33,7 @@ final class StoriesViewModel: ObservableObject {
     }
 
     private static func player(for story: Story) -> Player {
-        Player(item: Media(from: story.template).playerItem(), configuration: Settings.playerConfigurationWithAirplayDisabled())
+        Player(item: Media(from: story.template).playerItem(), configuration: .externalPlaybackDisabled)
     }
 
     private static func players(

--- a/Demo/Sources/StoriesViewModel.swift
+++ b/Demo/Sources/StoriesViewModel.swift
@@ -33,7 +33,7 @@ final class StoriesViewModel: ObservableObject {
     }
 
     private static func player(for story: Story) -> Player {
-        Player(item: Media(from: story.template).playerItem())
+        Player(item: Media(from: story.template).playerItem(), configuration: Settings.playerConfigurationWithAirplayDisabled())
     }
 
     private static func players(

--- a/Demo/Sources/TwinsView.swift
+++ b/Demo/Sources/TwinsView.swift
@@ -11,15 +11,15 @@ import SwiftUI
 struct TwinsView: View {
     let media: Media
 
-    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @StateObject private var player = Player(configuration: .externalPlaybackDisabled)
     @State private var mode: Mode = .both
 
     private var topPlayer: Player {
-        mode != .bottom ? player : Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+        mode != .bottom ? player : Player(configuration: .externalPlaybackDisabled)
     }
 
     private var bottomPlayer: Player {
-        mode != .top ? player : Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+        mode != .top ? player : Player(configuration: .externalPlaybackDisabled)
     }
 
     var body: some View {

--- a/Demo/Sources/TwinsView.swift
+++ b/Demo/Sources/TwinsView.swift
@@ -11,15 +11,15 @@ import SwiftUI
 struct TwinsView: View {
     let media: Media
 
-    @StateObject private var player = Player()
+    @StateObject private var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
     @State private var mode: Mode = .both
 
     private var topPlayer: Player {
-        mode != .bottom ? player : Player()
+        mode != .bottom ? player : Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
     }
 
     private var bottomPlayer: Player {
-        mode != .top ? player : Player()
+        mode != .top ? player : Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
     }
 
     var body: some View {

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -21,6 +21,7 @@ extension UserDefaults {
     static let presenterModeEnabledKey = "presenterModeEnabled"
     static let bodyCountersEnabledKey = "bodyCountersEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
+    static let allowsExternalPlaybackSettingKey = "allowsExternalPlaybackSetting"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -41,5 +42,9 @@ extension UserDefaults {
 
     @objc dynamic var seekBehaviorSetting: SeekBehaviorSetting {
         SeekBehaviorSetting(rawValue: integer(forKey: Self.seekBehaviorSettingKey)) ?? .immediate
+    }
+
+    @objc dynamic var allowsExternalPlaybackEnabled: Bool {
+        bool(forKey: Self.allowsExternalPlaybackSettingKey)
     }
 }

--- a/Demo/Sources/WrappedView.swift
+++ b/Demo/Sources/WrappedView.swift
@@ -33,13 +33,13 @@ struct WrappedView: View {
     }
 
     private func play() {
-        let player = Player(item: media.playerItem(), configuration: Settings.playerConfigurationWithAirplayDisabled())
+        let player = Player(item: media.playerItem(), configuration: .externalPlaybackDisabled)
         model.player = player
         player.play()
     }
 
     private func stop() {
-        model.player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+        model.player = Player(configuration: .externalPlaybackDisabled)
     }
 }
 

--- a/Demo/Sources/WrappedView.swift
+++ b/Demo/Sources/WrappedView.swift
@@ -33,13 +33,13 @@ struct WrappedView: View {
     }
 
     private func play() {
-        let player = Player(item: media.playerItem())
+        let player = Player(item: media.playerItem(), configuration: Settings.playerConfigurationWithAirplayDisabled())
         model.player = player
         player.play()
     }
 
     private func stop() {
-        model.player = Player()
+        model.player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
     }
 }
 

--- a/Demo/Sources/WrappedViewModel.swift
+++ b/Demo/Sources/WrappedViewModel.swift
@@ -8,5 +8,5 @@ import Combine
 import Player
 
 final class WrappedViewModel: ObservableObject {
-    @Published var player = Player()
+    @Published var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
 }

--- a/Demo/Sources/WrappedViewModel.swift
+++ b/Demo/Sources/WrappedViewModel.swift
@@ -8,5 +8,5 @@ import Combine
 import Player
 
 final class WrappedViewModel: ObservableObject {
-    @Published var player = Player(configuration: Settings.playerConfigurationWithAirplayDisabled())
+    @Published var player = Player(configuration: .externalPlaybackDisabled)
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -526,5 +526,6 @@ extension Player {
 
     private func configurePlayerConfiguration() {
         rawPlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
+        rawPlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileExternalScreenIsActive
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -63,11 +63,11 @@ public final class Player: ObservableObject, Equatable {
     /// Create a player with a given item queue.
     /// - Parameters:
     ///   - items: The items to be queued initially.
-    ///   - configuration: A closure in which the player can be configured.
-    public init(items: [PlayerItem] = [], configuration: (inout PlayerConfiguration) -> Void = { _ in }) {
+    ///   - configuration: The configuration to apply to the player.
+    public init(items: [PlayerItem] = [], configuration: PlayerConfiguration = .init()) {
         rawPlayer = RawPlayer()
-        self.configuration = Self.configure(with: configuration)
         storedItems = Deque(items)
+        self.configuration = configuration
 
         configurePlaybackStatePublisher()
         configureCurrentItemTimeRangePublisher()
@@ -77,24 +77,19 @@ public final class Player: ObservableObject, Equatable {
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
         configureRawPlayerUpdatePublisher()
+        configurePlayerConfiguration()
     }
 
     /// Create a player with a single item in its queue.
     /// - Parameters:
     ///   - item: The item to queue.
-    ///   - configuration: A closure in which the player can be configured.
-    public convenience init(item: PlayerItem, configuration: (inout PlayerConfiguration) -> Void = { _  in }) {
+    ///   - configuration: The configuration to apply to the player.
+    public convenience init(item: PlayerItem, configuration: PlayerConfiguration = .init()) {
         self.init(items: [item], configuration: configuration)
     }
 
     public nonisolated static func == (lhs: Player, rhs: Player) -> Bool {
         lhs === rhs
-    }
-
-    private static func configure(with configuration: (inout PlayerConfiguration) -> Void) -> PlayerConfiguration {
-        var playerConfiguration = PlayerConfiguration()
-        configuration(&playerConfiguration)
-        return playerConfiguration
     }
 
     deinit {
@@ -527,5 +522,9 @@ extension Player {
             }
             .switchToLatest()
             .eraseToAnyPublisher()
+    }
+
+    private func configurePlayerConfiguration() {
+        rawPlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -41,7 +41,7 @@ public final class Player: ObservableObject, Equatable {
     /// Raw player used for playback.
     let rawPlayer: RawPlayer
 
-    let configuration: PlayerConfiguration
+    public let configuration: PlayerConfiguration
     private var cancellables = Set<AnyCancellable>()
 
     /// The type of stream currently played.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -41,7 +41,7 @@ public final class Player: ObservableObject, Equatable {
     /// Raw player used for playback.
     let rawPlayer: RawPlayer
 
-    private let configuration: PlayerConfiguration
+    let configuration: PlayerConfiguration
     private var cancellables = Set<AnyCancellable>()
 
     /// The type of stream currently played.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -77,7 +77,7 @@ public final class Player: ObservableObject, Equatable {
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
         configureRawPlayerUpdatePublisher()
-        configurePlayerConfiguration()
+        configurePlayer()
     }
 
     /// Create a player with a single item in its queue.
@@ -524,8 +524,8 @@ extension Player {
             .eraseToAnyPublisher()
     }
 
-    private func configurePlayerConfiguration() {
+    private func configurePlayer() {
         rawPlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
-        rawPlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileExternalScreenIsActive
+        rawPlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring
     }
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -11,16 +11,16 @@ public struct PlayerConfiguration {
     /// A Boolean value that indicates whether the player allows switching to external playback mode.
     public let allowsExternalPlayback: Bool
 
-    /// A Boolean value that indicates whether the player allows to switch to external plaback mode even though the screen mirroring is enable.
+    /// A Boolean value that indicates whether the player allows switching to external playback when mirroring.
     /// This property has no effect when `allowsExternalPlayback` is false.
-    public let usesExternalPlaybackWhileExternalScreenIsActive: Bool
+    public let usesExternalPlaybackWhileMirroring: Bool
 
     /// Create a player configuration.
     /// - Parameters:
     ///   - allowsExternalPlayback: Allows switching to external playback mode.
-    ///   - usesExternalPlaybackWhileExternalScreenIsActive: Allows the external playback usage during a screen mirroring.
-    public init(allowsExternalPlayback: Bool = true, usesExternalPlaybackWhileExternalScreenIsActive: Bool = false) {
+    ///   - usesExternalPlaybackWhileMirroring: Allows switching to external playback when mirroring.
+    public init(allowsExternalPlayback: Bool = true, usesExternalPlaybackWhileMirroring: Bool = false) {
         self.allowsExternalPlayback = allowsExternalPlayback
-        self.usesExternalPlaybackWhileExternalScreenIsActive = usesExternalPlaybackWhileExternalScreenIsActive
+        self.usesExternalPlaybackWhileMirroring = usesExternalPlaybackWhileMirroring
     }
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -11,9 +11,16 @@ public struct PlayerConfiguration {
     /// A Boolean value that indicates whether the player allows switching to external playback mode.
     public let allowsExternalPlayback: Bool
 
+    /// A Boolean value that indicates whether the player allows to switch to external plaback mode even though the screen mirroring is enable.
+    /// This property has no effect when `allowsExternalPlayback` is false.
+    public let usesExternalPlaybackWhileExternalScreenIsActive: Bool
+
     /// Create a player configuration.
-    /// - Parameter allowsExternalPlayback: Allows switching to external playback mode.
-    public init(allowsExternalPlayback: Bool = true) {
+    /// - Parameters:
+    ///   - allowsExternalPlayback: Allows switching to external playback mode.
+    ///   - usesExternalPlaybackWhileExternalScreenIsActive: Allows the external playback usage during a screen mirroring.
+    public init(allowsExternalPlayback: Bool = true, usesExternalPlaybackWhileExternalScreenIsActive: Bool = false) {
         self.allowsExternalPlayback = allowsExternalPlayback
+        self.usesExternalPlaybackWhileExternalScreenIsActive = usesExternalPlaybackWhileExternalScreenIsActive
     }
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -8,4 +8,12 @@ import CoreMedia
 
 /// Player configuration.
 public struct PlayerConfiguration {
+    /// A Boolean value that indicates whether the player allows switching to external playback mode.
+    public let allowsExternalPlayback: Bool
+
+    /// Create a player configuration.
+    /// - Parameter allowsExternalPlayback: Allows switching to external playback mode.
+    public init(allowsExternalPlayback: Bool = true) {
+        self.allowsExternalPlayback = allowsExternalPlayback
+    }
 }

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -14,16 +14,16 @@ final class PlayerConfigurationTests: XCTestCase {
         let configuration = PlayerConfiguration()
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beTrue())
-        expect(player.configuration.usesExternalPlaybackWhileExternalScreenIsActive).to(beFalse())
+        expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
     }
 
     func testPlayerConfigurationInit() {
         let configuration = PlayerConfiguration(
             allowsExternalPlayback: false,
-            usesExternalPlaybackWhileExternalScreenIsActive: true
+            usesExternalPlaybackWhileMirroring: true
         )
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
-        expect(player.configuration.usesExternalPlaybackWhileExternalScreenIsActive).to(beTrue())
+        expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
     }
 }

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -14,11 +14,16 @@ final class PlayerConfigurationTests: XCTestCase {
         let configuration = PlayerConfiguration()
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beTrue())
+        expect(player.configuration.usesExternalPlaybackWhileExternalScreenIsActive).to(beFalse())
     }
 
     func testPlayerConfigurationInit() {
-        let configuration = PlayerConfiguration(allowsExternalPlayback: false)
+        let configuration = PlayerConfiguration(
+            allowsExternalPlayback: false,
+            usesExternalPlaybackWhileExternalScreenIsActive: true
+        )
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
+        expect(player.configuration.usesExternalPlaybackWhileExternalScreenIsActive).to(beTrue())
     }
 }

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Nimble
+import XCTest
+
+final class PlayerConfigurationTests: XCTestCase {
+    func testPlayerConfigurationDefaultValues() {
+        let configuration = PlayerConfiguration()
+        let player = Player(configuration: configuration)
+        expect(player.configuration.allowsExternalPlayback).to(beTrue())
+    }
+
+    func testPlayerConfigurationInit() {
+        let configuration = PlayerConfiguration(allowsExternalPlayback: false)
+        let player = Player(configuration: configuration)
+        expect(player.configuration.allowsExternalPlayback).to(beFalse())
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

This PR provides a way to enable/disable the external playback. 
The PR also avoid to switch to the external playback mode when the screen mirroring and the presentation mode are enable.

## Changes made

- Add a configuration flag to enable or disable the external playback mode.
- Add a configuration flag to enable or disable the external playback mode during a screen mirroring.

## Checklist

- [X] Your branch has been rebased onto the `main` branch.
- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
~The playground has been updated (if relevant).~
