### PR TITLE
214 enable or disable control center buttons

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -280,10 +280,7 @@ public extension Player {
 
     /// Return the list of items to be loaded to return to the previous (playable) item.
     private var returningItems: [PlayerItem] {
-        guard let currentIndex else { return [] }
-        let previousIndex = storedItems.index(before: currentIndex)
-        guard previousIndex >= 0 else { return [] }
-        return Array(storedItems.suffix(from: previousIndex))
+        Self.items(before: currentIndex, in: storedItems)
     }
 
     /// Items past the current item (not included).
@@ -500,10 +497,21 @@ public extension Player {
 }
 
 extension Player {
+    private static func items(before index: Int?, in items: Deque<PlayerItem>) -> [PlayerItem] {
+        guard let index else { return [] }
+        let previousIndex = items.index(before: index)
+        guard previousIndex >= 0 else { return [] }
+        return Array(items.suffix(from: previousIndex))
+    }
+
+    private static func canReturnToItem(before index: Int?, in items: Deque<PlayerItem>) -> Bool {
+        !Self.items(before: index, in: items).isEmpty
+    }
+
     /// Check whether returning to the previous item in the deque is possible.`
     /// - Returns: `true` if possible.
     func canReturnToPreviousItem() -> Bool {
-        !returningItems.isEmpty
+        Self.canReturnToItem(before: currentIndex, in: storedItems)
     }
 
     /// Return to the previous item in the deque. Skips failed items.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -516,6 +516,10 @@ extension Player {
         !Self.items(before: index, in: items).isEmpty
     }
 
+    private static func canAdvanceToItem(after index: Int?, in items: Deque<PlayerItem>) -> Bool {
+        !Self.items(after: index, in: items).isEmpty
+    }
+
     /// Check whether returning to the previous item in the deque is possible.`
     /// - Returns: `true` if possible.
     func canReturnToPreviousItem() -> Bool {
@@ -531,7 +535,7 @@ extension Player {
     /// Check whether moving to the next item in the deque is possible.`
     /// - Returns: `true` if possible.
     func canAdvanceToNextItem() -> Bool {
-        !advancingItems.isEmpty
+        Self.canAdvanceToItem(after: currentIndex, in: storedItems)
     }
 
     /// Move to the next item in the deque.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -651,7 +651,7 @@ extension Player {
                 self.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled
                 self.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled
                 self.nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = self.canReturn(before: index, in: items, streamType: streamType)
-                self.nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = self.canAdvanceToNext()
+                self.nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = Self.canAdvanceToItem(after: index, in: items)
             }
             .store(in: &cancellables)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -753,14 +753,16 @@ extension Player {
     }
 
     private func previousTrackRegistration() -> some RemoteCommandRegistrable {
-        nowPlayingSession.remoteCommandCenter.register(command: \.previousTrackCommand) { [weak self] _ in
+        nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = false
+        return nowPlayingSession.remoteCommandCenter.register(command: \.previousTrackCommand) { [weak self] _ in
             self?.returnToPrevious()
             return .success
         }
     }
 
     private func nextTrackRegistration() -> some RemoteCommandRegistrable {
-        nowPlayingSession.remoteCommandCenter.register(command: \.nextTrackCommand) { [weak self] _ in
+        nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = false
+        return nowPlayingSession.remoteCommandCenter.register(command: \.nextTrackCommand) { [weak self] _ in
             self?.advanceToNext()
             return .success
         }
@@ -775,6 +777,7 @@ extension Player {
     }
 
     private func skipBackwardRegistration() -> some RemoteCommandRegistrable {
+        nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = false
         nowPlayingSession.remoteCommandCenter.skipBackwardCommand.preferredIntervals = [.init(value: configuration.backwardSkipInterval)]
         return nowPlayingSession.remoteCommandCenter.register(command: \.skipBackwardCommand) { [weak self] _ in
             self?.skipBackward()
@@ -783,6 +786,7 @@ extension Player {
     }
 
     private func skipForwardRegistration() -> some RemoteCommandRegistrable {
+        nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = false
         nowPlayingSession.remoteCommandCenter.skipForwardCommand.preferredIntervals = [.init(value: configuration.forwardSkipInterval)]
         return nowPlayingSession.remoteCommandCenter.register(command: \.skipForwardCommand) { [weak self] _ in
             self?.skipForward()

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -294,10 +294,7 @@ public extension Player {
 
     /// Return the list of items to be loaded to advance to the next (playable) item.
     private var advancingItems: [PlayerItem] {
-        guard let currentIndex else { return [] }
-        let nextIndex = storedItems.index(after: currentIndex)
-        guard nextIndex < storedItems.count else { return [] }
-        return Array(storedItems.suffix(from: nextIndex))
+        Self.items(after: currentIndex, in: storedItems)
     }
 
     private func canInsert(_ item: PlayerItem, before beforeItem: PlayerItem?) -> Bool {
@@ -506,6 +503,13 @@ extension Player {
         let previousIndex = items.index(before: index)
         guard previousIndex >= 0 else { return [] }
         return Array(items.suffix(from: previousIndex))
+    }
+
+    private static func items(after index: Int?, in items: Deque<PlayerItem>) -> [PlayerItem] {
+        guard let index else { return [] }
+        let nextIndex = items.index(after: index)
+        guard nextIndex < items.count else { return [] }
+        return Array(items.suffix(from: nextIndex))
     }
 
     private static func canReturnToItem(before index: Int?, in items: Deque<PlayerItem>) -> Bool {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -551,11 +551,11 @@ extension Player {
         let index: Int
     }
 
-    struct ItemUpdate {
+    private struct ItemUpdate {
         let items: Deque<PlayerItem>
         let currentItem: AVPlayerItem?
 
-        func index() -> Int? {
+        func currentIndex() -> Int? {
             items.firstIndex(where: { $0.matches(currentItem) })
         }
     }
@@ -640,7 +640,7 @@ extension Player {
             .map { update in
                 Publishers.CombineLatest3(
                     Just(update.items),
-                    Just(update.index()),
+                    Just(update.currentIndex()),
                     Self.streamTypePublisher(for: update.currentItem)
                 )
             }
@@ -704,7 +704,7 @@ extension Player {
     private func currentPublisher() -> AnyPublisher<Current?, Never> {
         itemUpdatePublisher()
             .map { update in
-                guard let currentIndex = update.index() else { return nil }
+                guard let currentIndex = update.currentIndex() else { return nil }
                 return .init(item: update.items[currentIndex], index: currentIndex)
             }
             .removeDuplicates()

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -445,15 +445,19 @@ public extension Player {
 public extension Player {
     internal static let startTimeThreshold: TimeInterval = 3
 
-    /// Check whether returning to the previous content is possible.`
-    /// - Returns: `true` if possible.
-    func canReturnToPrevious() -> Bool {
+    private func canReturn(before index: Int?, in items: Deque<PlayerItem>, streamType: StreamType) -> Bool {
         if configuration.isSmartNavigationEnabled && streamType == .onDemand {
             return true
         }
         else {
-            return canReturnToPreviousItem()
+            return Self.canReturnToItem(before: index, in: items)
         }
+    }
+
+    /// Check whether returning to the previous content is possible.`
+    /// - Returns: `true` if possible.
+    func canReturnToPrevious() -> Bool {
+        canReturn(before: currentIndex, in: storedItems, streamType: streamType)
     }
 
     private func isFarFromStartTime() -> Bool {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -647,7 +647,7 @@ extension Player {
             .switchToLatest()
             .sink { [weak self] items, index, streamType in
                 guard let self else { return }
-                let areSkipsEnabled = items.count <= 1
+                let areSkipsEnabled = items.count <= 1 && streamType != .live
                 self.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled
                 self.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled
                 self.nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = self.canReturn(before: index, in: items, streamType: streamType)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -556,7 +556,7 @@ extension Player {
         let currentItem: AVPlayerItem?
 
         func currentIndex() -> Int? {
-            items.firstIndex(where: { $0.matches(currentItem) })
+            items.firstIndex { $0.matches(currentItem) }
         }
     }
 
@@ -689,7 +689,7 @@ extension Player {
             .receiveOnMainThread()
             .assign(to: &$isExternalPlaybackActive)
     }
-    
+
     private func itemUpdatePublisher() -> AnyPublisher<ItemUpdate, Never> {
         Publishers.CombineLatest($storedItems, queuePlayer.publisher(for: \.currentItem))
             .filter { storedItems, currentItem in

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -603,9 +603,11 @@ extension Player {
 
     private func configureControlCenterAvailability() {
         $storedItems.sink { [weak self] items in
-            let isEnabled = items.count <= 1
-            self?.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = isEnabled
-            self?.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = isEnabled
+            let areSkipsEnabled = items.count <= 1
+            self?.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled
+            self?.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled
+            self?.nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = self?.canReturnToPrevious() ?? true
+            self?.nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = self?.canAdvanceToNext() ?? true
         }.store(in: &cancellables)
     }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -617,7 +617,7 @@ extension Player {
 
     private func configureControlCenterPublishers() {
         configureControlCenterPublisher()
-        configureControlCenterAvailability()
+        configureControlCenterCommandAvailabilityPublisher()
     }
 
     private func configureControlCenterPublisher() {
@@ -635,7 +635,7 @@ extension Player {
         .store(in: &cancellables)
     }
 
-    private func configureControlCenterAvailability() {
+    private func configureControlCenterCommandAvailabilityPublisher() {
         itemUpdatePublisher()
             .map { update in
                 Publishers.CombineLatest3(

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -81,7 +81,7 @@ public final class Player: ObservableObject, Equatable {
         configureSeekingPublisher()
         configureBufferingPublisher()
         configureCurrentIndexPublisher()
-        configureControlCenterPublisher()
+        configureControlCenterPublishers()
         configureQueueUpdatePublisher()
         configureExternalPlaybackPublisher()
 
@@ -581,6 +581,11 @@ extension Player {
             .assign(to: &$currentIndex)
     }
 
+    private func configureControlCenterPublishers() {
+        configureControlCenterPublisher()
+        configureControlCenterAvailability()
+    }
+
     private func configureControlCenterPublisher() {
         Publishers.CombineLatest(
             nowPlayingInfoMetadataPublisher(),
@@ -594,6 +599,14 @@ extension Player {
             )
         }
         .store(in: &cancellables)
+    }
+
+    private func configureControlCenterAvailability() {
+        $storedItems.sink { [weak self] items in
+            let isEnabled = items.count <= 1
+            self?.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = isEnabled
+            self?.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = isEnabled
+        }.store(in: &cancellables)
     }
 
     private func configureQueueUpdatePublisher() {

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -43,6 +43,17 @@ extension AVPlayerItem {
         .eraseToAnyPublisher()
     }
 
+    func streamTypePublisher() -> AnyPublisher<StreamType, Never> {
+        Publishers.CombineLatest(
+            timeRangePublisher(),
+            durationPublisher()
+        )
+        .map { timeRange, duration in
+            StreamType(for: timeRange, itemDuration: duration)
+        }
+        .eraseToAnyPublisher()
+    }
+
     func bufferingPublisher() -> AnyPublisher<Bool, Never> {
         Publishers.CombineLatest(
             publisher(for: \.isPlaybackLikelyToKeepUp),


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to enable/disable some Control Center buttons when [appropriate](https://github.com/SRGSSR/pillarbox-documentation/issues/17).

## Changes made

- Disable skip buttons and track buttons by default.
- Enable track buttons when the playlist contains more than one item.
- Enable skip buttons when the player contains only one item.

## Checklist

- [X] Your branch has been rebased onto the `main` branch.
- ~[ ] APIs have been properly documented (if relevant).~
- ~[ ] The documentation has been updated (if relevant).~
- ~[ ] New unit tests have been written (if relevant).~
- ~[ ] The demo has been updated (if relevant).~
- ~[ ] The playground has been updated (if relevant).~
