### PR TITLE
Fix behavior when skipping several times in a row

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6FA83B7E296831D5001578DB /* BasicPlaybackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA83B7D296831D5001578DB /* BasicPlaybackView.swift */; };
 		6FA83B80296834F8001578DB /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA83B7F296834F8001578DB /* Template.swift */; };
 		6FA83B82296834FE001578DB /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA83B81296834FE001578DB /* Playlist.swift */; };
+		6FAB36BD29A754AA009E1F45 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAB36BC29A754AA009E1F45 /* Constant.swift */; };
 		6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB553B128C3AF020067CFC4 /* StoriesView.swift */; };
 		6FBD8F1B296C2A6E0051ABEB /* SystemPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */; };
 		6FBEFCEB289132DB004BE625 /* UserInterface in Frameworks */ = {isa = PBXBuildFile; productRef = 6FBEFCEA289132DB004BE625 /* UserInterface */; };
@@ -70,6 +71,7 @@
 		6FA83B7D296831D5001578DB /* BasicPlaybackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicPlaybackView.swift; sourceTree = "<group>"; };
 		6FA83B7F296834F8001578DB /* Template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
 		6FA83B81296834FE001578DB /* Playlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
+		6FAB36BC29A754AA009E1F45 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		6FB553B128C3AF020067CFC4 /* StoriesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
 		6FBD8F1A296C2A6E0051ABEB /* SystemPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPlayerView.swift; sourceTree = "<group>"; };
 		6FCA4748292CC101008C2812 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 			children = (
 				6FCA8D7B28AD2AB900CF75FB /* AppDelegate.swift */,
 				6FA83B7D296831D5001578DB /* BasicPlaybackView.swift */,
+				6FAB36BC29A754AA009E1F45 /* Constant.swift */,
 				6F917C0A2887EA8E004113BA /* DemoApp.swift */,
 				6F48A5DC2932673A00B80393 /* DeveloperTools.swift */,
 				6FCD6A1A28AD1B9200FCE4EA /* ExamplesView.swift */,
@@ -318,6 +321,7 @@
 				0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */,
 				6FCD6A1B28AD1B9200FCE4EA /* ExamplesView.swift in Sources */,
 				6F917C0F2887EA8E004113BA /* DemoApp.swift in Sources */,
+				6FAB36BD29A754AA009E1F45 /* Constant.swift in Sources */,
 				6F7750D628EABD5100E80196 /* SimplePlayerView.swift in Sources */,
 				0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */,
 				6F9B5BCB28D03E1E0074B9E0 /* TwinsView.swift in Sources */,

--- a/Demo/Sources/BasicPlaybackView.swift
+++ b/Demo/Sources/BasicPlaybackView.swift
@@ -38,7 +38,7 @@ struct BasicPlaybackView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
 #endif
             ProgressView()
-                .opacity(player.isBuffering ? 1 : 0)
+                .opacity(player.isBusy ? 1 : 0)
         }
     }
 }

--- a/Demo/Sources/Constant.swift
+++ b/Demo/Sources/Constant.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+func constant<T>(iOS: T, tvOS: T) -> T {
+#if os(tvOS)
+    return tvOS
+#else
+    return iOS
+#endif
+}

--- a/Demo/Sources/LinkView.swift
+++ b/Demo/Sources/LinkView.swift
@@ -19,7 +19,7 @@ struct LinkView: View {
             ZStack {
                 BasicPlaybackView(player: isDisplayed ? player : Player())
                 ProgressView()
-                    .opacity(player.isBuffering ? 1 : 0)
+                    .opacity(player.isBusy ? 1 : 0)
             }
             Toggle("Content displayed", isOn: $isDisplayed)
                 .padding()

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -31,7 +31,7 @@ private struct ContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
 #endif
         }
-        .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
+        .animation(.easeInOut(duration: 0.2), value: player.isBusy)
         .animation(.easeInOut(duration: 0.2), value: isUserInterfaceHidden)
         .debugBodyCounter()
     }
@@ -63,7 +63,7 @@ private struct ContentView: View {
     private func loadingIndicator() -> some View {
         ProgressView()
             .tint(.white)
-            .opacity(player.isBuffering ? 1 : 0)
+            .opacity(player.isBusy ? 1 : 0)
 #if os(iOS)
             .controlSize(.large)
 #endif
@@ -120,7 +120,7 @@ private struct PlaybackButton: View {
                 .resizable()
                 .tint(.white)
         }
-        .opacity(player.isBuffering ? 0 : 1)
+        .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
         .frame(height: 90)
     }

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -122,7 +122,7 @@ private struct PlaybackButton: View {
         }
         .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
-        .frame(height: 90)
+        .frame(height: constant(iOS: 90, tvOS: 150))
     }
 }
 
@@ -138,7 +138,7 @@ private struct SkipBackwardButton: View {
                 .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
-        .frame(height: 45)
+        .frame(height: constant(iOS: 45, tvOS: 75))
         .disabled(!player.canSkipBackward())
     }
 
@@ -159,7 +159,7 @@ private struct SkipForwardButton: View {
                 .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
-        .frame(height: 45)
+        .frame(height: constant(iOS: 45, tvOS: 75))
         .disabled(!player.canSkipForward())
     }
 

--- a/Demo/Sources/SimplePlayerView.swift
+++ b/Demo/Sources/SimplePlayerView.swift
@@ -18,7 +18,7 @@ struct SimplePlayerView: View {
         ZStack {
             VideoView(player: player)
             ProgressView()
-                .opacity(player.isBuffering ? 1 : 0)
+                .opacity(player.isBusy ? 1 : 0)
         }
         .onAppear {
             play()

--- a/Demo/Sources/StoriesView.swift
+++ b/Demo/Sources/StoriesView.swift
@@ -17,11 +17,11 @@ private struct StoryView: View {
             VideoView(player: player, gravity: .resizeAspectFill)
                 .ignoresSafeArea()
             ProgressView()
-                .opacity(player.isBuffering ? 1 : 0)
+                .opacity(player.isBusy ? 1 : 0)
             TimeProgress(player: player)
         }
         .tint(.white)
-        .animation(.easeInOut(duration: 0.2), value: player.isBuffering)
+        .animation(.easeInOut(duration: 0.2), value: player.isBusy)
     }
 }
 

--- a/Sources/Player/AVPlayerItem.swift
+++ b/Sources/Player/AVPlayerItem.swift
@@ -7,7 +7,7 @@
 import AVFoundation
 
 extension AVPlayerItem {
-    var timeRange: CMTimeRange? {
+    var timeRange: CMTimeRange {
         Self.timeRange(loadedTimeRanges: loadedTimeRanges, seekableTimeRanges: seekableTimeRanges)
     }
 
@@ -15,10 +15,10 @@ extension AVPlayerItem {
         playerItems(from: items.map(\.source))
     }
 
-    static func timeRange(loadedTimeRanges: [NSValue], seekableTimeRanges: [NSValue]) -> CMTimeRange? {
+    static func timeRange(loadedTimeRanges: [NSValue], seekableTimeRanges: [NSValue]) -> CMTimeRange {
         guard let firstRange = seekableTimeRanges.first?.timeRangeValue, !firstRange.isIndefinite,
               let lastRange = seekableTimeRanges.last?.timeRangeValue, !lastRange.isIndefinite else {
-            return !loadedTimeRanges.isEmpty ? .zero : nil
+            return !loadedTimeRanges.isEmpty ? .zero : .invalid
         }
         return CMTimeRangeFromTimeToTime(start: firstRange.start, end: lastRange.end)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -251,8 +251,8 @@ public extension Player {
 }
 
 public extension Player {
-    /// Return a publisher periodically emitting the current time while the player is active. Emits the current time
-    /// also on subscription.
+    /// Return a publisher periodically emitting the current time while the player is playing content. Does not emit any
+    /// value on subscription and only emits valid times.
     /// - Parameters:
     ///   - interval: The interval at which events must be emitted.
     ///   - queue: The queue on which values are published.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -158,8 +158,8 @@ public extension Player {
     ///   - toleranceBefore: Tolerance before the desired position.
     ///   - toleranceAfter: Tolerance after the desired position.
     ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before
-    ///     the new seek is performed, preventing unnecessary cancellation so that the playhead position can move in
-    ///     a smoother way.
+    ///     any new seek is performed, preventing unnecessary cancellation. This makes it possible for the playhead
+    ///     position to be moved in a smoother way.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs
     ///     whether the seek could finish without being cancelled.
     func seek(

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -152,7 +152,9 @@ public extension Player {
     ///   - time: The time to seek to.
     ///   - toleranceBefore: Tolerance before the desired position.
     ///   - toleranceAfter: Tolerance after the desired position.
-    ///   - smooth: Set to `true` to enable smooth seeking, preventing unnecessary seek cancellation.
+    ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before
+    ///     the new seek is performed, preventing unnecessary cancellation so that the playhead position can move in
+    ///     a smoother way.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs
     ///     whether the seek could finish without being cancelled.
     func seek(

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -227,19 +227,24 @@ public extension Player {
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipBackward(completion: @escaping (Bool) -> Void = { _ in }) {
-        skip(withInterval: backwardSkipTime, completion: completion)
+        skip(withInterval: backwardSkipTime, toleranceBefore: .positiveInfinity, toleranceAfter: .zero, completion: completion)
     }
 
     /// Skip forward.
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipForward(completion: @escaping (Bool) -> Void = { _ in }) {
-        skip(withInterval: forwardSkipTime, completion: completion)
+        skip(withInterval: forwardSkipTime, toleranceBefore: .zero, toleranceAfter: .positiveInfinity, completion: completion)
     }
 
-    private func skip(withInterval interval: CMTime, completion: @escaping (Bool) -> Void = { _ in }) {
+    private func skip(
+        withInterval interval: CMTime,
+        toleranceBefore: CMTime,
+        toleranceAfter: CMTime,
+        completion: @escaping (Bool) -> Void = { _ in }
+    ) {
         let currentTime = queuePlayer.targetSeekTime ?? time
-        seek(to: currentTime + interval, completion: completion)
+        seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, completion: completion)
     }
 }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -48,6 +48,11 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer.timeRange
     }
 
+    /// Returns whether the player is currently busy (buffering or seeking).
+    public var isBusy: Bool {
+        isBuffering || isSeeking
+    }
+
     /// The current item duration or `.invalid` when not known.
     private var itemDuration: CMTime {
         queuePlayer.itemDuration

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -246,7 +246,7 @@ public extension Player {
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
         let currentTime = queuePlayer.targetSeekTime ?? time
-        seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, completion: completion)
+        seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: true, completion: completion)
     }
 }
 

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -27,9 +27,9 @@ extension AVPlayerItem {
             publisher(for: \.loadedTimeRanges),
             publisher(for: \.seekableTimeRanges)
         )
-        .filter { $0.0 == .readyToPlay }
-        .compactMap { _, loadedTimeRanges, seekableTimeRanges in
-            Self.timeRange(loadedTimeRanges: loadedTimeRanges, seekableTimeRanges: seekableTimeRanges)
+        .map { status, loadedTimeRanges, seekableTimeRanges in
+            guard status == .readyToPlay else { return .invalid }
+            return Self.timeRange(loadedTimeRanges: loadedTimeRanges, seekableTimeRanges: seekableTimeRanges)
         }
         .removeDuplicates()
         .eraseToAnyPublisher()

--- a/Sources/Player/ProgressTracker.swift
+++ b/Sources/Player/ProgressTracker.swift
@@ -78,6 +78,7 @@ public final class ProgressTracker: ObservableObject {
                 .map { time, timeRange in
                     Self.progress(for: time, in: timeRange)
                 }
+                .prepend(Self.progress(for: player.time, in: player.timeRange))
                 .eraseToAnyPublisher()
             }
             .switchToLatest()

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -69,10 +69,9 @@ final class QueuePlayer: AVQueuePlayer {
         }
 
         move(to: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
-            if finished {
-                self?.notifySeekEnd()
-                self?.targetSeek = nil
-            }
+            guard let self, finished else { return }
+            self.notifySeekEnd()
+            self.targetSeek = nil
         }
     }
 

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -197,14 +197,12 @@ extension QueuePlayer {
     }
 
     private func processPendingSeeks() {
-//        guard let targetSeek = self.targetSeek else { return }
-//        while let pendingSeek = self.pendingSeeks.popFirst() {
-//            pendingSeek.completionHandler(true)
-//        }
-//        targetSeek.completionHandler(true)
-//        self.targetSeek = nil
-//        self.notifySeekEnd()
-//        Self.logger.info("Sentinel detected unhandled completion and fixed it")
+        guard !pendingSeeks.isEmpty else { return }
+        while let pendingSeek = pendingSeeks.popFirst() {
+            pendingSeek.completionHandler(true)
+        }
+        self.notifySeekEnd()
+        Self.logger.info("Sentinel detected unhandled completion and fixed it")
     }
 
     /// Perform a low-level seek without seek tracking.

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -56,14 +56,18 @@ final class QueuePlayer: AVQueuePlayer {
         notifySeekStart(at: time)
 
         let seek = Seek(time: time, isSmooth: smooth, completionHandler: completionHandler)
-        targetSeekTime = time
         pendingSeeks.append(seek)
 
-        if !smooth || pendingSeeks.count == 1 {
-            enqueue(seek: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
-                guard let self, finished else { return }
-                self.notifySeekEnd()
-            }
+        if smooth && targetSeekTime != nil {
+            targetSeekTime = time
+            return
+        }
+
+        targetSeekTime = time
+        enqueue(seek: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
+            guard let self, finished else { return }
+            self.notifySeekEnd()
+            self.targetSeekTime = nil
         }
     }
 
@@ -98,7 +102,6 @@ final class QueuePlayer: AVQueuePlayer {
         else {
             seek.completionHandler(finished)
             pendingSeeks.removeAll()
-            targetSeekTime = nil
             completion(finished)
         }
     }

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -102,7 +102,7 @@ final class QueuePlayer: AVQueuePlayer {
         else {
             seek.completionHandler(finished)
             pendingSeeks.removeAll()
-            completion(finished)
+            completion(true)
         }
     }
 

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -75,8 +75,8 @@ final class QueuePlayer: AVQueuePlayer {
         targetSeekTime = time
         enqueue(seek: seek) { [weak self] in
             guard let self else { return }
-            self.notifySeekEnd()
             self.targetSeekTime = nil
+            self.notifySeekEnd()
         }
     }
 
@@ -87,11 +87,11 @@ final class QueuePlayer: AVQueuePlayer {
     }
 
     private func process(seek: Seek, finished: Bool, completion: @escaping () -> Void) {
-        if let targetSeek = pendingSeeks.last, targetSeek != seek {
+        if let targetSeek = pendingSeeks.last, seek != targetSeek {
             seek.completionHandler(targetSeek.isSmooth)
             while let pendingSeek = pendingSeeks.popFirst(), pendingSeek != targetSeek {
                 guard pendingSeek != seek else { continue }
-                pendingSeek.completionHandler(finished)
+                pendingSeek.completionHandler(targetSeek.isSmooth)
             }
             if finished {
                 enqueue(seek: targetSeek, completion: completion)

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -103,8 +103,8 @@ final class QueuePlayer: AVQueuePlayer {
                 pendingSeek.completionHandler(finished)
             }
             if targetSeek == seek {
-                seek.completionHandler(finished)
-                completionHandler(finished)
+                seek.completionHandler(true)
+                completionHandler(true)
             }
             else if finished {
                 move(
@@ -117,7 +117,7 @@ final class QueuePlayer: AVQueuePlayer {
         }
         else if targetSeek.isSmooth {
             if targetSeek == seek {
-                completionHandler(finished)
+                completionHandler(true)
             }
             else {
                 seek.completionHandler(finished)
@@ -134,7 +134,7 @@ final class QueuePlayer: AVQueuePlayer {
             pendingSeeks.removeAll()
             seek.completionHandler(finished)
             if targetSeek == seek {
-                completionHandler(finished)
+                completionHandler(true)
             }
         }
     }

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -91,12 +91,8 @@ final class QueuePlayer: AVQueuePlayer {
 
     private func process(seek: Seek, finished: Bool, completion: @escaping () -> Void) {
         if let targetSeek, seek != targetSeek {
-            // TODO: Could probably be written in a better way
-            while let pendingSeek = pendingSeeks.popFirst() {
-                guard pendingSeek != targetSeek else {
-                    pendingSeeks.insert(pendingSeek, at: 0)
-                    break
-                }
+            while let pendingSeek = pendingSeeks.first, pendingSeek != targetSeek {
+                pendingSeeks.removeFirst()
                 pendingSeek.completionHandler(targetSeek.isSmooth)
             }
             if finished {

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -33,8 +33,11 @@ final class QueuePlayer: AVQueuePlayer {
     private static var logger = Logger(category: "QueuePlayer")
 
     private var pendingSeeks = Deque<Seek>()
-    private var targetSeek: Seek?
     private var cancellables = Set<AnyCancellable>()
+
+    private var targetSeek: Seek? {
+        pendingSeeks.last
+    }
 
     var targetSeekTime: CMTime? {
         targetSeek?.time
@@ -70,15 +73,12 @@ final class QueuePlayer: AVQueuePlayer {
         )
         pendingSeeks.append(seek)
 
-        if smooth && targetSeek != nil {
-            targetSeek = seek
+        if smooth && pendingSeeks.count != 1 {
             return
         }
 
-        targetSeek = seek
         enqueue(seek: seek) { [weak self] in
             guard let self else { return }
-            self.targetSeek = nil
             self.notifySeekEnd()
         }
     }

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -13,7 +13,7 @@ enum SeekKey: String {
     case time
 }
 
-private struct Seek: Equatable {
+struct Seek: Equatable {
     let time: CMTime
     let toleranceBefore: CMTime
     let toleranceAfter: CMTime
@@ -27,7 +27,7 @@ private struct Seek: Equatable {
     }
 }
 
-final class QueuePlayer: AVQueuePlayer {
+class QueuePlayer: AVQueuePlayer {
     static let notificationCenter = NotificationCenter()
 
     private static var logger = Logger(category: "QueuePlayer")
@@ -83,7 +83,7 @@ final class QueuePlayer: AVQueuePlayer {
         }
     }
 
-    private func enqueue(seek: Seek, completion: @escaping () -> Void) {
+    func enqueue(seek: Seek, completion: @escaping () -> Void) {
         super.seek(to: seek.time, toleranceBefore: seek.toleranceBefore, toleranceAfter: seek.toleranceAfter) { [weak self] finished in
             self?.process(seek: seek, finished: finished, completion: completion)
         }

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -64,8 +64,8 @@ final class QueuePlayer: AVQueuePlayer {
         }
 
         targetSeekTime = time
-        enqueue(seek: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
-            guard let self, finished else { return }
+        enqueue(seek: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] in
+            guard let self else { return }
             self.notifySeekEnd()
             self.targetSeekTime = nil
         }
@@ -75,7 +75,7 @@ final class QueuePlayer: AVQueuePlayer {
         seek: Seek,
         toleranceBefore: CMTime,
         toleranceAfter: CMTime,
-        completion: @escaping (Bool) -> Void
+        completion: @escaping () -> Void
     ) {
         super.seek(to: seek.time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] finished in
             self?.process(seek: seek, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, finished: finished, completion: completion)
@@ -87,7 +87,7 @@ final class QueuePlayer: AVQueuePlayer {
         toleranceBefore: CMTime,
         toleranceAfter: CMTime,
         finished: Bool,
-        completion: @escaping (Bool) -> Void
+        completion: @escaping () -> Void
     ) {
         if let targetSeek = pendingSeeks.last, targetSeek != seek {
             seek.completionHandler(targetSeek.isSmooth)
@@ -102,7 +102,7 @@ final class QueuePlayer: AVQueuePlayer {
         else {
             seek.completionHandler(finished)
             pendingSeeks.removeAll()
-            completion(true)
+            completion()
         }
     }
 

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -19,7 +19,7 @@ private struct Seek: Equatable {
     let toleranceAfter: CMTime
     let isSmooth: Bool
     let completionHandler: (Bool) -> Void
-    
+
     private let id = UUID()
 
     static func == (lhs: Seek, rhs: Seek) -> Bool {
@@ -104,9 +104,9 @@ final class QueuePlayer: AVQueuePlayer {
             }
         }
         else {
+            completion()
             seek.completionHandler(finished)
             pendingSeeks.removeAll()
-            completion()
         }
     }
 

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -107,11 +107,11 @@ final class QueuePlayer: AVQueuePlayer {
     }
 
     override func seek(to time: CMTime, completionHandler: @escaping (Bool) -> Void) {
-        self.seek(to: time, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity, completionHandler: completionHandler)
+        seek(to: time, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity, completionHandler: completionHandler)
     }
 
     override func seek(to time: CMTime) {
-        self.seek(to: time) { _ in }
+        seek(to: time) { _ in }
     }
 
     private func notifySeekStart(at time: CMTime) {
@@ -204,7 +204,7 @@ extension QueuePlayer {
         while let pendingSeek = pendingSeeks.popFirst() {
             pendingSeek.completionHandler(true)
         }
-        self.notifySeekEnd()
+        notifySeekEnd()
         Self.logger.info("Sentinel detected unhandled completion and fixed it")
     }
 

--- a/Sources/Player/Time.swift
+++ b/Sources/Player/Time.swift
@@ -8,6 +8,7 @@ import CoreMedia
 
 extension CMTime {
     func clamped(to range: CMTimeRange, offset: CMTime = .zero) -> CMTime {
+        guard range.isValid, self != .invalid else { return .invalid }
         let offsetRange = CMTimeRange(start: range.start, duration: max(range.duration - offset, .zero))
         guard !offsetRange.isEmpty else { return offsetRange.start }
         return CMTimeClampToRange(self, range: offsetRange)

--- a/Tests/PlayerTests/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayerItemTests.swift
@@ -14,13 +14,13 @@ import XCTest
 final class AVPlayerItemTests: XCTestCase {
     func testNonLoadedItem() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
-        expect(item.timeRange).toAlways(beNil())
+        expect(item.timeRange).toAlways(equal(.invalid))
     }
 
     func testOnDemand() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
     }
 
     func testPlayerItems() {

--- a/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
@@ -17,6 +17,7 @@ final class ItemTimeRangePublisherQueueTests: XCTestCase {
         let player = AVQueuePlayer(items: [item1, item2])
         expectPublished(
             values: [
+                .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
                 CMTimeRange(start: .zero, duration: Stream.onDemand.duration)
             ],
@@ -35,7 +36,9 @@ final class ItemTimeRangePublisherQueueTests: XCTestCase {
         let player = AVQueuePlayer(items: [item1, item2, item3])
         expectPublished(
             values: [
+                .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
+                .invalid,
                 CMTimeRange(start: .zero, duration: Stream.onDemand.duration)
             ],
             from: player.currentItemTimeRangePublisher(),

--- a/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
@@ -24,7 +24,7 @@ final class ItemTimeRangePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
-            values: [CMTimeRange(start: .zero, duration: Stream.onDemand.duration)],
+            values: [.invalid, CMTimeRange(start: .zero, duration: Stream.onDemand.duration)],
             from: player.currentItemTimeRangePublisher(),
             to: beClose(within: 1)
         )
@@ -34,7 +34,7 @@ final class ItemTimeRangePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.live.url)
         let player = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
-            values: [.zero],
+            values: [.invalid, .zero],
             from: player.currentItemTimeRangePublisher()
         )
     }
@@ -45,6 +45,7 @@ final class ItemTimeRangePublisherTests: XCTestCase {
         player.actionAtItemEnd = .advance
         expectEqualPublished(
             values: [
+                .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
                 .invalid
             ],
@@ -61,6 +62,7 @@ final class ItemTimeRangePublisherTests: XCTestCase {
         player.actionAtItemEnd = .none
         expectEqualPublished(
             values: [
+                .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration)
             ],
             from: player.currentItemTimeRangePublisher(),
@@ -75,7 +77,10 @@ final class ItemTimeRangePublisherTests: XCTestCase {
         let item = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: [])
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
-            values: [CMTimeRange(start: .zero, duration: Stream.onDemand.duration)],
+            values: [
+                .invalid,
+                CMTimeRange(start: .zero, duration: Stream.onDemand.duration)
+            ],
             from: player.currentItemTimeRangePublisher(),
             to: beClose(within: 1)
         )

--- a/Tests/PlayerTests/PeriodicTimePublisherTests.swift
+++ b/Tests/PlayerTests/PeriodicTimePublisherTests.swift
@@ -16,9 +16,7 @@ final class PeriodicTimePublisherTests: XCTestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectPublished(
-            values: [
-                .invalid
-            ],
+            values: [],
             from: Publishers.PeriodicTimePublisher(
                 for: player,
                 interval: CMTimeMake(value: 1, timescale: 2)
@@ -64,10 +62,7 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
         expectPublished(
-            values: [
-                .invalid,
-                .zero
-            ],
+            values: [.zero],
             from: Publishers.PeriodicTimePublisher(
                 for: player,
                 interval: CMTimeMake(value: 1, timescale: 2)
@@ -82,7 +77,6 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
             values: [
-                .invalid,
                 .zero,
                 CMTimeMake(value: 1, timescale: 2),
                 CMTimeMake(value: 2, timescale: 2),
@@ -105,7 +99,6 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
             values: [
-                .invalid,
                 CMTimeMake(value: 5, timescale: 1)
             ],
             from: Publishers.PeriodicTimePublisher(

--- a/Tests/PlayerTests/PeriodicTimePublisherTests.swift
+++ b/Tests/PlayerTests/PeriodicTimePublisherTests.swift
@@ -55,7 +55,8 @@ final class PeriodicTimePublisherTests: XCTestCase {
 
         let times = collectOutput(from: publisher, during: 2)
         expect(times).to(allPass { time, timeRange in
-            timeRange.start <= time && time <= timeRange.end
+            guard time.isValid, timeRange.isValid else { return true }
+            return timeRange.start <= time && time <= timeRange.end
         })
     }
 
@@ -64,6 +65,7 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let player = AVPlayer(playerItem: item)
         expectPublished(
             values: [
+                .invalid,
                 .zero
             ],
             from: Publishers.PeriodicTimePublisher(
@@ -80,6 +82,7 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
             values: [
+                .invalid,
                 .zero,
                 CMTimeMake(value: 1, timescale: 2),
                 CMTimeMake(value: 2, timescale: 2),
@@ -101,7 +104,10 @@ final class PeriodicTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
         expectAtLeastPublished(
-            values: [CMTimeMake(value: 5, timescale: 1)],
+            values: [
+                .invalid,
+                CMTimeMake(value: 5, timescale: 1)
+            ],
             from: Publishers.PeriodicTimePublisher(
                 for: player,
                 interval: CMTimeMake(value: 1, timescale: 2)

--- a/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
@@ -15,7 +15,7 @@ final class ItemStreamTypePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
-            values: [.onDemand],
+            values: [.unknown, .onDemand],
             from: item.streamTypePublisher(),
             during: 2
         )
@@ -25,7 +25,7 @@ final class ItemStreamTypePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.live.url)
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
-            values: [.live],
+            values: [.unknown, .live],
             from: item.streamTypePublisher(),
             during: 2
         )
@@ -35,7 +35,7 @@ final class ItemStreamTypePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.dvr.url)
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
-            values: [.dvr],
+            values: [.unknown, .dvr],
             from: item.streamTypePublisher(),
             during: 2
         )

--- a/Tests/PlayerTests/PlayerSkipBackwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipBackwardTests.swift
@@ -42,7 +42,7 @@ final class PlayerSkipBackwardTests: XCTestCase {
 
         waitUntil { done in
             player.skipBackward { finished in
-                expect(finished).to(beFalse())
+                expect(finished).to(beTrue())
             }
 
             player.skipBackward { finished in

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -42,7 +42,7 @@ final class PlayerSkipForwardTests: XCTestCase {
 
         waitUntil { done in
             player.skipForward { finished in
-                expect(finished).to(beFalse())
+                expect(finished).to(beTrue())
             }
 
             player.skipForward { finished in

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -113,4 +113,28 @@ final class ProgressTrackerProgressAvailabilityTests: XCTestCase {
             progressTracker.player = nil
         }
     }
+
+    func testForTrackerBoundToPlayerAtSomeTime() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+
+        expect(player.timeRange).toEventuallyNot(equal(.invalid))
+        let time = CMTime(value: 20, timescale: 1)
+
+        waitUntil { done in
+            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+                done()
+            }
+        }
+
+        expectEqualPublished(
+            values: [false, true],
+            from: progressTracker.changePublisher(at: \.isProgressAvailable)
+                .removeDuplicates(),
+            during: 1
+        ) {
+            progressTracker.player = player
+        }
+    }
 }

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -113,4 +113,28 @@ final class ProgressTrackerRangeTests: XCTestCase {
             progressTracker.player = nil
         }
     }
+
+    func testForTrackerBoundToPlayerAtSomeTime() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+
+        expect(player.timeRange).toEventuallyNot(equal(.invalid))
+        let time = CMTime(value: 20, timescale: 1)
+
+        waitUntil { done in
+            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+                done()
+            }
+        }
+
+        expectEqualPublished(
+            values: [0...0, 0...1],
+            from: progressTracker.changePublisher(at: \.range)
+                .removeDuplicates(),
+            during: 1
+        ) {
+            progressTracker.player = player
+        }
+    }
 }

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -132,4 +132,29 @@ final class ProgressTrackerTimeTests: XCTestCase {
             progressTracker.player = nil
         }
     }
+
+    func testForTrackerBoundToPlayerAtSomeTime() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+
+        expect(player.timeRange).toEventuallyNot(equal(.invalid))
+        let time = CMTime(value: 20, timescale: 1)
+
+        waitUntil { done in
+            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+                done()
+            }
+        }
+
+        expectPublished(
+            values: [nil, time],
+            from: progressTracker.changePublisher(at: \.time)
+                .removeDuplicates(),
+            to: beClose(within: 0.1),
+            during: 1
+        ) {
+            progressTracker.player = player
+        }
+    }
 }

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -171,11 +171,11 @@ final class QueuePlayerSeekTests: XCTestCase {
         expect(item.timeRange).toEventuallyNot(beNil())
 
         let values = collectOutput(from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 10), queue: .main), during: 3) {
-            player.seek(to: CMTime(value: 8, timescale: 1)) { _ in
-                player.seek(to: CMTime(value: 10, timescale: 1)) { _ in
-                    player.seek(to: CMTime(value: 12, timescale: 1)) { _ in
-                        player.seek(to: CMTime(value: 100, timescale: 1)) { _ in
-                            player.seek(to: CMTime(value: 100, timescale: 1))
+            player.seek(to: CMTime(value: 8, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
+                player.seek(to: CMTime(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
+                    player.seek(to: CMTime(value: 12, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
+                        player.seek(to: CMTime(value: 100, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
+                            player.seek(to: CMTime(value: 100, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity)
                         }
                     }
                 }

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -67,7 +67,7 @@ final class QueuePlayerSeekTests: XCTestCase {
     func testNotificationsForMultipleSeeksWithinTimeRange() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -88,7 +88,7 @@ final class QueuePlayerSeekTests: XCTestCase {
     func testNotificationsForSeekAfterSmoothSeekWithinTimeRange() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -109,7 +109,7 @@ final class QueuePlayerSeekTests: XCTestCase {
     func testCompletionsForMultipleSeeks() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -138,7 +138,7 @@ final class QueuePlayerSeekTests: XCTestCase {
     func testCompletionsForMultipleSmoothSeeksEndingWithSeek() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -170,7 +170,7 @@ final class QueuePlayerSeekTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         player.play()
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let values = collectOutput(from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 10), queue: .main), during: 3) {
             player.seek(to: CMTime(value: 8, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -164,7 +164,9 @@ final class QueuePlayerSeekTests: XCTestCase {
         ]))
     }
 
-    func testMultipleSeekStability() {
+    // Checks that time is not jumping back when seeking forward several times in a row (no tolerance before is allowed
+    // in this test as otherwise the player is allowed to pick a position before the desired position),
+    func testMultipleSeekMonotonicity() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         player.play()

--- a/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
@@ -156,4 +156,18 @@ final class QueuePlayerSmoothSeekTests: XCTestCase {
             3: true
         ]))
     }
+
+    func testTargetSeekTimeWithMultipleSeeks() {
+        let item = AVPlayerItem(url: Stream.onDemand.url)
+        let player = QueuePlayer(playerItem: item)
+        expect(player.timeRange).toEventuallyNot(equal(.invalid))
+
+        let time1 = CMTime(value: 1, timescale: 1)
+        player.seek(to: time1, smooth: true) { _ in }
+        expect(player.targetSeekTime).to(equal(time1))
+
+        let time2 = CMTime(value: 2, timescale: 1)
+        player.seek(to: time2, smooth: true) { _ in }
+        expect(player.targetSeekTime).to(equal(time2))
+    }
 }

--- a/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
@@ -60,7 +60,7 @@ final class QueuePlayerSmoothSeekTests: XCTestCase {
     func testNotificationsForMultipleSeeksWithinTimeRange() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -81,7 +81,7 @@ final class QueuePlayerSmoothSeekTests: XCTestCase {
     func testNotificationsForSmoothSeekAfterSeekWithinTimeRange() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -102,7 +102,7 @@ final class QueuePlayerSmoothSeekTests: XCTestCase {
     func testCompletionsForMultipleSeeks() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -131,7 +131,7 @@ final class QueuePlayerSmoothSeekTests: XCTestCase {
     func testCompletionsForMultipleSeeksEndingWithSmoothSeek() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)

--- a/Tests/PlayerTests/SeekTimePublisherTests.swift
+++ b/Tests/PlayerTests/SeekTimePublisherTests.swift
@@ -67,7 +67,7 @@ final class SeekTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         player.play()
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
@@ -85,7 +85,7 @@ final class SeekTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         player.play()
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time = CMTime(value: 1, timescale: 1)
         expectEqualPublished(

--- a/Tests/PlayerTests/SeekingPublisherTests.swift
+++ b/Tests/PlayerTests/SeekingPublisherTests.swift
@@ -66,4 +66,18 @@ final class SeekingPublisherTests: XCTestCase {
             player.seek(to: time2)
         }
     }
+
+    func testTargetSeekTimeWithMultipleSeeks() {
+        let item = AVPlayerItem(url: Stream.onDemand.url)
+        let player = QueuePlayer(playerItem: item)
+        expect(player.timeRange).toEventuallyNot(equal(.invalid))
+
+        let time1 = CMTime(value: 1, timescale: 1)
+        player.seek(to: time1)
+        expect(player.targetSeekTime).to(equal(time1))
+
+        let time2 = CMTime(value: 2, timescale: 1)
+        player.seek(to: time2)
+        expect(player.targetSeekTime).to(equal(time2))
+    }
 }

--- a/Tests/PlayerTests/SeekingPublisherTests.swift
+++ b/Tests/PlayerTests/SeekingPublisherTests.swift
@@ -53,7 +53,7 @@ final class SeekingPublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         player.play()
-        expect(item.timeRange).toEventuallyNot(beNil())
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
@@ -18,9 +18,8 @@ final class SmoothCurrentTimePublisherQueueTests: XCTestCase {
         let player = QueuePlayer(items: [item1, item2])
         expectPublished(
             values: [
-                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
-                .invalid
+                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.3),
@@ -37,9 +36,8 @@ final class SmoothCurrentTimePublisherQueueTests: XCTestCase {
         let player = QueuePlayer(items: [item1, item2, item3])
         expectPublished(
             values: [
-                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
-                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
-                .invalid
+                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
+                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.3),

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
@@ -18,7 +18,7 @@ final class SmoothCurrentTimePublisherQueueTests: XCTestCase {
         let player = QueuePlayer(items: [item1, item2])
         expectPublished(
             values: [
-                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
+                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .invalid
             ],
@@ -37,8 +37,8 @@ final class SmoothCurrentTimePublisherQueueTests: XCTestCase {
         let player = QueuePlayer(items: [item1, item2, item3])
         expectPublished(
             values: [
-                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
-                .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
+                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
+                .invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .invalid
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
@@ -25,7 +25,7 @@ final class SmoothCurrentTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(playerItem: item)
         expectPublished(
-            values: [.zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1), .invalid],
+            values: [.invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1), .invalid],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.1),
             during: 2
@@ -49,7 +49,7 @@ final class SmoothCurrentTimePublisherTests: XCTestCase {
         let player = QueuePlayer(playerItem: item)
         let publisher = player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1000), queue: .main)
         expectAtLeastPublished(
-            values: [.zero, CMTime(value: 1, timescale: 1000)],
+            values: [.invalid, .zero, CMTime(value: 1, timescale: 1000)],
             from: publisher,
             to: beClose(within: 0.3)
         ) {

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
@@ -15,7 +15,7 @@ final class SmoothCurrentTimePublisherTests: XCTestCase {
     func testEmpty() {
         let player = QueuePlayer()
         expectEqualPublished(
-            values: [.invalid],
+            values: [],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1), queue: .main),
             during: 2
         )
@@ -25,7 +25,7 @@ final class SmoothCurrentTimePublisherTests: XCTestCase {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(playerItem: item)
         expectPublished(
-            values: [.invalid, .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1), .invalid],
+            values: [.zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.1),
             during: 2
@@ -49,7 +49,7 @@ final class SmoothCurrentTimePublisherTests: XCTestCase {
         let player = QueuePlayer(playerItem: item)
         let publisher = player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1000), queue: .main)
         expectAtLeastPublished(
-            values: [.invalid, .zero, CMTime(value: 1, timescale: 1000)],
+            values: [.zero, CMTime(value: 1, timescale: 1000)],
             from: publisher,
             to: beClose(within: 0.3)
         ) {

--- a/Tests/PlayerTests/TimeTests.swift
+++ b/Tests/PlayerTests/TimeTests.swift
@@ -14,6 +14,7 @@ final class TimeTests: XCTestCase {
     func testClampedWithNonEmptyRange() {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 10, timescale: 1))
         expect(CMTime.zero.clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.invalid.clamped(to: range)).to(equal(.invalid))
         expect(CMTime(value: 1, timescale: 1).clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 5, timescale: 1).clamped(to: range)).to(equal(CMTime(value: 5, timescale: 1)))
         expect(CMTime(value: 10, timescale: 1).clamped(to: range)).to(equal(CMTime(value: 10, timescale: 1)))
@@ -23,7 +24,8 @@ final class TimeTests: XCTestCase {
     func testClampedWithNonEmptyRangeAndOffset() {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 10, timescale: 1))
         let offset = CMTime(value: 1, timescale: 10)
-        expect(CMTime.zero.clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.zero.clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.invalid.clamped(to: range, offset: offset)).to(equal(.invalid))
         expect(CMTime(value: 1, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 5, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 5, timescale: 1)))
         expect(CMTime(value: 10, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 99, timescale: 10)))
@@ -33,7 +35,8 @@ final class TimeTests: XCTestCase {
     func testClampedWithNonEmptyRangeAndLargeOffset() {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 10, timescale: 1))
         let offset = CMTime(value: 100, timescale: 1)
-        expect(CMTime.zero.clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.zero.clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.invalid.clamped(to: range, offset: offset)).to(equal(.invalid))
         expect(CMTime(value: 1, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 5, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 10, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
@@ -43,6 +46,7 @@ final class TimeTests: XCTestCase {
     func testClampedWithEmptyRange() {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 1, timescale: 1))
         expect(CMTime.zero.clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.invalid.clamped(to: range)).to(equal(.invalid))
         expect(CMTime(value: 1, timescale: 1).clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 5, timescale: 1).clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))
     }
@@ -51,7 +55,23 @@ final class TimeTests: XCTestCase {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 1, timescale: 1))
         let offset = CMTime(value: 1, timescale: 10)
         expect(CMTime.zero.clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(CMTime.invalid.clamped(to: range, offset: offset)).to(equal(.invalid))
         expect(CMTime(value: 1, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
         expect(CMTime(value: 5, timescale: 1).clamped(to: range, offset: offset)).to(equal(CMTime(value: 1, timescale: 1)))
+    }
+
+    func testClampedWithInvalidRange() {
+        let range = CMTimeRange.invalid
+        expect(CMTime.zero.clamped(to: range)).to(equal(.invalid))
+        expect(CMTime.invalid.clamped(to: range)).to(equal(.invalid))
+        expect(CMTime(value: 1, timescale: 1).clamped(to: range)).to(equal(.invalid))
+    }
+
+    func testClampedWithInvalidRangeAndOffset() {
+        let range = CMTimeRange.invalid
+        let offset = CMTime(value: 1, timescale: 10)
+        expect(CMTime.zero.clamped(to: range, offset: offset)).to(equal(.invalid))
+        expect(CMTime.invalid.clamped(to: range, offset: offset)).to(equal(.invalid))
+        expect(CMTime(value: 1, timescale: 1).clamped(to: range, offset: offset)).to(equal(.invalid))
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR fixes a few issues when skipping several times in a row:

- Position sometimes wrapping at the end (instead of sticking at the end).
- `ProgressTracker` progress sometimes briefly stuck at an incorrect position when skipping immediately after transitioning to a new item.

## Changes made

- Fixed `QueuePlayer` seek implementation and ensured that cases previously uncovered (e.g. smooth seeking vs. hard seeking behavior) are now correctly tested.
- Improved publisher contracts:
   - Almost all publishers now deliver their value immediately. This was not the case for time ranges, for which publishers could deliver older values, leading to issues after item transitions (and thus incorrect progress being calculated with a non-matching time range, so that progress would remain temporarily stuck at an incorrect value calculated based on the previous item range).
   - Current time publishers now work closer to their underlying time observers, i.e. they emit no initial time and no closing time after playlist exhaustion.
- Improved UI status reporting by providing a new `isBusy` property.
- Fix tvOS skip button icon display. Layout is still rough but should be better.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
