### PR TITLE
205 now playing session metadata

### DIFF
--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -29,6 +29,8 @@ final class ResourceLoadedPlayerItem: AVPlayerItem {
 
 /// An asset representing content to be played.
 public struct Asset {
+    typealias NowPlayingInfo = [String: Any]
+
     private let type: `Type`
     private let metadata: Metadata?
     private let configuration: (AVPlayerItem) -> Void
@@ -98,12 +100,13 @@ public struct Asset {
         return item
     }
 
-    func nowPlayingInfo() -> [String: Any] {
-        guard let metadata else { return [:] }
-        var nowPlayingInfo: [String: Any] = [:]
-        nowPlayingInfo[MPMediaItemPropertyTitle] = metadata.title
-        nowPlayingInfo[MPMediaItemPropertyArtist] = metadata.subtitle
-        nowPlayingInfo[MPMediaItemPropertyComments] = metadata.description
+    func nowPlayingInfo() -> NowPlayingInfo {
+        var nowPlayingInfo = NowPlayingInfo()
+        if let metadata {
+            nowPlayingInfo[MPMediaItemPropertyTitle] = metadata.title
+            nowPlayingInfo[MPMediaItemPropertyArtist] = metadata.subtitle
+            nowPlayingInfo[MPMediaItemPropertyComments] = metadata.description
+        }
         return nowPlayingInfo
     }
 }

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -5,6 +5,7 @@
 //
 
 import AVFoundation
+import MediaPlayer
 import OSLog
 
 private let kContentKeySession = AVContentKeySession(keySystem: .fairPlayStreaming)
@@ -95,6 +96,15 @@ public struct Asset {
         let item = type.playerItem()
         configuration(item)
         return item
+    }
+
+    func nowPlayingInfo() -> [String: Any] {
+        guard let metadata else { return [:] }
+        var nowPlayingInfo: [String: Any] = [:]
+        nowPlayingInfo[MPMediaItemPropertyTitle] = metadata.title
+        nowPlayingInfo[MPMediaItemPropertyArtist] = metadata.subtitle
+        nowPlayingInfo[MPMediaItemPropertyComments] = metadata.description
+        return nowPlayingInfo
     }
 }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -484,16 +484,8 @@ extension Player {
     }
 
     private func configureCurrentIndexPublisher() {
-        Publishers.CombineLatest($storedItems, queuePlayer.publisher(for: \.currentItem))
-            .filter { storedItems, currentItem in
-                // The current item is automatically set to `nil` when a failure is encountered. If this is the case
-                // preserve the previous value, provided the player is loaded with items.
-                storedItems.isEmpty || currentItem != nil
-            }
-            .map { storedItems, currentItem in
-                storedItems.firstIndex { $0.matches(currentItem) }
-            }
-            .removeDuplicates()
+        currentItemPublisher()
+            .map(\.?.index)
             .receiveOnMainThread()
             .lane("player_current_index")
             .assign(to: &$currentIndex)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -83,9 +83,9 @@ public final class Player: ObservableObject, Equatable {
         configureCurrentItemPublisher()
         configureQueueUpdatePublisher()
         configureExternalPlaybackPublisher()
-        configureNowPlayingSession()
 
         configurePlayer()
+        configureNowPlayingSession()
     }
 
     /// Create a player with a single item in its queue.
@@ -557,7 +557,9 @@ extension Player {
             .removeDuplicates()
             .eraseToAnyPublisher()
     }
+}
 
+extension Player {
     private func configurePlayer() {
         queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
         queuePlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -497,16 +497,18 @@ extension Player {
 
     private func configureCurrentItemPublisher() {
         currentPublisher()
-            .map { current -> AnyPublisher<Source?, Never> in
-                guard let current else { return Just(nil).eraseToAnyPublisher() }
+            .map { current in
+                guard let current else {
+                    return Just(Optional<Asset.NowPlayingInfo>.none).eraseToAnyPublisher()
+                }
                 return current.item.$source
-                    .map { Optional($0) }
+                    .map { $0.asset.nowPlayingInfo() }
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
             .receiveOnMainThread()
-            .sink { [weak nowPlayingSession] source in
-                nowPlayingSession?.nowPlayingInfoCenter.nowPlayingInfo = source?.asset.nowPlayingInfo()
+            .sink { [weak nowPlayingSession] nowPlayingInfo in
+                nowPlayingSession?.nowPlayingInfoCenter.nowPlayingInfo = nowPlayingInfo
             }
             .store(in: &cancellables)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -8,6 +8,7 @@ import AVFoundation
 import Combine
 import Core
 import DequeModule
+import MediaPlayer
 import TimelaneCombine
 
 /// An audio / video player maintaining its items as a double-ended queue (deque).
@@ -41,8 +42,8 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer.currentTime()
     }
 
-    /// Low-level player used for playback.
     let queuePlayer = QueuePlayer()
+    private let nowPlayingSession: MPNowPlayingSession
 
     public let configuration: PlayerConfiguration
     private var cancellables = Set<AnyCancellable>()
@@ -69,6 +70,7 @@ public final class Player: ObservableObject, Equatable {
     ///   - configuration: The configuration to apply to the player.
     public init(items: [PlayerItem] = [], configuration: PlayerConfiguration = .init()) {
         storedItems = Deque(items)
+        nowPlayingSession = MPNowPlayingSession(players: [queuePlayer])
         self.configuration = configuration
 
         configurePlaybackStatePublisher()

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -78,6 +78,7 @@ public final class Player: ObservableObject, Equatable {
         configureSeekingPublisher()
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
+        configureCurrentItemPublisher()
         configureQueueUpdatePublisher()
         configureExternalPlaybackPublisher()
 
@@ -489,6 +490,16 @@ extension Player {
             .receiveOnMainThread()
             .lane("player_current_index")
             .assign(to: &$currentIndex)
+    }
+
+    private func configureCurrentItemPublisher() {
+        currentItemPublisher()
+            .map(\.?.item)
+            .receiveOnMainThread()
+            .sink { item in
+                print(item)
+            }
+            .store(in: &cancellables)
     }
 
     private func configureQueueUpdatePublisher() {

--- a/Sources/Player/RemoteCommandCenter.swift
+++ b/Sources/Player/RemoteCommandCenter.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+import MediaPlayer
+
+struct RemoteCommandRegistration {
+    fileprivate let command: KeyPath<MPRemoteCommandCenter, MPRemoteCommand>
+    fileprivate let target: Any?
+}
+
+extension MPRemoteCommandCenter {
+    func register(
+        command: KeyPath<MPRemoteCommandCenter, MPRemoteCommand>,
+        handler: @escaping (MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus
+    ) -> RemoteCommandRegistration {
+        let target = self[keyPath: command].addTarget(handler: handler)
+        return .init(command: command, target: target)
+    }
+
+    func unregister(_ registration: RemoteCommandRegistration?) {
+        guard let registration else { return }
+        self[keyPath: registration.command].removeTarget(registration.target)
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to see in the control center what is currently being played.
 
## Changes made

- Title and subtile are displayed in the Control Center.
- Title and subtile are correctly displayed and updated in the Control Center when transitioning to another item.

## Checklist

- [X] Your branch has been rebased onto the `main` branch.
- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] ~New unit tests have been written (if relevant).~
- [X] ~The demo has been updated (if relevant).~
- [X] ~The playground has been updated (if relevant).~
