### PR TITLE
Deliver textual asset metadata

### DIFF
--- a/Demo/Pillarbox.playground/Contents.swift
+++ b/Demo/Pillarbox.playground/Contents.swift
@@ -34,7 +34,7 @@ private struct TimeSlider: View {
 // Behavior: h-exp, v-exp
 struct PlayerView: View {
     @StateObject private var player = Player(
-        item: PlayerItem(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
+        item: PlayerItem.simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
     )
 
     private var playbackButtonImage: String? {

--- a/Demo/Sources/Media.swift
+++ b/Demo/Sources/Media.swift
@@ -35,7 +35,7 @@ struct Media: Hashable, Identifiable {
     }
 
     func playerItem() -> PlayerItem {
-        let metadata = Asset.Metadata(title: title, subtitle: description ?? "", description: "")
+        let metadata = Asset.Metadata(title: title, subtitle: description)
         switch type {
         case let .url(url):
             return .simple(url: url, metadata: metadata)

--- a/Demo/Sources/Media.swift
+++ b/Demo/Sources/Media.swift
@@ -37,9 +37,9 @@ struct Media: Hashable, Identifiable {
     func playerItem() -> PlayerItem {
         switch type {
         case let .url(url):
-            return PlayerItem(url: url)
+            return .simple(url: url, metadata: nil /* TODO */)
         case let .unbufferedUrl(url):
-            return PlayerItem(url: url) { item in
+            return .simple(url: url, metadata: nil /* TODO */) { item in
                 item.automaticallyPreservesTimeOffsetFromLive = true
                 item.preferredForwardBufferDuration = 1
             }

--- a/Demo/Sources/Media.swift
+++ b/Demo/Sources/Media.swift
@@ -35,11 +35,12 @@ struct Media: Hashable, Identifiable {
     }
 
     func playerItem() -> PlayerItem {
+        let metadata = Asset.Metadata(title: title, subtitle: description ?? "", description: "")
         switch type {
         case let .url(url):
-            return .simple(url: url, metadata: nil /* TODO */)
+            return .simple(url: url, metadata: metadata)
         case let .unbufferedUrl(url):
-            return .simple(url: url, metadata: nil /* TODO */) { item in
+            return .simple(url: url, metadata: metadata) { item in
                 item.automaticallyPreservesTimeOffsetFromLive = true
                 item.preferredForwardBufferDuration = 1
             }

--- a/Sources/CoreBusiness/Chapter.swift
+++ b/Sources/CoreBusiness/Chapter.swift
@@ -9,6 +9,7 @@ import Foundation
 struct Chapter: Decodable {
     enum CodingKeys: String, CodingKey {
         case blockingReason = "blockReason"
+        case description
         case endDate = "validTo"
         case resources = "resourceList"
         case startDate = "validFrom"
@@ -20,6 +21,7 @@ struct Chapter: Decodable {
 
     let urn: String
     let title: String
+    let description: String?
     let resources: [Resource]
 
     let startDate: Date?

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -41,16 +41,4 @@ final class DataProvider {
             }
             .eraseToAnyPublisher()
     }
-
-    func recommendedPlayableResource(forUrn urn: String) -> AnyPublisher<Resource, Error> {
-        playableMediaComposition(forUrn: urn)
-            .map(\.mainChapter.recommendedResource)
-            .tryMap { resource in
-                guard let resource else {
-                    throw DataError.noResourceAvailable
-                }
-                return resource
-            }
-            .eraseToAnyPublisher()
-    }
 }

--- a/Sources/CoreBusiness/MediaComposition.swift
+++ b/Sources/CoreBusiness/MediaComposition.swift
@@ -10,10 +10,12 @@ struct MediaComposition: Decodable {
     enum CodingKeys: String, CodingKey {
         case chapterUrn
         case chapters = "chapterList"
+        case show
     }
 
     let chapterUrn: String
     let chapters: [Chapter]
+    let show: Show
 }
 
 extension MediaComposition {

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -24,7 +24,7 @@ public extension PlayerItem {
             throw DataError.noResourceAvailable
         }
 
-        let metadata = assetMetadata(for: mainChapter, of: mediaComposition.show)
+        let metadata = assetMetadata(for: mainChapter, show: mediaComposition.show)
         let configuration = assetConfiguration(for: resource)
 
         if let certificateUrl = resource.drms?.first(where: { $0.type == .fairPlay })?.certificateUrl {
@@ -51,12 +51,8 @@ public extension PlayerItem {
         }
     }
 
-    private static func assetMetadata(for chapter: Chapter, of show: Show?) -> Asset.Metadata {
-        .init(
-            title: chapter.title,
-            subtitle: show?.title ?? "",
-            description: chapter.description ?? ""
-        )
+    private static func assetMetadata(for chapter: Chapter, show: Show?) -> Asset.Metadata {
+        .init(title: chapter.title, subtitle: show?.title, description: chapter.description)
     }
 
     private static func assetConfiguration(for resource: Resource) -> ((AVPlayerItem) -> Void) {

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -13,38 +13,45 @@ public extension PlayerItem {
     ///   - urn: The URN to play.
     ///   - environment: The environment which the URN is played from.
     convenience init(urn: String, environment: Environment = .production) {
-        let publisher = DataProvider(environment: environment).recommendedPlayableResource(forUrn: urn)
-            .map { Self.asset(for: $0) }
+        let publisher = DataProvider(environment: environment).playableMediaComposition(forUrn: urn)
+            .tryMap { try Self.asset(for: $0) }
         self.init(publisher: publisher)
     }
 
-    private static func asset(for resource: Resource) -> Asset {
-        let configuration: (AVPlayerItem) -> Void = { item in
-            if resource.streamType == .live {
-                // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
-                // livestreams cannot be paused and resumed in the past, as requested by business people.
-                item.automaticallyPreservesTimeOffsetFromLive = true
-                item.preferredForwardBufferDuration = 1
-            }
+    private static func asset(for mediaComposition: MediaComposition) throws -> Asset {
+        let mainChapter = mediaComposition.mainChapter
+        guard let resource = mainChapter.recommendedResource else {
+            throw DataError.noResourceAvailable
         }
+        
+        return .init(type: assetType(for: resource), metadata: assetMetadata(for: mainChapter)) { item in
+            guard resource.streamType == .live else { return }
+            // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
+            // livestreams cannot be paused and resumed in the past, as requested by business people.
+            item.automaticallyPreservesTimeOffsetFromLive = true
+            item.preferredForwardBufferDuration = 1
+        }
+    }
+
+    private static func assetMetadata(for chapter: Chapter) -> Asset.Metadata {
+        .init(
+            title: chapter.title,
+            subtitle: "",
+            description: ""
+        )
+    }
+
+    private static func assetType(for resource: Resource) -> Asset.`Type` {
         if let certificateUrl = resource.drms?.first(where: { $0.type == .fairPlay })?.certificateUrl {
-            return .init(
-                type: .encrypted(url: resource.url, delegate: ContentKeySessionDelegate(certificateUrl: certificateUrl)),
-                metadata: nil /* TODO */,
-                configuration: configuration
-            )
+            return .encrypted(url: resource.url, delegate: ContentKeySessionDelegate(certificateUrl: certificateUrl))
         }
         else {
             switch resource.tokenType {
             case .akamai:
                 let id = UUID()
-                return .init(
-                    type: .custom(url: AkamaiURLCoding.encodeUrl(resource.url, id: id), delegate: AkamaiResourceLoaderDelegate(id: id)),
-                    metadata: nil /* TODO */,
-                    configuration: configuration
-                )
+                return .custom(url: AkamaiURLCoding.encodeUrl(resource.url, id: id), delegate: AkamaiResourceLoaderDelegate(id: id))
             default:
-                return .init(type: .simple(url: resource.url), metadata: nil /* TODO */, configuration: configuration)
+                return .simple(url: resource.url)
             }
         }
     }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -26,21 +26,8 @@ public extension PlayerItem {
         
         return .init(
             type: assetType(for: resource),
-            metadata: assetMetadata(for: mainChapter, of: mediaComposition.show)
-        ) { item in
-            guard resource.streamType == .live else { return }
-            // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
-            // livestreams cannot be paused and resumed in the past, as requested by business people.
-            item.automaticallyPreservesTimeOffsetFromLive = true
-            item.preferredForwardBufferDuration = 1
-        }
-    }
-
-    private static func assetMetadata(for chapter: Chapter, of show: Show?) -> Asset.Metadata {
-        .init(
-            title: chapter.title,
-            subtitle: show?.title ?? "",
-            description: chapter.description ?? ""
+            metadata: assetMetadata(for: mainChapter, of: mediaComposition.show),
+            configuration: assetConfiguration(for: resource)
         )
     }
 
@@ -56,6 +43,24 @@ public extension PlayerItem {
             default:
                 return .simple(url: resource.url)
             }
+        }
+    }
+
+    private static func assetMetadata(for chapter: Chapter, of show: Show?) -> Asset.Metadata {
+        .init(
+            title: chapter.title,
+            subtitle: show?.title ?? "",
+            description: chapter.description ?? ""
+        )
+    }
+
+    private static func assetConfiguration(for resource: Resource) -> ((AVPlayerItem) -> Void) {
+        { item in
+            guard resource.streamType == .live else { return }
+            // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
+            // livestreams cannot be paused and resumed in the past, as requested by business people.
+            item.automaticallyPreservesTimeOffsetFromLive = true
+            item.preferredForwardBufferDuration = 1
         }
     }
 }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -28,9 +28,9 @@ public extension PlayerItem {
             }
         }
         if let certificateUrl = resource.drms?.first(where: { $0.type == .fairPlay })?.certificateUrl {
-            return .encrypted(
-                url: resource.url,
-                delegate: ContentKeySessionDelegate(certificateUrl: certificateUrl),
+            return .init(
+                type: .encrypted(url: resource.url, delegate: ContentKeySessionDelegate(certificateUrl: certificateUrl)),
+                metadata: nil /* TODO */,
                 configuration: configuration
             )
         }
@@ -38,13 +38,13 @@ public extension PlayerItem {
             switch resource.tokenType {
             case .akamai:
                 let id = UUID()
-                return .custom(
-                    url: AkamaiURLCoding.encodeUrl(resource.url, id: id),
-                    delegate: AkamaiResourceLoaderDelegate(id: id),
+                return .init(
+                    type: .custom(url: AkamaiURLCoding.encodeUrl(resource.url, id: id), delegate: AkamaiResourceLoaderDelegate(id: id)),
+                    metadata: nil /* TODO */,
                     configuration: configuration
                 )
             default:
-                return .simple(url: resource.url, configuration: configuration)
+                return .init(type: .simple(url: resource.url), metadata: nil /* TODO */, configuration: configuration)
             }
         }
     }

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -24,7 +24,10 @@ public extension PlayerItem {
             throw DataError.noResourceAvailable
         }
         
-        return .init(type: assetType(for: resource), metadata: assetMetadata(for: mainChapter)) { item in
+        return .init(
+            type: assetType(for: resource),
+            metadata: assetMetadata(for: mainChapter, of: mediaComposition.show)
+        ) { item in
             guard resource.streamType == .live else { return }
             // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
             // livestreams cannot be paused and resumed in the past, as requested by business people.
@@ -33,11 +36,11 @@ public extension PlayerItem {
         }
     }
 
-    private static func assetMetadata(for chapter: Chapter) -> Asset.Metadata {
+    private static func assetMetadata(for chapter: Chapter, of show: Show?) -> Asset.Metadata {
         .init(
             title: chapter.title,
-            subtitle: "",
-            description: ""
+            subtitle: show?.title ?? "",
+            description: chapter.description ?? ""
         )
     }
 

--- a/Sources/CoreBusiness/Show.swift
+++ b/Sources/CoreBusiness/Show.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+struct Show: Decodable {
+    let title: String
+}

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -50,6 +50,12 @@ public extension Asset {
         let title: String
         let subtitle: String
         let description: String
+
+        public init(title: String, subtitle: String, description: String) {
+            self.title = title
+            self.subtitle = subtitle
+            self.description = description
+        }
     }
 
     enum `Type` {

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -32,16 +32,12 @@ public struct Asset {
     private let metadata: Metadata?
     private let configuration: (AVPlayerItem) -> Void
 
-    func playerItem() -> AVPlayerItem {
-        let item = type.playerItem()
-        configuration(item)
-        return item
-    }
-
     /// A simple asset playable from a URL.
     /// - Parameters:
     ///   - url: The URL to be played.
+    ///   - metadata: The metadata associated with the asset.
     ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The asset.
     public static func simple(
         url: URL,
         metadata: Metadata? = nil,
@@ -59,7 +55,9 @@ public struct Asset {
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The custom resource loader to use.
+    ///   - metadata: The metadata associated with the asset.
     ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The asset.
     public static func custom(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -77,7 +75,9 @@ public struct Asset {
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The content key session delegate to use.
+    ///   - metadata: The metadata associated with the asset.
     ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The asset.
     public static func encrypted(
         url: URL,
         delegate: AVContentKeySessionDelegate,
@@ -90,22 +90,33 @@ public struct Asset {
             configuration: configuration
         )
     }
+
+    func playerItem() -> AVPlayerItem {
+        let item = type.playerItem()
+        configuration(item)
+        return item
+    }
 }
 
 public extension Asset {
+    /// Metadata associated with an asset.
     struct Metadata {
-        let title: String
-        let subtitle: String
-        let description: String
+        /// Title.
+        let title: String?
+        /// Subtitle.
+        let subtitle: String?
+        /// Description.
+        let description: String?
 
-        public init(title: String, subtitle: String, description: String) {
+        /// Create an asset metadata.
+        public init(title: String? = nil, subtitle: String? = nil, description: String? = nil) {
             self.title = title
             self.subtitle = subtitle
             self.description = description
         }
     }
 
-    enum `Type` {
+    private enum `Type` {
         case simple(url: URL)
         case custom(url: URL, delegate: AVAssetResourceLoaderDelegate)
         case encrypted(url: URL, delegate: AVContentKeySessionDelegate)

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -32,15 +32,8 @@ public final class PlayerItem: Equatable {
     /// - Parameters:
     ///   - url: The URL to play.
     ///   - configuration: A closure to configure player items created from the receiver.
-    public convenience init(
-        url: URL,
-        configuration: @escaping (AVPlayerItem) -> Void = { _ in }
-    ) {
-        self.init(
-            publisher: Just(
-                .simple(url: url, configuration: configuration)
-            )
-        )
+    public convenience init(asset: Asset) {
+        self.init(publisher: Just(asset))
     }
 
     public static func == (lhs: PlayerItem, rhs: PlayerItem) -> Bool {
@@ -49,6 +42,34 @@ public final class PlayerItem: Equatable {
 
     func matches(_ playerItem: AVPlayerItem?) -> Bool {
         playerItem?.id == id
+    }
+}
+
+public extension PlayerItem {
+    static func simple(
+        url: URL,
+        metadata: Asset.Metadata? = nil,
+        configuration: @escaping (AVPlayerItem) -> Void = { _ in }
+    ) -> Self {
+        self.init(asset: .init(type: .simple(url: url), metadata: metadata, configuration: configuration))
+    }
+
+    static func custom(
+        url: URL,
+        delegate: AVAssetResourceLoaderDelegate,
+        metadata: Asset.Metadata? = nil,
+        configuration: @escaping (AVPlayerItem) -> Void = { _ in }
+    ) -> Self {
+        self.init(asset: .init(type: .custom(url: url, delegate: delegate), metadata: metadata, configuration: configuration))
+    }
+
+    static func encrypted(
+        url: URL,
+        delegate: AVContentKeySessionDelegate,
+        metadata: Asset.Metadata? = nil,
+        configuration: @escaping (AVPlayerItem) -> Void = { _ in }
+    ) -> Self {
+        self.init(asset: .init(type: .encrypted(url: url, delegate: delegate), metadata: metadata, configuration: configuration))
     }
 }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -51,7 +51,7 @@ public extension PlayerItem {
         metadata: Asset.Metadata? = nil,
         configuration: @escaping (AVPlayerItem) -> Void = { _ in }
     ) -> Self {
-        self.init(asset: .init(type: .simple(url: url), metadata: metadata, configuration: configuration))
+        self.init(asset: .simple(url: url, metadata: metadata, configuration: configuration))
     }
 
     static func custom(
@@ -60,7 +60,7 @@ public extension PlayerItem {
         metadata: Asset.Metadata? = nil,
         configuration: @escaping (AVPlayerItem) -> Void = { _ in }
     ) -> Self {
-        self.init(asset: .init(type: .custom(url: url, delegate: delegate), metadata: metadata, configuration: configuration))
+        self.init(asset: .custom(url: url, delegate: delegate, metadata: metadata, configuration: configuration))
     }
 
     static func encrypted(
@@ -69,7 +69,7 @@ public extension PlayerItem {
         metadata: Asset.Metadata? = nil,
         configuration: @escaping (AVPlayerItem) -> Void = { _ in }
     ) -> Self {
-        self.init(asset: .init(type: .encrypted(url: url, delegate: delegate), metadata: metadata, configuration: configuration))
+        self.init(asset: .encrypted(url: url, delegate: delegate, metadata: metadata, configuration: configuration))
     }
 }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -46,6 +46,12 @@ public final class PlayerItem: Equatable {
 }
 
 public extension PlayerItem {
+    /// A simple playable item.
+    /// - Parameters:
+    ///   - url: The URL to be played.
+    ///   - metadata: The metadata associated with the item.
+    ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The item.
     static func simple(
         url: URL,
         metadata: Asset.Metadata? = nil,
@@ -54,6 +60,14 @@ public extension PlayerItem {
         self.init(asset: .simple(url: url, metadata: metadata, configuration: configuration))
     }
 
+    /// An item loaded with custom resource loading. The scheme of the URL to be played has to be recognized by
+    /// the associated resource loader delegate.
+    /// - Parameters:
+    ///   - url: The URL to be played.
+    ///   - delegate: The custom resource loader to use.
+    ///   - metadata: The metadata associated with the item.
+    ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The item.
     static func custom(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -63,6 +77,13 @@ public extension PlayerItem {
         self.init(asset: .custom(url: url, delegate: delegate, metadata: metadata, configuration: configuration))
     }
 
+    /// An encrypted item loaded with a content key session.
+    /// - Parameters:
+    ///   - url: The URL to be played.
+    ///   - delegate: The content key session delegate to use.
+    ///   - metadata: The metadata associated with the item.
+    ///   - configuration: A closure to configure player items created from the receiver.
+    /// - Returns: The item.
     static func encrypted(
         url: URL,
         delegate: AVContentKeySessionDelegate,

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -23,12 +23,6 @@ final class DataProviderTests: XCTestCase {
         )
     }
 
-    func testExistingRecommendedResource() {
-        expectSuccess(
-            from: DataProvider().recommendedPlayableResource(forUrn: "urn:rts:video:6820736")
-        )
-    }
-
     func testBlockedMediaComposition() {
         expectFailure(
             DataError.blocked(withMessage: "This content is not available anymore."),

--- a/Tests/PlayerTests/AssetTests.swift
+++ b/Tests/PlayerTests/AssetTests.swift
@@ -14,29 +14,29 @@ import XCTest
 
 final class AssetTests: XCTestCase {
     func testSimpleEquality() {
-        expect(Asset(type: .simple(url: Stream.dvr.url))).to(equal(Asset(type: .simple(url: Stream.dvr.url))))
-        expect(Asset(type: .simple(url: Stream.live.url))).notTo(equal(Asset(type: .simple(url: Stream.dvr.url))))
-        expect(Asset(type: .simple(url: Stream.live.url))).notTo(equal(Asset(type: .custom(url: Stream.live.url, delegate: LoadingResourceLoaderDelegate()))))
+        expect(Asset.simple(url: Stream.dvr.url)).to(equal(.simple(url: Stream.dvr.url)))
+        expect(Asset.simple(url: Stream.live.url)).notTo(equal(.simple(url: Stream.dvr.url)))
+        expect(Asset.simple(url: Stream.live.url)).notTo(equal(.custom(url: Stream.live.url, delegate: LoadingResourceLoaderDelegate())))
     }
 
     func testCustomEquality() {
         let delegate1 = LoadingResourceLoaderDelegate()
-        expect(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))).to(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))))
+        expect(Asset.custom(url: Stream.dvr.url, delegate: delegate1)).to(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate1)))
         let delegate2 = LoadingResourceLoaderDelegate()
-        expect(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))).notTo(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate2))))
-        expect(Asset(type: .custom(url: Stream.live.url, delegate: delegate1))).notTo(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))))
+        expect(Asset.custom(url: Stream.dvr.url, delegate: delegate1)).notTo(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate2)))
+        expect(Asset.custom(url: Stream.live.url, delegate: delegate1)).notTo(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate1)))
     }
 
     func testEncryptedEquality() {
         let delegate1 = DummyContentKeySessionDelegate()
-        expect(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))).to(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))))
+        expect(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)).to(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)))
         let delegate2 = DummyContentKeySessionDelegate()
-        expect(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))).notTo(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate2))))
-        expect(Asset(type: .encrypted(url: Stream.live.url, delegate: delegate1))).notTo(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))))
+        expect(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)).notTo(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate2)))
+        expect(Asset.encrypted(url: Stream.live.url, delegate: delegate1)).notTo(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)))
     }
 
     func testNativePlayerItem() {
-        let item = Asset(type: .simple(url: Stream.onDemand.url)).playerItem()
+        let item = Asset.simple(url: Stream.onDemand.url).playerItem()
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [false, true],

--- a/Tests/PlayerTests/AssetTests.swift
+++ b/Tests/PlayerTests/AssetTests.swift
@@ -14,29 +14,29 @@ import XCTest
 
 final class AssetTests: XCTestCase {
     func testSimpleEquality() {
-        expect(Asset.simple(url: Stream.dvr.url)).to(equal(.simple(url: Stream.dvr.url)))
-        expect(Asset.simple(url: Stream.live.url)).notTo(equal(.simple(url: Stream.dvr.url)))
-        expect(Asset.simple(url: Stream.live.url)).notTo(equal(.custom(url: Stream.live.url, delegate: LoadingResourceLoaderDelegate())))
+        expect(Asset(type: .simple(url: Stream.dvr.url))).to(equal(Asset(type: .simple(url: Stream.dvr.url))))
+        expect(Asset(type: .simple(url: Stream.live.url))).notTo(equal(Asset(type: .simple(url: Stream.dvr.url))))
+        expect(Asset(type: .simple(url: Stream.live.url))).notTo(equal(Asset(type: .custom(url: Stream.live.url, delegate: LoadingResourceLoaderDelegate()))))
     }
 
     func testCustomEquality() {
         let delegate1 = LoadingResourceLoaderDelegate()
-        expect(Asset.custom(url: Stream.dvr.url, delegate: delegate1)).to(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate1)))
+        expect(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))).to(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))))
         let delegate2 = LoadingResourceLoaderDelegate()
-        expect(Asset.custom(url: Stream.dvr.url, delegate: delegate1)).notTo(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate2)))
-        expect(Asset.custom(url: Stream.live.url, delegate: delegate1)).notTo(equal(Asset.custom(url: Stream.dvr.url, delegate: delegate1)))
+        expect(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))).notTo(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate2))))
+        expect(Asset(type: .custom(url: Stream.live.url, delegate: delegate1))).notTo(equal(Asset(type: .custom(url: Stream.dvr.url, delegate: delegate1))))
     }
 
     func testEncryptedEquality() {
         let delegate1 = DummyContentKeySessionDelegate()
-        expect(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)).to(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)))
+        expect(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))).to(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))))
         let delegate2 = DummyContentKeySessionDelegate()
-        expect(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)).notTo(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate2)))
-        expect(Asset.encrypted(url: Stream.live.url, delegate: delegate1)).notTo(equal(Asset.encrypted(url: Stream.dvr.url, delegate: delegate1)))
+        expect(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))).notTo(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate2))))
+        expect(Asset(type: .encrypted(url: Stream.live.url, delegate: delegate1))).notTo(equal(Asset(type: .encrypted(url: Stream.dvr.url, delegate: delegate1))))
     }
 
     func testNativePlayerItem() {
-        let item = Asset.simple(url: Stream.onDemand.url).playerItem()
+        let item = Asset(type: .simple(url: Stream.onDemand.url)).playerItem()
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [false, true],

--- a/Tests/PlayerTests/ItemInsertionAfterTests.swift
+++ b/Tests/PlayerTests/ItemInsertionAfterTests.swift
@@ -12,76 +12,76 @@ import XCTest
 
 final class ItemInsertionAfterTests: XCTestCase {
     func testInsertItemAfterNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, after: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item2, insertedItem, item3]))
     }
 
     func testInsertItemAfterCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, after: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item2, insertedItem, item3]))
     }
 
     func testInsertItemAfterPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, after: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item2, insertedItem, item3]))
     }
 
     func testInsertItemAfterLastItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, after: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item2, insertedItem]))
     }
 
     func testInsertItemAfterIdenticalItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.insert(item1, after: item2)).to(beFalse())
         expect(player.items).to(equalDiff([item1, item2]))
     }
 
     func testInsertItemAfterForeignItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.insert(insertedItem, after: foreignItem)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testInsertItemAfterNil() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, after: nil)).to(beTrue())
         expect(player.items).to(equalDiff([item, insertedItem]))
     }
 
     func testAppendItem() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.append(insertedItem)).to(beTrue())
         expect(player.items).to(equalDiff([item, insertedItem]))
     }

--- a/Tests/PlayerTests/ItemInsertionBeforeTests.swift
+++ b/Tests/PlayerTests/ItemInsertionBeforeTests.swift
@@ -12,76 +12,76 @@ import XCTest
 
 final class ItemInsertionBeforeTests: XCTestCase {
     func testInsertItemBeforeNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, before: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, insertedItem, item2, item3]))
     }
 
     func testInsertItemBeforeCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, before: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, insertedItem, item2, item3]))
     }
 
     func testInsertItemBeforePreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, before: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, insertedItem, item2, item3]))
     }
 
     func testInsertItemBeforeFirstItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, before: item1)).to(beTrue())
         expect(player.items).to(equalDiff([insertedItem, item1, item2]))
     }
 
     func testInsertItemBeforeIdenticalItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.insert(item1, before: item2)).to(beFalse())
         expect(player.items).to(equalDiff([item1, item2]))
     }
 
     func testInsertItemBeforeForeignItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.insert(insertedItem, before: foreignItem)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testInsertItemBeforeNil() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.insert(insertedItem, before: nil)).to(beTrue())
         expect(player.items).to(equalDiff([insertedItem, item]))
     }
 
     func testPrependItem() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
-        let insertedItem = PlayerItem(url: Stream.insertedItem.url)
+        let insertedItem = PlayerItem.simple(url: Stream.insertedItem.url)
         expect(player.prepend(insertedItem)).to(beTrue())
         expect(player.items).to(equalDiff([insertedItem, item]))
     }

--- a/Tests/PlayerTests/ItemMoveAfterTests.swift
+++ b/Tests/PlayerTests/ItemMoveAfterTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 final class ItemMoveAfterTests: XCTestCase {
     func testMovePreviousItemAfterNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item1, after: item3)).to(beTrue())
@@ -22,9 +22,9 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMovePreviousItemAfterCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -33,9 +33,9 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMovePreviousItemAfterPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -44,9 +44,9 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMoveCurrentItemAfterNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.move(item1, after: item2)).to(beTrue())
         expect(player.currentIndex).to(equal(1))
@@ -54,9 +54,9 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMoveCurrentItemAfterPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -66,9 +66,9 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMoveNextItemAfterPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item3, after: item1)).to(beTrue())
@@ -76,72 +76,72 @@ final class ItemMoveAfterTests: XCTestCase {
     }
 
     func testMoveNextItemAfterCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.move(item3, after: item1)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item3, item2]))
     }
 
     func testMoveNextItemAfterNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.move(item2, after: item3)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item3, item2]))
     }
 
     func testMoveItemAfterIdenticalItem() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
         expect(player.move(item, after: item)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveItemAfterItemAlreadyAtExpectedLocation() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item2, after: item1)).to(beFalse())
         expect(player.items).to(equalDiff([item1, item2]))
     }
 
     func testMoveForeignItemAfterItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.move(foreignItem, after: item)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveItemAfterForeignItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.move(item, after: foreignItem)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveItemAfterLastItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item1, after: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item2, item1]))
     }
 
     func testMoveItemAfterNil() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item1, after: nil)).to(beTrue())
         expect(player.items).to(equalDiff([item2, item1]))
     }
 
     func testMoveLastItemAfterNil() {
-        let item = PlayerItem(url: Stream.item(numbered: 1).url)
+        let item = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let player = Player(items: [item])
         expect(player.move(item, after: nil)).to(beFalse())
         expect(player.items).to(equalDiff([item]))

--- a/Tests/PlayerTests/ItemMoveBeforeTests.swift
+++ b/Tests/PlayerTests/ItemMoveBeforeTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 final class ItemMoveBeforeTests: XCTestCase {
     func testMovePreviousItemBeforeNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item1, before: item3)).to(beTrue())
@@ -22,9 +22,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMovePreviousItemBeforeCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -33,9 +33,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMovePreviousItemBeforePreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -44,9 +44,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMoveCurrentItemBeforeNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.move(item1, before: item3)).to(beTrue())
         expect(player.currentIndex).to(equal(1))
@@ -54,9 +54,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMoveCurrentItemBeforePreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item2, before: item1)).to(beTrue())
@@ -65,9 +65,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMoveNextItemBeforePreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item3, before: item1)).to(beTrue())
@@ -75,9 +75,9 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMoveNextItemBeforeCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.move(item3, before: item2)).to(beTrue())
@@ -85,63 +85,63 @@ final class ItemMoveBeforeTests: XCTestCase {
     }
 
     func testMoveNextItemBeforeNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.move(item3, before: item2)).to(beTrue())
         expect(player.items).to(equalDiff([item1, item3, item2]))
     }
 
     func testMoveItemBeforeIdenticalItem() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
         expect(player.move(item, before: item)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveItemBeforeItemAlreadyAtExpectedLocation() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item1, before: item2)).to(beFalse())
         expect(player.items).to(equalDiff([item1, item2]))
     }
 
     func testMoveForeignItemBeforeItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.move(foreignItem, before: item)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveBeforeForeignItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         expect(player.move(item, before: foreignItem)).to(beFalse())
         expect(player.items).to(equalDiff([item]))
     }
 
     func testMoveItemBeforeFirstItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item2, before: item1)).to(beTrue())
         expect(player.items).to(equalDiff([item2, item1]))
     }
 
     func testMoveBeforeNil() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.move(item2, before: nil)).to(beTrue())
         expect(player.items).to(equalDiff([item2, item1]))
     }
 
     func testMoveFirstItemBeforeNil() {
-        let item = PlayerItem(url: Stream.item.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
         let player = Player(items: [item])
         expect(player.move(item, before: nil)).to(beFalse())
         expect(player.items).to(equalDiff([item]))

--- a/Tests/PlayerTests/ItemNavigationTests.swift
+++ b/Tests/PlayerTests/ItemNavigationTests.swift
@@ -11,16 +11,16 @@ import XCTest
 
 final class ItemNavigationTests: XCTestCase {
     func testCanReturnToPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.advanceToNextItem()
         expect(player.canReturnToPreviousItem()).to(beTrue())
     }
 
     func testCannotReturnToPreviousItemAtFront() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.canReturnToPreviousItem()).to(beFalse())
     }
@@ -31,15 +31,15 @@ final class ItemNavigationTests: XCTestCase {
     }
 
     func testCanAdvanceToNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         expect(player.canAdvanceToNextItem()).to(beTrue())
     }
 
     func testCannotAdvanceToNextItemAtBack() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.advanceToNextItem()
         expect(player.canAdvanceToNextItem()).to(beFalse())
@@ -51,34 +51,34 @@ final class ItemNavigationTests: XCTestCase {
     }
 
     func testCanAdvanceToNextItemOnFailedItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.unavailable.url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.unavailable.url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.canReturnToPreviousItem()).toAlways(beTrue(), until: .milliseconds(500))
     }
 
     func testCanReturnToPreviousItemOnFailedItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.unavailable.url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.unavailable.url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.canAdvanceToNextItem()).toAlways(beTrue(), until: .milliseconds(500))
     }
 
     func testAdvanceToNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.advanceToNextItem()
         expect(player.currentIndex).to(equal(1))
     }
 
     func testAdvanceToNextItemAtBack() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.advanceToNextItem()
         player.advanceToNextItem()
@@ -86,8 +86,8 @@ final class ItemNavigationTests: XCTestCase {
     }
 
     func testReturnToPreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.advanceToNextItem()
         player.returnToPreviousItem()
@@ -95,17 +95,17 @@ final class ItemNavigationTests: XCTestCase {
     }
 
     func testReturnToPreviousItemAtFront() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
         let player = Player(items: [item1, item2])
         player.returnToPreviousItem()
         expect(player.currentIndex).to(equal(0))
     }
 
     func testReturnToPreviousItemOnFailedItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.unavailable.url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.unavailable.url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.returnToPreviousItem()
@@ -113,9 +113,9 @@ final class ItemNavigationTests: XCTestCase {
     }
 
     func testAdvanceToNextItemOnFailedItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.unavailable.url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.unavailable.url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()

--- a/Tests/PlayerTests/ItemRemovalTests.swift
+++ b/Tests/PlayerTests/ItemRemovalTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 final class ItemRemovalTests: XCTestCase {
     func testRemovePreviousItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.remove(item1)
@@ -22,9 +22,9 @@ final class ItemRemovalTests: XCTestCase {
     }
 
     func testRemoveCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.remove(item2)
@@ -33,9 +33,9 @@ final class ItemRemovalTests: XCTestCase {
     }
 
     func testRemoveNextItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.remove(item3)
@@ -43,17 +43,17 @@ final class ItemRemovalTests: XCTestCase {
     }
 
     func testRemoveForeignItem() {
-        let item = PlayerItem(url: Stream.item.url)
-        let foreignItem = PlayerItem(url: Stream.foreignItem.url)
+        let item = PlayerItem.simple(url: Stream.item.url)
+        let foreignItem = PlayerItem.simple(url: Stream.foreignItem.url)
         let player = Player(items: [item])
         player.remove(foreignItem)
         expect(player.items).to(equalDiff([item]))
     }
 
     func testRemoveAllItems() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.removeAllItems()
         expect(player.items).to(beEmpty())

--- a/Tests/PlayerTests/ItemTests.swift
+++ b/Tests/PlayerTests/ItemTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 final class ItemTests: XCTestCase {
     func testItemsOnFirstItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         expect(player.items).to(equalDiff([item1, item2, item3]))
         expect(player.previousItems).to(beEmpty())
@@ -22,9 +22,9 @@ final class ItemTests: XCTestCase {
     }
 
     func testItemsOnMiddleItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         expect(player.items).to(equalDiff([item1, item2, item3]))
@@ -33,9 +33,9 @@ final class ItemTests: XCTestCase {
     }
 
     func testItemsOnLastItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
         player.advanceToNextItem()

--- a/Tests/PlayerTests/ItemUpdateTests.swift
+++ b/Tests/PlayerTests/ItemUpdateTests.swift
@@ -12,10 +12,10 @@ import XCTest
 
 final class ItemUpdateTests: XCTestCase {
     func testUpdateWithCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
-        let item4 = PlayerItem(url: Stream.item(numbered: 4).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
+        let item4 = PlayerItem.simple(url: Stream.item(numbered: 4).url)
         let player = Player(items: [item1, item2, item3])
         player.items = [item4, item3, item1]
         expect(player.items).to(equalDiff([item4, item3, item1]))
@@ -23,10 +23,10 @@ final class ItemUpdateTests: XCTestCase {
     }
 
     func testUpdateWithCurrentItemMustNotInterruptPlayback() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
-        let item4 = PlayerItem(url: Stream.item(numbered: 4).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
+        let item4 = PlayerItem.simple(url: Stream.item(numbered: 4).url)
         let player = Player(items: [item1, item2, item3])
         expectNothingPublishedNext(from: player.queuePlayer.publisher(for: \.currentItem), during: 2) {
             player.items = [item4, item3, item1]
@@ -34,12 +34,12 @@ final class ItemUpdateTests: XCTestCase {
     }
 
     func testUpdateWithoutCurrentItem() {
-        let item1 = PlayerItem(url: Stream.item(numbered: 1).url)
-        let item2 = PlayerItem(url: Stream.item(numbered: 2).url)
-        let item3 = PlayerItem(url: Stream.item(numbered: 3).url)
-        let item4 = PlayerItem(url: Stream.item(numbered: 4).url)
-        let item5 = PlayerItem(url: Stream.item(numbered: 5).url)
-        let item6 = PlayerItem(url: Stream.item(numbered: 6).url)
+        let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
+        let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)
+        let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
+        let item4 = PlayerItem.simple(url: Stream.item(numbered: 4).url)
+        let item5 = PlayerItem.simple(url: Stream.item(numbered: 5).url)
+        let item6 = PlayerItem.simple(url: Stream.item(numbered: 6).url)
         let player = Player(items: [item1, item2, item3])
         player.items = [item4, item5, item6]
         expect(player.items).to(equalDiff([item4, item5, item6]))

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -14,8 +14,8 @@ import XCTest
 
 final class PlayerCurrentIndexTests: XCTestCase {
     func testCurrentIndex() {
-        let item1 = PlayerItem(url: Stream.shortOnDemand.url)
-        let item2 = PlayerItem(url: Stream.onDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(items: [item1, item2])
         expectAtLeastEqualPublished(values: [0, 1], from: player.$currentIndex) {
             player.play()
@@ -28,8 +28,8 @@ final class PlayerCurrentIndexTests: XCTestCase {
     }
 
     func testSlowFirstCurrentIndex() {
-        let item1 = PlayerItem(url: Stream.shortOnDemand.url, delay: 2)
-        let item2 = PlayerItem(url: Stream.onDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url, delay: 2)
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(items: [item1, item2])
         expectAtLeastEqualPublished(
             values: [0, 1],
@@ -40,7 +40,7 @@ final class PlayerCurrentIndexTests: XCTestCase {
     }
 
     func testCurrentIndexAfterPlayerEnded() {
-        let item = PlayerItem(url: Stream.shortOnDemand.url)
+        let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item])
         expectAtLeastEqualPublished(values: [0], from: player.$currentIndex) {
             player.play()
@@ -48,8 +48,8 @@ final class PlayerCurrentIndexTests: XCTestCase {
     }
 
     func testSetCurrentIndex() {
-        let item1 = PlayerItem(url: Stream.onDemand.url)
-        let item2 = PlayerItem(url: Stream.shortOnDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.onDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
 
         expectAtLeastEqualPublished(values: [0, 1], from: player.$currentIndex) {
@@ -58,8 +58,8 @@ final class PlayerCurrentIndexTests: XCTestCase {
     }
 
     func testSetCurrentIndexUpdatePlayerCurrentItem() {
-        let item1 = PlayerItem(url: Stream.onDemand.url)
-        let item2 = PlayerItem(url: Stream.shortOnDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.onDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
         let publisher = player.queuePlayer.publisher(for: \.currentItem).compactMap { item -> URL? in
             guard let asset = item?.asset as? AVURLAsset else { return nil }
@@ -77,7 +77,7 @@ final class PlayerCurrentIndexTests: XCTestCase {
     }
 
     func testSetCurrentIndexToSameValue() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         let publisher = player.queuePlayer.publisher(for: \.currentItem)
 

--- a/Tests/PlayerTests/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItemTests.swift
@@ -14,34 +14,34 @@ import XCTest
 
 final class PlayerItemsTests: XCTestCase {
     func testGenericItem() {
-        let publisher = Just(Asset.simple(url: Stream.onDemand.url))
+        let asset = Asset(type: .simple(url: Stream.onDemand.url))
+        let publisher = Just(asset)
         let item = PlayerItem(publisher: publisher)
-        expectAtLeastSimilarPublished(
-            values: [
-                .simple(url: Stream.onDemand.url)
-            ],
+        expectAtLeastEqualPublished(
+            values: [asset],
             from: item.$source.map(\.asset)
         )
     }
 
     func testUrlItem() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         expectAtLeastSimilarPublished(
             values: [
-                .simple(url: Stream.onDemand.url)
+                Asset(type: .simple(url: Stream.onDemand.url))
             ],
             from: item.$source.map(\.asset)
         )
     }
 
     func testCustomItemSuccessAsync() {
-        let publisher = Just(Asset.simple(url: Stream.onDemand.url))
+        let asset = Asset(type: .simple(url: Stream.onDemand.url))
+        let publisher = Just(asset)
             .delay(for: 0.5, scheduler: DispatchQueue.main)
         let item = PlayerItem(publisher: publisher)
         expectAtLeastSimilarPublished(
             values: [
                 .loading,
-                .simple(url: Stream.onDemand.url)
+                asset
             ],
             from: item.$source.map(\.asset)
         )

--- a/Tests/PlayerTests/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItemTests.swift
@@ -14,11 +14,12 @@ import XCTest
 
 final class PlayerItemsTests: XCTestCase {
     func testGenericItem() {
-        let asset = Asset(type: .simple(url: Stream.onDemand.url))
-        let publisher = Just(asset)
+        let publisher = Just(Asset.simple(url: Stream.onDemand.url))
         let item = PlayerItem(publisher: publisher)
-        expectAtLeastEqualPublished(
-            values: [asset],
+        expectAtLeastSimilarPublished(
+            values: [
+                .simple(url: Stream.onDemand.url)
+            ],
             from: item.$source.map(\.asset)
         )
     }
@@ -27,21 +28,20 @@ final class PlayerItemsTests: XCTestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         expectAtLeastSimilarPublished(
             values: [
-                Asset(type: .simple(url: Stream.onDemand.url))
+                .simple(url: Stream.onDemand.url)
             ],
             from: item.$source.map(\.asset)
         )
     }
 
     func testCustomItemSuccessAsync() {
-        let asset = Asset(type: .simple(url: Stream.onDemand.url))
-        let publisher = Just(asset)
+        let publisher = Just(Asset.simple(url: Stream.onDemand.url))
             .delay(for: 0.5, scheduler: DispatchQueue.main)
         let item = PlayerItem(publisher: publisher)
         expectAtLeastSimilarPublished(
             values: [
                 .loading,
-                asset
+                .simple(url: Stream.onDemand.url)
             ],
             from: item.$source.map(\.asset)
         )

--- a/Tests/PlayerTests/PlayerSkipToLiveTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToLiveTests.swift
@@ -18,26 +18,26 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testCannotSkipToLiveForOnDemand() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expect(player.canSkipToLive()).toAlways(beFalse())
     }
 
     func testCannotSkipToLiveForLive() {
-        let item = PlayerItem(url: Stream.live.url)
+        let item = PlayerItem.simple(url: Stream.live.url)
         let player = Player(item: item)
         expect(player.canSkipToLive()).toAlways(beFalse())
     }
 
     func testCannotSkipToLiveForDvrInLiveConditions() {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         expect(player.time).toEventuallyNot(equal(.zero))
         expect(player.canSkipToLive()).toAlways(beFalse())
     }
 
     func testCanSkipToLiveForDvrInPastConditions() {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.dvr))
 
@@ -52,7 +52,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testCanSkipToLiveForDvrInPastConditionsAsync() async {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         await expect(player.streamType).toEventually(equal(.dvr))
         let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
@@ -68,7 +68,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testSkipToLiveForOnDemand() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         player.skipToLive { _ in
             fail("Must not be called")
@@ -76,7 +76,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testSkipToLiveForLive() {
-        let item = PlayerItem(url: Stream.live.url)
+        let item = PlayerItem.simple(url: Stream.live.url)
         let player = Player(item: item)
         player.skipToLive { _ in
             fail("Must not be called")
@@ -84,7 +84,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testSkipToLiveForDvrInLiveConditions() {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         expect(player.time).toEventuallyNot(equal(.zero))
         player.skipToLive { _ in
@@ -93,7 +93,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testSkipToLiveForDvrInPastConditions() {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.dvr))
 
@@ -116,7 +116,7 @@ final class PlayerSkipToLiveTests: XCTestCase {
     }
 
     func testSkipToLiveForDvrInPastConditionsAsync() async {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         await expect(player.streamType).toEventually(equal(.dvr))
         let seeked = await player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)

--- a/Tests/PlayerTests/PlayerStreamTypeTests.swift
+++ b/Tests/PlayerTests/PlayerStreamTypeTests.swift
@@ -16,25 +16,25 @@ final class PlayerStreamTypeTests: XCTestCase {
     }
 
     func testOnDemand() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.onDemand))
     }
 
     func testLive() {
-        let item = PlayerItem(url: Stream.live.url)
+        let item = PlayerItem.simple(url: Stream.live.url)
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.live))
     }
 
     func testDVR() {
-        let item = PlayerItem(url: Stream.dvr.url)
+        let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
         expect(player.streamType).toEventually(equal(.dvr))
     }
 
     func testStabilityAtStart() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expect(player.streamType).toNever(equal(.dvr), pollInterval: .microseconds(1))
     }

--- a/Tests/PlayerTests/PlayerTests.swift
+++ b/Tests/PlayerTests/PlayerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 final class PlayerTests: XCTestCase {
     func testDeallocation() {
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         var player: Player? = Player(item: item)
 
         weak var weakPlayer = player

--- a/Tests/PlayerTests/ProgressTrackerTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTests.swift
@@ -59,7 +59,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testProgressForTrackerBoundToPausedPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expectEqualPublished(
             values: [0],
@@ -73,7 +73,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testRangeForTrackerBoundToPausedPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expectEqualPublished(
             values: [0...0, 0...1],
@@ -87,7 +87,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testProgressForTrackerDuringEntirePlayback() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.shortOnDemand.url)
+        let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(item: item)
         expectPublished(
             values: [0, 0.25, 0.5, 0.75, 1, 0],
@@ -103,7 +103,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testRangeForTrackerDuringEntirePlayback() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.shortOnDemand.url)
+        let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(item: item)
         expectEqualPublished(
             values: [0...0, 0...1, 0...0],
@@ -121,7 +121,7 @@ final class ProgressTrackerTests: XCTestCase {
             interval: CMTime(value: 1, timescale: 4),
             seekBehavior: .immediate
         )
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         expect(progressTracker.range).toEventually(equal(0...1), timeout: .seconds(2))
@@ -142,7 +142,7 @@ final class ProgressTrackerTests: XCTestCase {
             interval: CMTime(value: 1, timescale: 4),
             seekBehavior: .deferred
         )
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         expect(progressTracker.range).toEventually(equal(0...1), timeout: .seconds(2))
@@ -168,7 +168,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testProgressForTrackerRebinding() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
@@ -187,7 +187,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testRangeForTrackerRebinding() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
@@ -205,7 +205,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testProgressForTrackerUnbinding() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
@@ -224,7 +224,7 @@ final class ProgressTrackerTests: XCTestCase {
 
     func testRangeForTrackerUnbinding() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        let item = PlayerItem(url: Stream.onDemand.url)
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
         player.play()

--- a/Tests/PlayerTests/SlowPlayerItem.swift
+++ b/Tests/PlayerTests/SlowPlayerItem.swift
@@ -11,9 +11,9 @@ import Combine
 import Foundation
 
 extension PlayerItem {
-    convenience init(url: URL, delay: TimeInterval) {
-        let publisher = Just(Asset.simple(url: url))
+    static func simple(url: URL, delay: TimeInterval) -> Self {
+        let publisher = Just(Asset(type: .simple(url: url)))
             .delay(for: .seconds(delay), scheduler: DispatchQueue.main)
-        self.init(publisher: publisher)
+        return .init(publisher: publisher)
     }
 }

--- a/Tests/PlayerTests/SlowPlayerItem.swift
+++ b/Tests/PlayerTests/SlowPlayerItem.swift
@@ -12,7 +12,7 @@ import Foundation
 
 extension PlayerItem {
     static func simple(url: URL, delay: TimeInterval) -> Self {
-        let publisher = Just(Asset(type: .simple(url: url)))
+        let publisher = Just(Asset.simple(url: url))
             .delay(for: .seconds(delay), scheduler: DispatchQueue.main)
         return .init(publisher: publisher)
     }

--- a/Tests/PlayerTests/SourceTests.swift
+++ b/Tests/PlayerTests/SourceTests.swift
@@ -13,12 +13,9 @@ import XCTest
 
 final class SourceTests: XCTestCase {
     func testSourceEquality() {
-        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url))))
-            .to(equal(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url)))))
-        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.live.url))))
-            .notTo(equal(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url)))))
-        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url))))
-            .notTo(equal(Source(id: UUID("2"), asset: .init(type: .simple(url: Stream.dvr.url)))))
+        expect(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))).to(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))
+        expect(Source(id: UUID("1"), asset: .simple(url: Stream.live.url))).notTo(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))
+        expect(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))).notTo(equal(Source(id: UUID("2"), asset: .simple(url: Stream.dvr.url))))
     }
 
     func testPlayerItemsWithoutCurrentItem() {
@@ -140,7 +137,7 @@ final class SourceTests: XCTestCase {
     }
 
     func testPlayerItemsWithUpdatedCurrentItem() {
-        let currentItemSource = Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.item.url)))
+        let currentItemSource = Source(id: UUID("1"), asset: .simple(url: Stream.item.url))
         let previousSources = [
             Source(id: UUID("1"), asset: .loading),
             Source(id: UUID("2"), asset: .loading),

--- a/Tests/PlayerTests/SourceTests.swift
+++ b/Tests/PlayerTests/SourceTests.swift
@@ -13,9 +13,12 @@ import XCTest
 
 final class SourceTests: XCTestCase {
     func testSourceEquality() {
-        expect(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))).to(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))
-        expect(Source(id: UUID("1"), asset: .simple(url: Stream.live.url))).notTo(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))
-        expect(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))).notTo(equal(Source(id: UUID("2"), asset: .simple(url: Stream.dvr.url))))
+        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url))))
+            .to(equal(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url)))))
+        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.live.url))))
+            .notTo(equal(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url)))))
+        expect(Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.dvr.url))))
+            .notTo(equal(Source(id: UUID("2"), asset: .init(type: .simple(url: Stream.dvr.url)))))
     }
 
     func testPlayerItemsWithoutCurrentItem() {
@@ -137,7 +140,7 @@ final class SourceTests: XCTestCase {
     }
 
     func testPlayerItemsWithUpdatedCurrentItem() {
-        let currentItemSource = Source(id: UUID("1"), asset: .simple(url: Stream.item.url))
+        let currentItemSource = Source(id: UUID("1"), asset: .init(type: .simple(url: Stream.item.url)))
         let previousSources = [
             Source(id: UUID("1"), asset: .loading),
             Source(id: UUID("2"), asset: .loading),

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -25,7 +25,7 @@ In your SwiftUI view simply instantiate and store a `Player` as `@StateObject`. 
 ```swift
 struct PlayerView: View {
     @StateObject private var player = Player(
-        item: PlayerItem(url: URL(string: "https://server.com/stream.m38u")!)
+        item: PlayerItem.simple(url: URL(string: "https://server.com/stream.m38u")!)
     )
 
     // ...
@@ -41,7 +41,7 @@ Once you have a player you can display its contents in a `VideoView`, provided y
 ```swift
 struct PlayerView: View {
     @StateObject private var player = Player(
-        item: PlayerItem(url: URL(string: "https://server.com/stream.m38u")!)
+        item: PlayerItem.simple(url: URL(string: "https://server.com/stream.m38u")!)
     )
 
     var body: some View {


### PR DESCRIPTION
# Pull request

## Description

This PR adds a way to deliver textual asset metadata.

## Changes made

- Provide API for metadata delivery.
- Implement delivery for URL and URN-based items.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
