### PR TITLE
Add AirPlay player state Boolean

### DIFF
--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -16,7 +16,18 @@ private struct ContentView: View {
     var body: some View {
         ZStack {
             Group {
-                VideoView(player: player)
+                if player.isExternalPlaybackActive {
+                    Image(systemName: "airplayvideo")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        // https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape
+                        .contentShape(Rectangle())
+                        .foregroundColor(.white)
+                        .padding()
+                } else {
+                    VideoView(player: player)
+                }
                 Group {
                     Color(white: 0, opacity: 0.3)
                     PlaybackButton(player: player)
@@ -24,7 +35,7 @@ private struct ContentView: View {
                 .opacity(isUserInterfaceHidden ? 0 : 1)
 
                 ProgressView()
-                    .tint(Color.white)
+                    .tint(.white)
                     .opacity(player.isBuffering ? 1 : 0)
             }
             .onTapGesture {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -16,27 +16,9 @@ private struct ContentView: View {
     var body: some View {
         ZStack {
             Group {
-                if player.isExternalPlaybackActive {
-                    Image(systemName: "airplayvideo")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        // https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape
-                        .contentShape(Rectangle())
-                        .foregroundColor(.white)
-                        .padding()
-                } else {
-                    VideoView(player: player)
-                }
-                Group {
-                    Color(white: 0, opacity: 0.3)
-                    PlaybackButton(player: player)
-                }
-                .opacity(isUserInterfaceHidden ? 0 : 1)
-
-                ProgressView()
-                    .tint(.white)
-                    .opacity(player.isBuffering ? 1 : 0)
+                main()
+                controls()
+                loadingIndicator()
             }
             .onTapGesture {
                 isUserInterfaceHidden.toggle()
@@ -52,6 +34,39 @@ private struct ContentView: View {
         .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
         .animation(.easeInOut(duration: 0.2), value: isUserInterfaceHidden)
         .debugBodyCounter()
+    }
+
+    @ViewBuilder
+    private func main() -> some View {
+        if player.isExternalPlaybackActive {
+            Image(systemName: "airplayvideo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape
+                .contentShape(Rectangle())
+                .foregroundColor(.white)
+                .padding()
+        }
+        else {
+            VideoView(player: player)
+        }
+    }
+
+    @ViewBuilder
+    private func controls() -> some View {
+        Group {
+            Color(white: 0, opacity: 0.3)
+            PlaybackButton(player: player)
+        }
+        .opacity(isUserInterfaceHidden ? 0 : 1)
+    }
+
+    @ViewBuilder
+    private func loadingIndicator() -> some View {
+        ProgressView()
+            .tint(.white)
+            .opacity(player.isBuffering ? 1 : 0)
     }
 }
 

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -214,9 +214,11 @@ private struct TimeSlider: View {
                     },
                     minimumValueLabel: {
                         Text(formattedElapsedTime)
+                            .monospacedDigit()
                     },
                     maximumValueLabel: {
                         Text(formattedTotalTime)
+                            .monospacedDigit()
                     }
                 )
             case .unknown:

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -30,6 +30,9 @@ public final class Player: ObservableObject, Equatable {
     /// Duration of a chunk for the currently played item.
     @Published public private(set) var chunkDuration: CMTime = .invalid
 
+    /// Indicates whether the player is currently playing video in external playback mode.
+    @Published public private(set) var isExternalPlaybackActive = false
+
     @Published private var storedItems: Deque<PlayerItem>
     @Published private var itemDuration: CMTime = .indefinite
 
@@ -77,6 +80,8 @@ public final class Player: ObservableObject, Equatable {
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
         configureRawPlayerUpdatePublisher()
+        configureExternalPlaybackPublisher()
+
         configurePlayer()
     }
 
@@ -522,6 +527,12 @@ extension Player {
             }
             .switchToLatest()
             .eraseToAnyPublisher()
+    }
+
+    private func configureExternalPlaybackPublisher() {
+        rawPlayer.publisher(for: \.isExternalPlaybackActive)
+            .receiveOnMainThread()
+            .assign(to: &$isExternalPlaybackActive)
     }
 
     private func configurePlayer() {


### PR DESCRIPTION
# Pull request

## Description

This PR display an overlay when the player enter in AirPlay mode.

## Changes made

- A boolean has been added to know whether AirPlay is active or not.
- An overlay has been added over the player when AirPlay is active.
- The seek bar digits have now a fixed size (#169).

## Checklist

- [X] Your branch has been rebased onto the `main` branch.
- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
~New unit tests have been written (if relevant).~
- [X] The demo has been updated (if relevant).
~The playground has been updated (if relevant).~
