### PR TITLE
Mitigate playback issues when seeking near the end of a stream

### DIFF
--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     // swiftlint:disable:next discouraged_optional_collection
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         try? AVAudioSession.sharedInstance().setCategory(.playback)
+        UserDefaults.standard.registerDefaults()
         configureShowTime()
         return true
     }

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -17,16 +17,16 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.seekBehaviorSettingKey)
     private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
 
-    @AppStorage(UserDefaults.allowsExternalPlaybackSettingKey)
-    private var allowsExternalPlaybackSetting = true
+    @AppStorage(UserDefaults.allowsExternalPlaybackKey)
+    private var allowsExternalPlayback = true
 
-    @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicySettingKey)
-    private var audiovisualBackgroundPlaybackPolicySettingKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
+    @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicyKey)
+    private var audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
 
     var body: some View {
         List {
             Toggle("Presenter mode", isOn: $isPresentedModeEnabled)
-            Toggle("Allows external playback", isOn: $allowsExternalPlaybackSetting)
+            Toggle("Allows external playback", isOn: $allowsExternalPlayback)
             seekBehaviorPicker()
             audiovisualBackgroundPlaybackPolicyPicker()
             Toggle("Body counters", isOn: $areBodyCountersEnabled)
@@ -49,7 +49,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func audiovisualBackgroundPlaybackPolicyPicker() -> some View {
-        Picker("Audiovisual background policy", selection: $audiovisualBackgroundPlaybackPolicySettingKey) {
+        Picker("Audiovisual background policy", selection: $audiovisualBackgroundPlaybackPolicyKey) {
             Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
             Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
             Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -22,8 +22,8 @@ extension UserDefaults {
     static let presenterModeEnabledKey = "presenterModeEnabled"
     static let bodyCountersEnabledKey = "bodyCountersEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
-    static let allowsExternalPlaybackSettingKey = "allowsExternalPlaybackSetting"
-    static let audiovisualBackgroundPlaybackPolicySettingKey = "audiovisualBackgroundPlaybackPolicySetting"
+    static let allowsExternalPlaybackKey = "allowsExternalPlayback"
+    static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -47,11 +47,11 @@ extension UserDefaults {
     }
 
     @objc dynamic var allowsExternalPlaybackEnabled: Bool {
-        bool(forKey: Self.allowsExternalPlaybackSettingKey)
+        bool(forKey: Self.allowsExternalPlaybackKey)
     }
 
     @objc dynamic var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {
-        .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicySettingKey)) ?? .automatic
+        .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicyKey)) ?? .automatic
     }
 
     func registerDefaults() {
@@ -59,8 +59,8 @@ extension UserDefaults {
             Self.presenterModeEnabledKey: false,
             Self.bodyCountersEnabledKey: false,
             Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
-            Self.allowsExternalPlaybackSettingKey: true,
-            Self.audiovisualBackgroundPlaybackPolicySettingKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue
+            Self.allowsExternalPlaybackKey: true,
+            Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue
         ])
     }
 }

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -53,4 +53,14 @@ extension UserDefaults {
     @objc dynamic var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {
         .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicySettingKey)) ?? .automatic
     }
+
+    func registerDefaults() {
+        register(defaults: [
+            Self.presenterModeEnabledKey: false,
+            Self.bodyCountersEnabledKey: false,
+            Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
+            Self.allowsExternalPlaybackSettingKey: true,
+            Self.audiovisualBackgroundPlaybackPolicySettingKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue
+        ])
+    }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -458,17 +458,7 @@ extension Player {
     }
 
     private func configureChunkDurationPublisher() {
-        rawPlayer.publisher(for: \.currentItem)
-            .map { item -> AnyPublisher<CMTime, Never> in
-                guard let item else { return Just(.invalid).eraseToAnyPublisher() }
-                return item.asset.propertyPublisher(.minimumTimeOffsetFromLive)
-                    .map { CMTimeMultiplyByRatio($0, multiplier: 1, divisor: 3) }       // The minimum offset represents 3 chunks
-                    .replaceError(with: .invalid)
-                    .prepend(.invalid)
-                    .eraseToAnyPublisher()
-            }
-            .switchToLatest()
-            .removeDuplicates()
+        rawPlayer.chunkDurationPublisher()
             .receiveOnMainThread()
             .lane("player_chunk_duration")
             .assign(to: &$chunkDuration)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -27,6 +27,9 @@ public final class Player: ObservableObject, Equatable {
     /// Available time range. `.invalid` when not known.
     @Published public private(set) var timeRange: CMTimeRange = .invalid
 
+    /// Duration of a chunk for the currently played item.
+    @Published public private(set) var chunkDuration: CMTime = .invalid
+
     /// Indicates whether the player is currently playing video in external playback mode.
     @Published public private(set) var isExternalPlaybackActive = false
 
@@ -71,6 +74,7 @@ public final class Player: ObservableObject, Equatable {
         configurePlaybackStatePublisher()
         configureCurrentItemTimeRangePublisher()
         configureCurrentItemDurationPublisher()
+        configureChunkDurationPublisher()
         configureSeekingPublisher()
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
@@ -160,7 +164,6 @@ public extension Player {
     /// - Returns: `true` if skipping to live conditions is possible.
     func canSkipToLive(from time: CMTime) -> Bool {
         guard streamType == .dvr, timeRange.isValid else { return false }
-        let chunkDuration = rawPlayer.chunkDuration
         return chunkDuration.isValid && time < timeRange.end - chunkDuration
     }
 
@@ -452,6 +455,13 @@ extension Player {
             .receiveOnMainThread()
             .lane("player_item_duration")
             .assign(to: &$itemDuration)
+    }
+
+    private func configureChunkDurationPublisher() {
+        rawPlayer.chunkDurationPublisher()
+            .receiveOnMainThread()
+            .lane("player_chunk_duration")
+            .assign(to: &$chunkDuration)
     }
 
     private func configureSeekingPublisher() {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -27,9 +27,6 @@ public final class Player: ObservableObject, Equatable {
     /// Available time range. `.invalid` when not known.
     @Published public private(set) var timeRange: CMTimeRange = .invalid
 
-    /// Duration of a chunk for the currently played item.
-    @Published public private(set) var chunkDuration: CMTime = .invalid
-
     /// Indicates whether the player is currently playing video in external playback mode.
     @Published public private(set) var isExternalPlaybackActive = false
 
@@ -74,7 +71,6 @@ public final class Player: ObservableObject, Equatable {
         configurePlaybackStatePublisher()
         configureCurrentItemTimeRangePublisher()
         configureCurrentItemDurationPublisher()
-        configureChunkDurationPublisher()
         configureSeekingPublisher()
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
@@ -164,6 +160,7 @@ public extension Player {
     /// - Returns: `true` if skipping to live conditions is possible.
     func canSkipToLive(from time: CMTime) -> Bool {
         guard streamType == .dvr, timeRange.isValid else { return false }
+        let chunkDuration = rawPlayer.chunkDuration
         return chunkDuration.isValid && time < timeRange.end - chunkDuration
     }
 
@@ -455,13 +452,6 @@ extension Player {
             .receiveOnMainThread()
             .lane("player_item_duration")
             .assign(to: &$itemDuration)
-    }
-
-    private func configureChunkDurationPublisher() {
-        rawPlayer.chunkDurationPublisher()
-            .receiveOnMainThread()
-            .lane("player_chunk_duration")
-            .assign(to: &$chunkDuration)
     }
 
     private func configureSeekingPublisher() {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -42,7 +42,7 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// Raw player used for playback.
-    let rawPlayer: RawPlayer
+    let rawPlayer = RawPlayer()
 
     public let configuration: PlayerConfiguration
     private var cancellables = Set<AnyCancellable>()
@@ -68,7 +68,6 @@ public final class Player: ObservableObject, Equatable {
     ///   - items: The items to be queued initially.
     ///   - configuration: The configuration to apply to the player.
     public init(items: [PlayerItem] = [], configuration: PlayerConfiguration = .init()) {
-        rawPlayer = RawPlayer()
         storedItems = Deque(items)
         self.configuration = configuration
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -69,8 +69,20 @@ extension Source {
 }
 
 extension AVPlayerItem {
+    var timeRange: CMTimeRange? {
+        Self.timeRange(loadedTimeRanges: loadedTimeRanges, seekableTimeRanges: seekableTimeRanges)
+    }
+
     static func playerItems(from items: [PlayerItem]) -> [AVPlayerItem] {
         playerItems(from: items.map(\.source))
+    }
+
+    static func timeRange(loadedTimeRanges: [NSValue], seekableTimeRanges: [NSValue]) -> CMTimeRange? {
+        guard let firstRange = seekableTimeRanges.first?.timeRangeValue, !firstRange.isIndefinite,
+              let lastRange = seekableTimeRanges.last?.timeRangeValue, !lastRange.isIndefinite else {
+            return !loadedTimeRanges.isEmpty ? .zero : nil
+        }
+        return CMTimeRangeFromTimeToTime(start: firstRange.start, end: lastRange.end)
     }
 }
 

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -26,13 +26,7 @@ extension AVPlayerItem {
             publisher(for: \.loadedTimeRanges),
             publisher(for: \.seekableTimeRanges)
         )
-        .compactMap { loadedTimeRanges, seekableTimeRanges in
-            guard let firstRange = seekableTimeRanges.first?.timeRangeValue, !firstRange.isIndefinite,
-                  let lastRange = seekableTimeRanges.last?.timeRangeValue, !lastRange.isIndefinite else {
-                return !loadedTimeRanges.isEmpty ? .zero : nil
-            }
-            return CMTimeRangeFromTimeToTime(start: firstRange.start, end: lastRange.end)
-        }
+        .compactMap { Self.timeRange(loadedTimeRanges: $0, seekableTimeRanges: $1) }
         .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -22,12 +22,11 @@ extension AVPlayerItem {
     }
 
     func timeRangePublisher() -> AnyPublisher<CMTimeRange, Never> {
-        Publishers.CombineLatest3(
+        Publishers.CombineLatest(
             publisher(for: \.loadedTimeRanges),
-            publisher(for: \.seekableTimeRanges),
-            publisher(for: \.duration)
+            publisher(for: \.seekableTimeRanges)
         )
-        .compactMap { loadedTimeRanges, seekableTimeRanges, _ in
+        .compactMap { loadedTimeRanges, seekableTimeRanges in
             guard let firstRange = seekableTimeRanges.first?.timeRangeValue, !firstRange.isIndefinite,
                   let lastRange = seekableTimeRanges.last?.timeRangeValue, !lastRange.isIndefinite else {
                 return !loadedTimeRanges.isEmpty ? .zero : nil

--- a/Sources/Player/PlayerPublishers.swift
+++ b/Sources/Player/PlayerPublishers.swift
@@ -96,4 +96,19 @@ extension AVPlayer {
             .removeDuplicates()
             .eraseToAnyPublisher()
     }
+
+    func chunkDurationPublisher() -> AnyPublisher<CMTime, Never> {
+        publisher(for: \.currentItem)
+            .map { item -> AnyPublisher<CMTime, Never> in
+                guard let item else { return Just(.invalid).eraseToAnyPublisher() }
+                return item.asset.propertyPublisher(.minimumTimeOffsetFromLive)
+                    .map { CMTimeMultiplyByRatio($0, multiplier: 1, divisor: 3) }       // The minimum offset represents 3 chunks
+                    .replaceError(with: .invalid)
+                    .prepend(.invalid)
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -7,7 +7,7 @@
 import AVFoundation
 import Combine
 
-final class RawPlayer: AVQueuePlayer {
+final class QueuePlayer: AVQueuePlayer {
     private static let offset = CMTime(value: 12, timescale: 1)
     private var seekCount = 0
 
@@ -74,6 +74,6 @@ final class RawPlayer: AVQueuePlayer {
 }
 
 extension Notification.Name {
-    static let willSeek = Notification.Name("RawPlayerWillSeekNotification")
-    static let didSeek = Notification.Name("RawPlayerDidSeekNotification")
+    static let willSeek = Notification.Name("QueuePlayerWillSeekNotification")
+    static let didSeek = Notification.Name("QueuePlayerDidSeekNotification")
 }

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -12,7 +12,7 @@ final class RawPlayer: AVQueuePlayer {
     private var seekCount = 0
 
     private static func safeSeekTime(_ time: CMTime, for item: AVPlayerItem?) -> CMTime {
-        guard let item, let timeRange = item.timeRange, !item.duration.isIndefinite else {
+        guard let item, let timeRange = item.timeRange, !item.duration.isIndefinite /* DVR stream */ else {
             return time
         }
         return CMTimeMinimum(time, CMTimeMaximum(timeRange.end - offset, .zero))

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import Combine
 
 final class RawPlayer: AVQueuePlayer {
-    @Published private var chunkDuration: CMTime = .invalid
+    @Published private(set) var chunkDuration: CMTime = .invalid
 
     private var seekCount = 0
 

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -28,10 +28,11 @@ final class RawPlayer: AVQueuePlayer {
     }
 
     private static func safeSeekTime(_ time: CMTime, for item: AVPlayerItem?, chunkDuration: CMTime) -> CMTime {
-        guard chunkDuration.isValid, let item, let timeRange = item.timeRange, !item.duration.isIndefinite else {
+        guard let item, let timeRange = item.timeRange, !item.duration.isIndefinite else {
             return time
         }
-        return CMTimeMinimum(time, CMTimeMaximum(timeRange.end - chunkDuration, .zero))
+        let offset = chunkDuration.isValid ? chunkDuration : CMTime(value: 8, timescale: 1)
+        return CMTimeMinimum(time, CMTimeMaximum(timeRange.end - offset, .zero))
     }
 
     override func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import Combine
 
 final class RawPlayer: AVQueuePlayer {
-    private static let offset = CMTime(value: 10, timescale: 1)
+    private static let offset = CMTime(value: 12, timescale: 1)
     private var seekCount = 0
 
     private static func safeSeekTime(_ time: CMTime, for item: AVPlayerItem?) -> CMTime {

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -39,7 +39,11 @@ final class RawPlayer: AVQueuePlayer {
             NotificationCenter.default.post(name: .willSeek, object: self)
         }
         seekCount += 1
-        super.seek(to: Self.safeSeekTime(time, for: currentItem, chunkDuration: chunkDuration), toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
+        super.seek(
+            to: Self.safeSeekTime(time, for: currentItem, chunkDuration: chunkDuration),
+            toleranceBefore: toleranceBefore,
+            toleranceAfter: toleranceAfter
+        ) { [weak self] finished in
             guard let self else { return }
             self.seekCount -= 1
             if self.seekCount == 0 {

--- a/Sources/Player/RawPlayer.swift
+++ b/Sources/Player/RawPlayer.swift
@@ -14,7 +14,8 @@ final class RawPlayer: AVQueuePlayer {
             NotificationCenter.default.post(name: .willSeek, object: self)
         }
         seekCount += 1
-        super.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { finished in
+        super.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
+            guard let self else { return }
             self.seekCount -= 1
             if self.seekCount == 0 {
                 NotificationCenter.default.post(name: .didSeek, object: self)

--- a/Sources/Player/SystemVideoView.swift
+++ b/Sources/Player/SystemVideoView.swift
@@ -15,7 +15,7 @@ public struct SystemVideoView: View {
     @ObservedObject private var player: Player
 
     public var body: some View {
-        VideoPlayer(player: player.rawPlayer)
+        VideoPlayer(player: player.queuePlayer)
     }
 
     public init(player: Player) {

--- a/Sources/Player/VideoView.swift
+++ b/Sources/Player/VideoView.swift
@@ -37,12 +37,12 @@ public struct VideoView: UIViewRepresentable {
     public func makeUIView(context: Context) -> VideoLayerView {
         let view = VideoLayerView()
         view.backgroundColor = .clear
-        view.player = player.rawPlayer
+        view.player = player.queuePlayer
         view.playerLayer.videoGravity = gravity
         return view
     }
 
     public func updateUIView(_ uiView: VideoLayerView, context: Context) {
-        uiView.player = player.rawPlayer
+        uiView.player = player.queuePlayer
     }
 }

--- a/Tests/PlayerTests/ChunkDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ChunkDurationPublisherTests.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import AVFoundation
+import Circumspect
+import XCTest
+
+final class ChunkDurationPublisherTests: XCTestCase {
+    func testChunkDuration() {
+        let item = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let player = AVPlayer(playerItem: item)
+        expectEqualPublished(
+            values: [.invalid, CMTime(value: 1, timescale: 1)],
+            from: player.chunkDurationPublisher(),
+            during: 3
+        )
+    }
+
+    func testChunkDurationDuringEntirePlayback() {
+        let item = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let player = AVPlayer(playerItem: item)
+        expectAtLeastEqualPublished(
+            values: [.invalid, CMTime(value: 1, timescale: 1)],
+            from: player.chunkDurationPublisher()
+        ) {
+            player.play()
+        }
+    }
+
+    func testCheckDurationsDuringItemChange() {
+        let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let item2 = AVPlayerItem(url: Stream.onDemand.url)
+        let player = AVQueuePlayer(items: [item1, item2])
+        expectEqualPublished(
+            values: [
+                .invalid,
+                CMTime(value: 1, timescale: 1),
+                .invalid,
+                CMTime(value: 4, timescale: 1)
+            ],
+            from: player.chunkDurationPublisher(),
+            during: 3
+        ) {
+            player.play()
+        }
+    }
+}

--- a/Tests/PlayerTests/ChunkDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ChunkDurationPublisherTests.swift
@@ -32,6 +32,30 @@ final class ChunkDurationPublisherTests: XCTestCase {
         }
     }
 
+    func testChunkDurationDuringEntirePlaybackInQueuePlayerAdvancingAtItemEnd() {
+        let item = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let player = AVQueuePlayer(playerItem: item)
+        player.actionAtItemEnd = .advance
+        expectAtLeastEqualPublished(
+            values: [.invalid, CMTime(value: 1, timescale: 1), .invalid],
+            from: player.chunkDurationPublisher()
+        ) {
+            player.play()
+        }
+    }
+
+    func testChunkDurationDuringEntirePlaybackInQueuePlayerPausingAtItemEnd() {
+        let item = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let player = AVQueuePlayer(playerItem: item)
+        player.actionAtItemEnd = .pause
+        expectAtLeastEqualPublished(
+            values: [.invalid, CMTime(value: 1, timescale: 1)],
+            from: player.chunkDurationPublisher()
+        ) {
+            player.play()
+        }
+    }
+
     func testCheckDurationsDuringItemChange() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/ItemUpdateTests.swift
+++ b/Tests/PlayerTests/ItemUpdateTests.swift
@@ -28,7 +28,7 @@ final class ItemUpdateTests: XCTestCase {
         let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
         let item4 = PlayerItem(url: Stream.item(numbered: 4).url)
         let player = Player(items: [item1, item2, item3])
-        expectNothingPublishedNext(from: player.rawPlayer.publisher(for: \.currentItem), during: 2) {
+        expectNothingPublishedNext(from: player.queuePlayer.publisher(for: \.currentItem), during: 2) {
             player.items = [item4, item3, item1]
         }
     }

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -61,7 +61,7 @@ final class PlayerCurrentIndexTests: XCTestCase {
         let item1 = PlayerItem(url: Stream.onDemand.url)
         let item2 = PlayerItem(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
-        let publisher = player.rawPlayer.publisher(for: \.currentItem).compactMap { item -> URL? in
+        let publisher = player.queuePlayer.publisher(for: \.currentItem).compactMap { item -> URL? in
             guard let asset = item?.asset as? AVURLAsset else { return nil }
             return asset.url
         }
@@ -79,7 +79,7 @@ final class PlayerCurrentIndexTests: XCTestCase {
     func testSetCurrentIndexToSameValue() {
         let item = PlayerItem(url: Stream.onDemand.url)
         let player = Player(item: item)
-        let publisher = player.rawPlayer.publisher(for: \.currentItem)
+        let publisher = player.queuePlayer.publisher(for: \.currentItem)
 
         expectNothingPublishedNext(from: publisher, during: 1) {
             try! player.setCurrentIndex(0)

--- a/Tests/PlayerTests/PlayerTests.swift
+++ b/Tests/PlayerTests/PlayerTests.swift
@@ -12,45 +12,6 @@ import Nimble
 import XCTest
 
 final class PlayerTests: XCTestCase {
-    func testChunkDuration() {
-        let item = PlayerItem(url: Stream.shortOnDemand.url)
-        let player = Player(item: item)
-        expectEqualPublished(
-            values: [.invalid, CMTime(value: 1, timescale: 1)],
-            from: player.$chunkDuration,
-            during: 3
-        )
-    }
-
-    func testChunkDurationDuringEntirePlayback() {
-        let item = PlayerItem(url: Stream.shortOnDemand.url)
-        let player = Player(item: item)
-        expectAtLeastEqualPublished(
-            values: [.invalid, CMTime(value: 1, timescale: 1), .invalid],
-            from: player.$chunkDuration
-        ) {
-            player.play()
-        }
-    }
-
-    func testCheckDurationsDuringItemChange() {
-        let item1 = PlayerItem(url: Stream.shortOnDemand.url)
-        let item2 = PlayerItem(url: Stream.onDemand.url)
-        let player = Player(items: [item1, item2])
-        expectEqualPublished(
-            values: [
-                .invalid,
-                CMTime(value: 1, timescale: 1),
-                .invalid,
-                CMTime(value: 4, timescale: 1)
-            ],
-            from: player.$chunkDuration,
-            during: 3
-        ) {
-            player.play()
-        }
-    }
-
     func testDeallocation() {
         let item = PlayerItem(url: Stream.onDemand.url)
         var player: Player? = Player(item: item)

--- a/Tests/PlayerTests/QueuePlayerTests.swift
+++ b/Tests/PlayerTests/QueuePlayerTests.swift
@@ -11,18 +11,18 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class RawPlayerTests: XCTestCase {
+final class QueuePlayerTests: XCTestCase {
     func testReplaceItemsWithEmptyList() {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
-        let player = RawPlayer(items: [item1, item2, item3])
+        let player = QueuePlayer(items: [item1, item2, item3])
         player.replaceItems(with: [])
         expect(player.items()).to(beEmpty())
     }
 
     func testReplaceItemsWhenEmpty() {
-        let player = RawPlayer()
+        let player = QueuePlayer()
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
@@ -35,7 +35,7 @@ final class RawPlayerTests: XCTestCase {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
-        let player = RawPlayer(items: [item1, item2, item3])
+        let player = QueuePlayer(items: [item1, item2, item3])
         let item4 = AVPlayerItem(url: Stream.item(numbered: 4).url)
         let item5 = AVPlayerItem(url: Stream.item(numbered: 5).url)
         player.replaceItems(with: [item4, item5])
@@ -47,7 +47,7 @@ final class RawPlayerTests: XCTestCase {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
-        let player = RawPlayer(items: [item1, item2, item3])
+        let player = QueuePlayer(items: [item1, item2, item3])
         let item4 = AVPlayerItem(url: Stream.item(numbered: 4).url)
         player.replaceItems(with: [item1, item4])
         expect(player.items()).to(equalDiff([item1]))
@@ -57,7 +57,7 @@ final class RawPlayerTests: XCTestCase {
     func testReplaceItemsWithIdenticalItems() {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
-        let player = RawPlayer(items: [item1, item2])
+        let player = QueuePlayer(items: [item1, item2])
         player.replaceItems(with: [item1, item2])
         expect(player.items()).to(equalDiff([item1, item2]))
     }
@@ -66,7 +66,7 @@ final class RawPlayerTests: XCTestCase {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
-        let player = RawPlayer(items: [item1, item2, item3])
+        let player = QueuePlayer(items: [item1, item2, item3])
         player.replaceItems(with: [item2, item3])
         expect(player.items()).to(equalDiff([item2]))
         expect(player.items()).toEventually(equalDiff([item2, item3]), timeout: .seconds(2))
@@ -75,7 +75,7 @@ final class RawPlayerTests: XCTestCase {
     func testReplaceItemsWithPreviousItems() {
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         let item3 = AVPlayerItem(url: Stream.item(numbered: 3).url)
-        let player = RawPlayer(items: [item2, item3])
+        let player = QueuePlayer(items: [item2, item3])
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         player.replaceItems(with: [item1, item2, item3])
         expect(player.items()).to(equalDiff([item1]))
@@ -83,7 +83,7 @@ final class RawPlayerTests: XCTestCase {
     }
 
     func testReplaceItemsLastReplacementWins() {
-        let player = RawPlayer()
+        let player = QueuePlayer()
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)
         player.replaceItems(with: [item1, item2])

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,9 +55,6 @@ struct PlayerView: View {
 
 The system default playback user experience is provided as well. Just use `SystemVideoView` instead of `VideoView`.
 
-> **Warning**
-> A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button. This issue has been reported to Apple as FB11934227.
-
 ## Advanced view layouts
 
 Pillarbox currently does not provide any standard playback view you can use but you can build one yourself. Since `Player` is an `ObservableObject`, though, implementation of a playback view can be achieved in the same was as for any usual SwiftUI view.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,30 @@
+# Known issues
+
+The following document lists known Pillarbox issues. Entries with a feedback number (FBxxxxxxxx) have been reported to Apple and will hopefully be fixed in upcoming iOS and tvOS releases.
+
+## Video view leak (FB11934227)
+
+A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button.
+
+### Workaround
+
+No workaround is available yet.
+
+## Stuck periodic time observers with audio playlists played over AirPlay
+
+A bug with AVKit and AirPlay prevents time observers from working properly in playlists. After transitioning to another audio item in a playlist no more periodic time observer updates will be received. Reported times remain stuck at zero, which means:
+
+- `ProgressTracker` does not report progress anymore.
+- Sliders found in user interface components are not updated anymore.
+
+### Workaround
+
+No workaround is available yet.
+
+## DRM-protected streams do not play in the simulator
+
+DRM-protected streams do not play in the simulator. This is expected behavior as the required hardware features are not available in the simulator environment.
+
+### Workaround
+
+Use a physical device.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -28,3 +28,11 @@ DRM-protected streams do not play in the simulator. This is expected behavior as
 ### Workaround
 
 Use a physical device.
+
+## Seeking to the end of an on-demand stream is limited
+
+Seeks are currently prevented in the last 12 seconds of an on-demand stream to mitigate known player instabilities. If seeking is made within this window playback will resume at the nearest safely reachable location.
+
+### Workaround
+
+No workaround is available yet.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -36,3 +36,29 @@ Seeks are currently prevented in the last 12 seconds of an on-demand stream to m
 ### Workaround
 
 No workaround is available yet.
+
+## Very fast playlist navigation during AirPlay playback might confuse the player
+
+When seeking between items very fast the receiver might get confused, not being able to cope with the number of demands and the associated network activity. As a result the receiver might get stuck.
+
+### Workaround
+
+We have mitigated AirPlay instabilities as much as possible so that fast navigation is possible in almost all practical cases. If an issue is encountered, though, closing and reopening the player should make playback possible again.
+
+In some extreme cases it might happen that the AirPlay receiver is unable to recover from heavy usage. If this happens restarting the receiver will make it usable again.
+
+## DRM playback is sometimes not possible anymore
+
+It might happen that attempting to play DRM streams always ends with an error. The reason is likely an issue with key session management.
+
+### Workaround
+
+Kill and restart the application.
+
+## Token-protected content is not playable on Apple TV 3rd generation devices
+
+Token-protected content cannot be played on old Apple TV 3rd generation devices. An error is returned when attempting to play such content.
+
+### Workaround
+
+No workaround is available yet.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,9 @@ To learn more how integration of Pillarbox into your project please have a look 
 
 ## Documentation
 
-Follow the links below for further technical documentation:
+Follow the links below for further documentation:
 
+- [Known issues](KNOWN_ISSUES.md)
 - [Development setup](DEVELOPMENT_SETUP.md)
 - [Continuous integration](CONTINUOUS_INTEGRATION.md)
 - [Test streams](TEST_STREAMS.md)

--- a/markdown_style.rb
+++ b/markdown_style.rb
@@ -5,4 +5,5 @@ all
 exclude_rule 'MD013'
 exclude_rule 'MD041'
 
+rule 'MD024', allow_different_nesting: true
 rule 'MD029', style: :ordered


### PR DESCRIPTION
# Pull request

## Description

This PR is a mitigation proposal for the linked issue. No unit tests have been written since we haven't been able to write a test scenario which reproduces the issue (though the issue can be quite easily reproduced with the demo).

## Changes made

- Implemented mitigation strategy (see related issue for more details).
- Renamed `RawPlayer` as `QueuePlayer` (less abstract).
- Documented known issues, including an issue discovered with audio playlists played over AirPlay.
- Fixed incorrect initial demo configuration and renamed a few properties for consistency.
- Fixed unnecessary capture by seek closure.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
