### PR TITLE
Retry target seek until it finishes

### DIFF
--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -99,10 +99,15 @@ class QueuePlayer: AVQueuePlayer {
                 enqueue(seek: targetSeek, completion: completion)
             }
         }
-        else {
+        else if finished {
             completion()
             seek.completionHandler(finished)
             pendingSeeks.removeAll()
+        }
+        else {
+            // Sometimes the target seek might fail for no reason, especially when seeking near the stream end.
+            // In such cases retry.
+            enqueue(seek: seek, completion: completion)
         }
     }
 


### PR DESCRIPTION
# Pull request

## Description

This PR fixes an issue with `AVQueuePlayer` sometimes never finishing a target seek.

## Changes made

- Fix the issue.
- No unit test since very hard to reproduce reliably in an automated test.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
