### PR TITLE
Improve linter git hook to check only swift files in the staging area

### DIFF
--- a/Scripts/check-quality.sh
+++ b/Scripts/check-quality.sh
@@ -3,7 +3,11 @@
 set -e
 
 echo "... checking Swift code..."
-swiftlint --quiet --strict
+if [ $# -eq 0 ]; then
+  swiftlint --quiet --strict
+elif [[ "$1" == "forHook" ]]; then
+  git diff --staged --name-only | grep ".swift$" | xargs swiftlint lint --quiet --strict
+fi
 echo "... checking Ruby scripts..."
 bundle exec rubocop --format quiet
 echo "... checking Shell scripts..."

--- a/Scripts/check-quality.sh
+++ b/Scripts/check-quality.sh
@@ -5,7 +5,7 @@ set -e
 echo "... checking Swift code..."
 if [ $# -eq 0 ]; then
   swiftlint --quiet --strict
-elif [[ "$1" == "forHook" ]]; then
+elif [[ "$1" == "only-changes" ]]; then
   git diff --staged --name-only | grep ".swift$" | xargs swiftlint lint --quiet --strict
 fi
 echo "... checking Ruby scripts..."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,7 +6,7 @@
 
 PATH="$(which swiftlint):$(which ruby):$PATH"
 
-if Scripts/check-quality.sh forHook; then
+if Scripts/check-quality.sh only-changes; then
 	echo "✅ Quality checked"
 else
 	echo "❌ Quality check failed"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,7 +6,7 @@
 
 PATH="$(which swiftlint):$(which ruby):$PATH"
 
-if Scripts/check-quality.sh; then
+if Scripts/check-quality.sh forHook; then
 	echo "✅ Quality checked"
 else
 	echo "❌ Quality check failed"


### PR DESCRIPTION
# Pull request

## Description

This PR allows developer who use pre-commit hook to check only the staged files quality. 

## Changes made

- Update the pre-commit hook to check only staged swift files.

## Checklist

- [X] Your branch has been rebased onto the `main` branch.
- ~[ ] APIs have been properly documented (if relevant).~
- ~[ ] The documentation has been updated (if relevant).~
- ~[ ] New unit tests have been written (if relevant).~
- ~[ ] The demo has been updated (if relevant).~
- ~[ ] The playground has been updated (if relevant).~
