### PR TITLE
Enable more SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -87,6 +87,7 @@ opt_in_rules:
   - let_var_whitespace
   - line_length
   - literal_expression_end_indentation
+  - local_doc_comment
   - lower_acl_than_parent
   - missing_docs
   - modifier_order
@@ -123,6 +124,7 @@ opt_in_rules:
   - required_enum_case
   - return_value_from_void_function
   - self_binding
+  - self_in_property_initialization
   - shorthand_optional_binding
   - single_test_class
   - sorted_first_last


### PR DESCRIPTION
# Pull request

## Description

This PR adds two new rules for the Swift linter.

## Changes made

See file changes. I initially wanted to enable the `anyobject_protocol` rule as well but it appears this rule will soon be deprecated (warning logged when running SwiftLint).

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
