### PR TITLE
Add memory warning simulation button to the demo settings

### DIFF
--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
         List {
             applicationSection()
             playerSection()
+            debuggingSection()
         }
         .navigationTitle("Settings")
     }
@@ -62,6 +63,13 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private func debuggingSection() -> some View {
+        Section("Debugging") {
+            Button("Simulate memory warning", action: simulateMemoryWarning)
+        }
+    }
+
+    @ViewBuilder
     private func seekBehaviorPicker() -> some View {
         Picker("Seek behavior", selection: $seekBehaviorSetting) {
             Text("Immediate").tag(SeekBehaviorSetting.immediate)
@@ -76,6 +84,10 @@ struct SettingsView: View {
             Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
             Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
         }
+    }
+
+    private func simulateMemoryWarning() {
+        UIApplication.shared.perform(Selector(("_performMemoryWarning")))
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR adds a memory warning simulation button to the demo settings.

## Changes made

Self-explanatory. No private selector obfuscation is needed since the demo will not be published to the App Store.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
