### PR TITLE
Improve skip behavior near the end of a stream

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -250,14 +250,13 @@ public extension Player {
         toleranceAfter: CMTime,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
+        assert(interval != .zero)
+        let endTolerance = CMTime(value: 1, timescale: 1)
         let currentTime = queuePlayer.targetSeekTime ?? time
-        let threshold = CMTime(value: 1, timescale: 1)
-        let isNearEnd = (currentTime >= timeRange.end - threshold)
-        let isIntervalLessThanThreshold = (threshold < interval)
-        let isWithinCriticalZone = (isNearEnd && isIntervalLessThanThreshold)
-        if !isWithinCriticalZone {
+        if interval < .zero || currentTime < timeRange.end - endTolerance {
             seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: true, completion: completion)
-        } else {
+        }
+        else {
             completion(true)
         }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -251,7 +251,15 @@ public extension Player {
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
         let currentTime = queuePlayer.targetSeekTime ?? time
-        seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: true, completion: completion)
+        let threshold = CMTime(value: 1, timescale: 1)
+        let isNearEnd = (currentTime >= timeRange.end - threshold)
+        let isIntervalLessThanThreshold = (threshold < interval)
+        let isWithinCriticalZone = (isNearEnd && isIntervalLessThanThreshold)
+        if !isWithinCriticalZone {
+            seek(to: currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: true, completion: completion)
+        } else {
+            completion(true)
+        }
     }
 }
 

--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -12,7 +12,7 @@ import Player
 import XCTest
 
 final class PlayerItemTests: XCTestCase {
-    func testURNPlaybackHLS() {
+    func testUrnPlaybackHLS() {
         let item = PlayerItem.urn("urn:rts:video:6820736")
         let player = Player(item: item)
         expectAtLeastEqualPublished(
@@ -24,7 +24,7 @@ final class PlayerItemTests: XCTestCase {
         )
     }
 
-    func testURNPlaybackMP3() {
+    func testUrnPlaybackMP3() {
         let item = PlayerItem.urn("urn:rsi:audio:8833144")
         let player = Player(item: item)
         expectAtLeastEqualPublished(
@@ -36,7 +36,7 @@ final class PlayerItemTests: XCTestCase {
         )
     }
 
-    func testURNPlaybackUnknown() {
+    func testUrnPlaybackUnknown() {
         let item = PlayerItem.urn("urn:srf:video:unknown")
         let player = Player(item: item)
         expectAtLeastEqualPublished(
@@ -54,7 +54,7 @@ final class PlayerItemTests: XCTestCase {
         )
     }
 
-    func testURNPlaybackNotAvailableAnymore() {
+    func testUrnPlaybackNotAvailableAnymore() {
         let item = PlayerItem.urn("urn:rts:video:13382911")
         let player = Player(item: item)
         expectAtLeastEqualPublished(

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -76,4 +76,41 @@ final class PlayerSkipForwardTests: XCTestCase {
             }
         }
     }
+
+    func testSkipForOnDemandInCriticalZone() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        expect(player.streamType).toEventually(equal(.onDemand))
+        expect(player.time).to(equal(.zero))
+        let seekTo = Stream.onDemand.duration - CMTime(value: 1, timescale: 1)
+
+        waitUntil { done in
+            player.seek(to: seekTo) { finished in
+                expect(finished).to(beTrue())
+            }
+
+            player.skipForward { _ in
+                expect(player.time).to(equal(seekTo, by: beClose(within: 0.1)))
+                done()
+            }
+        }
+    }
+
+    func testSkipForDvrInCriticalZone() {
+        let player = Player(item: .simple(url: Stream.dvr.url))
+        expect(player.streamType).toEventually(equal(.dvr))
+        let headTime = player.time
+        let seekTo = headTime - CMTime(value: 1, timescale: 1)
+
+        waitUntil { done in
+            player.seek(to: seekTo) { finished in
+                expect(finished).to(beTrue())
+            }
+
+            player.skipForward { finished in
+                expect(player.time).to(equal(seekTo, by: beClose(within: 0.1)))
+                expect(finished).to(beTrue())
+                done()
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to skip forward repeatedly without the stream being blocked when we reach the end of the stream.

## Changes made

- A threshold of 1 second has been added to avoid seeking in the last second.
- This behaviour is enabled only for the forward skipping.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
