### PR TITLE
Introduce syntactic sugar for expressing times and tolerances

### DIFF
--- a/Sources/Player/Position.swift
+++ b/Sources/Player/Position.swift
@@ -58,7 +58,6 @@ public func before(_ time: CMTime) -> Position {
 /// An approximate position, but always located after the specified time.
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
-
 public func after(_ time: CMTime) -> Position {
     .init(time: time, toleranceBefore: .zero, toleranceAfter: .positiveInfinity)
 }

--- a/Sources/Player/Position.swift
+++ b/Sources/Player/Position.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import CoreMedia
+
+/// Describes a position to reach.
+public struct Position {
+    /// The time to reach.
+    public let time: CMTime
+
+    /// The tolerance allowed before the time to reach.
+    public let toleranceBefore: CMTime
+
+    /// The tolerance allowed after the time to reach.
+    public let toleranceAfter: CMTime
+
+    fileprivate init(time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) {
+        self.time = time
+        self.toleranceBefore = toleranceBefore
+        self.toleranceAfter = toleranceAfter
+    }
+}
+
+/// A position with explicitly associated tolerances.
+/// - Parameters:
+///   - time: The time to reach.
+///   - toleranceBefore: The tolerance allowed before the time to reach.
+///   - toleranceAfter: The tolerance allowed after the time to reach.
+/// - Returns: A position.
+public func to(_ time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) -> Position {
+    .init(time: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
+}
+
+/// A precise position.
+/// - Parameter time: The time to reach.
+/// - Returns: A position.
+public func at(_ time: CMTime) -> Position {
+    .init(time: time, toleranceBefore: .zero, toleranceAfter: .zero)
+}
+
+/// An approximate position.
+/// - Parameter time: The time to reach.
+/// - Returns: A position.
+public func near(_ time: CMTime) -> Position {
+    .init(time: time, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity)
+}
+
+/// An approximate position, but always located before the specified time.
+/// - Parameter time: The time to reach.
+/// - Returns: A position.
+public func before(_ time: CMTime) -> Position {
+    .init(time: time, toleranceBefore: .positiveInfinity, toleranceAfter: .zero)
+}
+
+/// An approximate position, but always located after the specified time.
+/// - Parameter time: The time to reach.
+/// - Returns: A position.
+
+public func after(_ time: CMTime) -> Position {
+    .init(time: time, toleranceBefore: .zero, toleranceAfter: .positiveInfinity)
+}

--- a/Sources/Player/ProgressTracker.swift
+++ b/Sources/Player/ProgressTracker.swift
@@ -109,7 +109,7 @@ public final class ProgressTracker: ObservableObject {
 
     private func seek(to progress: Float) {
         guard let player, let time = time(forProgress: progress) else { return }
-        player.seek(to: time, smooth: true)
+        player.seek(near(time), smooth: true)
     }
 
     private func time(forProgress progress: Float?) -> CMTime? {

--- a/Tests/PlayerTests/BackwardNavigationTests.swift
+++ b/Tests/PlayerTests/BackwardNavigationTests.swift
@@ -29,7 +29,7 @@ final class BackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { _ in
                 done()
             }
         }
@@ -54,7 +54,7 @@ final class BackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 5, timescale: 1))) { _ in
                 done()
             }
         }
@@ -124,7 +124,7 @@ final class BackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { _ in
                 done()
             }
         }
@@ -152,7 +152,7 @@ final class BackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 5, timescale: 1))) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/PlayerSeekTests.swift
+++ b/Tests/PlayerTests/PlayerSeekTests.swift
@@ -15,7 +15,7 @@ final class PlayerSeekTests: XCTestCase {
     func testSeekWhenEmpty() {
         let player = Player()
         waitUntil { done in
-            player.seek(to: .zero) { finished in
+            player.seek(near(.zero)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -26,7 +26,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         waitUntil { done in
-            player.seek(to: CMTimeMultiplyByFloat64(Stream.onDemand.duration, multiplier: 0.5)) { finished in
+            player.seek(near(CMTimeMultiplyByFloat64(Stream.onDemand.duration, multiplier: 0.5))) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -37,7 +37,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.live.url))
         expect(player.streamType).toEventually(equal(.live))
         waitUntil { done in
-            player.seek(to: .zero) { finished in
+            player.seek(near(.zero)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -48,7 +48,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         waitUntil { done in
-            player.seek(to: player.timeRange.start) { finished in
+            player.seek(near(player.timeRange.start)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -59,7 +59,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         waitUntil { done in
-            player.seek(to: player.timeRange.end) { finished in
+            player.seek(near(player.timeRange.end)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -70,7 +70,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         waitUntil { done in
-            player.seek(to: CMTime(value: -10, timescale: 1)) { finished in
+            player.seek(near(CMTime(value: -10, timescale: 1))) { finished in
                 expect(finished).to(beTrue())
                 expect(player.time).to(equal(.zero))
                 done()
@@ -82,7 +82,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         waitUntil { done in
-            player.seek(to: player.timeRange.end + CMTime(value: 10, timescale: 1)) { finished in
+            player.seek(near(player.timeRange.end + CMTime(value: 10, timescale: 1))) { finished in
                 expect(finished).to(beTrue())
                 expect(player.time).to(equal(player.timeRange.end, by: beClose(within: player.chunkDuration.seconds)))
                 done()
@@ -94,7 +94,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.play()
-        player.seek(to: CMTime(value: -10, timescale: 1))
+        player.seek(near(CMTime(value: -10, timescale: 1)))
         expect(player.time).toAlways(beGreaterThanOrEqualTo(player.timeRange.start))
     }
 
@@ -102,7 +102,7 @@ final class PlayerSeekTests: XCTestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.play()
-        player.seek(to: player.timeRange.end + CMTime(value: 10, timescale: 1))
+        player.seek(near(player.timeRange.end + CMTime(value: 10, timescale: 1)))
         expect(player.time).toAlways(beLessThanOrEqualTo(player.timeRange.end))
     }
 }

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -84,7 +84,7 @@ final class PlayerSkipForwardTests: XCTestCase {
         let seekTo = Stream.onDemand.duration - CMTime(value: 1, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: seekTo, toleranceBefore: .zero, toleranceAfter: .zero) { finished in
+            player.seek(at(seekTo)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }
@@ -102,7 +102,7 @@ final class PlayerSkipForwardTests: XCTestCase {
         let seekTo = Stream.onDemand.duration - CMTime(value: 1, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: seekTo, toleranceBefore: .zero, toleranceAfter: .zero) { finished in
+            player.seek(at(seekTo)) { finished in
                 expect(finished).to(beTrue())
                 done()
             }

--- a/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
@@ -40,7 +40,7 @@ final class PlayerSkipToDefaultChecksTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.dvr))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
@@ -76,7 +76,7 @@ final class PlayerSkipToDefaultTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.dvr))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { finished in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { finished in
                 expect(finished).to(beTrue())
                 done()
             }

--- a/Tests/PlayerTests/PositionTests.swift
+++ b/Tests/PlayerTests/PositionTests.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import CoreMedia
+import Nimble
+import XCTest
+
+final class PositionTests: XCTestCase {
+    func testPositionTo() {
+        let position = to(CMTime(value: 1, timescale: 1), toleranceBefore: CMTime(value: 2, timescale: 1), toleranceAfter: CMTime(value: 3, timescale: 1))
+        expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(position.toleranceBefore).to(equal(CMTime(value: 2, timescale: 1)))
+        expect(position.toleranceAfter).to(equal(CMTime(value: 3, timescale: 1)))
+    }
+
+    func testPositionAt() {
+        let position = at(CMTime(value: 1, timescale: 1))
+        expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(position.toleranceBefore).to(equal(.zero))
+        expect(position.toleranceAfter).to(equal(.zero))
+    }
+
+    func testPositionNear() {
+        let position = near(CMTime(value: 1, timescale: 1))
+        expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(position.toleranceBefore).to(equal(.positiveInfinity))
+        expect(position.toleranceAfter).to(equal(.positiveInfinity))
+    }
+
+    func testPositionBefore() {
+        let position = before(CMTime(value: 1, timescale: 1))
+        expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(position.toleranceBefore).to(equal(.positiveInfinity))
+        expect(position.toleranceAfter).to(equal(.zero))
+    }
+
+    func testPositionAfter() {
+        let position = after(CMTime(value: 1, timescale: 1))
+        expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))
+        expect(position.toleranceBefore).to(equal(.zero))
+        expect(position.toleranceAfter).to(equal(.positiveInfinity))
+    }
+}

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -123,7 +123,7 @@ final class ProgressTrackerProgressAvailabilityTests: XCTestCase {
         let time = CMTime(value: 20, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(time)) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressTests.swift
@@ -127,7 +127,7 @@ final class ProgressTrackerProgressTests: XCTestCase {
         let time = CMTime(value: 20, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(time)) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -123,7 +123,7 @@ final class ProgressTrackerRangeTests: XCTestCase {
         let time = CMTime(value: 20, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(time)) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -142,7 +142,7 @@ final class ProgressTrackerTimeTests: XCTestCase {
         let time = CMTime(value: 20, timescale: 1)
 
         waitUntil { done in
-            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(time)) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/SmartBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartBackwardNavigationTests.swift
@@ -25,7 +25,7 @@ final class SmartBackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { _ in
                 done()
             }
         }
@@ -50,7 +50,7 @@ final class SmartBackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 5, timescale: 1))) { _ in
                 done()
             }
         }
@@ -120,7 +120,7 @@ final class SmartBackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 1, timescale: 1))) { _ in
                 done()
             }
         }
@@ -148,7 +148,7 @@ final class SmartBackwardNavigationTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
 
         waitUntil { done in
-            player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in
+            player.seek(at(CMTime(value: 5, timescale: 1))) { _ in
                 done()
             }
         }


### PR DESCRIPTION
# Pull request

## Description

This PR adds syntactic sugar to express positions to reach in an expressive manner.

## Changes made

- Add `Position` and ergonomic helpers.
- Note that the low-level `AVQueuePlayer` API was not updated to use positions. This is more consistent with the original API and makes it easier for us to spot when we are using the top-level `Player` API or its low-level `AVQueuePlayer` counterpart.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
