### PR TITLE
Use more tolerant Nimble defaults

### DIFF
--- a/Tests/PlayerTests/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayerItemTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class AVPlayerItemTests: XCTestCase {
     func testNonLoadedItem() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
-        expect(item.timeRange).toAlways(equal(.invalid))
+        expect(item.timeRange).toAlways(equal(.invalid), until: .seconds(1))
     }
 
     func testOnDemand() {

--- a/Tests/PlayerTests/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayerItemTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class AVPlayerItemTests: XCTestCase {
+final class AVPlayerItemTests: TestCase {
     func testNonLoadedItem() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         expect(item.timeRange).toAlways(equal(.invalid), until: .seconds(1))

--- a/Tests/PlayerTests/AVPlayerTests.swift
+++ b/Tests/PlayerTests/AVPlayerTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class AVPlayerTests: XCTestCase {
+final class AVPlayerTests: TestCase {
     func testTimeRangeWhenEmpty() {
         let player = AVPlayer()
         expect(player.timeRange).to(equal(.invalid))

--- a/Tests/PlayerTests/AssetPublishersTests.swift
+++ b/Tests/PlayerTests/AssetPublishersTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class AssetPublishersTests: XCTestCase {
+final class AssetPublishersTests: TestCase {
     func testFetch() throws {
         let asset = AVURLAsset(url: Stream.onDemand.url)
         let duration = try waitForSingleOutput(from: asset.propertyPublisher(.duration))

--- a/Tests/PlayerTests/AssetTests.swift
+++ b/Tests/PlayerTests/AssetTests.swift
@@ -12,7 +12,7 @@ import Combine
 import Nimble
 import XCTest
 
-final class AssetTests: XCTestCase {
+final class AssetTests: TestCase {
     func testSimpleEquality() {
         expect(Asset.simple(url: Stream.dvr.url)).to(equal(.simple(url: Stream.dvr.url)))
         expect(Asset.simple(url: Stream.live.url)).notTo(equal(.simple(url: Stream.dvr.url)))

--- a/Tests/PlayerTests/BackwardNavigationTests.swift
+++ b/Tests/PlayerTests/BackwardNavigationTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class BackwardNavigationTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class BackwardNavigationTests: TestCase {
     private static func configuration() -> PlayerConfiguration {
         .init(smartNavigationEnabled: false)
     }

--- a/Tests/PlayerTests/BackwardNavigationTests.swift
+++ b/Tests/PlayerTests/BackwardNavigationTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class BackwardNavigationTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     private static func configuration() -> PlayerConfiguration {
         .init(smartNavigationEnabled: false)
     }

--- a/Tests/PlayerTests/BoundaryTimePublisherTests.swift
+++ b/Tests/PlayerTests/BoundaryTimePublisherTests.swift
@@ -12,7 +12,7 @@ import Combine
 import Nimble
 import XCTest
 
-final class BoundaryTimePublisherTests: XCTestCase {
+final class BoundaryTimePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectNothingPublished(

--- a/Tests/PlayerTests/BufferingPublisherQueueTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherQueueTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class BufferingPublisherQueueTests: XCTestCase {
+final class BufferingPublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/BufferingPublisherTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class BufferingPublisherTests: XCTestCase {
+final class BufferingPublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectEqualPublished(

--- a/Tests/PlayerTests/ChunkDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ChunkDurationPublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ChunkDurationPublisherTests: XCTestCase {
+final class ChunkDurationPublisherTests: TestCase {
     func testChunkDuration() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/ForwardNavigationTests.swift
+++ b/Tests/PlayerTests/ForwardNavigationTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class ForwardNavigationTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCanAdvanceForOnDemandWithNextItem() {
         let item1 = PlayerItem.simple(url: Stream.onDemand.url)
         let item2 = PlayerItem.simple(url: Stream.live.url)

--- a/Tests/PlayerTests/ForwardNavigationTests.swift
+++ b/Tests/PlayerTests/ForwardNavigationTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ForwardNavigationTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class ForwardNavigationTests: TestCase {
     func testCanAdvanceForOnDemandWithNextItem() {
         let item1 = PlayerItem.simple(url: Stream.onDemand.url)
         let item2 = PlayerItem.simple(url: Stream.live.url)

--- a/Tests/PlayerTests/ItemBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/ItemBackwardNavigationTests.swift
@@ -36,7 +36,7 @@ final class ItemBackwardNavigationTests: XCTestCase {
         let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let player = Player(items: [item1, item2, item3])
         player.advanceToNextItem()
-        expect(player.canReturnToPreviousItem()).toAlways(beTrue(), until: .milliseconds(500))
+        expect(player.canReturnToPreviousItem()).toAlways(beTrue(), until: .seconds(1))
     }
 
     func testReturnToPreviousItem() {

--- a/Tests/PlayerTests/ItemBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/ItemBackwardNavigationTests.swift
@@ -9,7 +9,7 @@
 import Nimble
 import XCTest
 
-final class ItemBackwardNavigationTests: XCTestCase {
+final class ItemBackwardNavigationTests: TestCase {
     func testCanReturnToPreviousItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemBufferingPublisherTests.swift
+++ b/Tests/PlayerTests/ItemBufferingPublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemBufferingPublisherTests: XCTestCase {
+final class ItemBufferingPublisherTests: TestCase {
     func testLoaded() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemDurationPublisherQueueTests: XCTestCase {
+final class ItemDurationPublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/ItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemDurationPublisherTests: XCTestCase {
+final class ItemDurationPublisherTests: TestCase {
     func testDuration() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/ItemForwardNavigationTests.swift
+++ b/Tests/PlayerTests/ItemForwardNavigationTests.swift
@@ -9,7 +9,7 @@
 import Nimble
 import XCTest
 
-final class ItemForwardNavigationTests: XCTestCase {
+final class ItemForwardNavigationTests: TestCase {
     func testCanAdvanceToNextItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemInsertionAfterTests.swift
+++ b/Tests/PlayerTests/ItemInsertionAfterTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemInsertionAfterTests: XCTestCase {
+final class ItemInsertionAfterTests: TestCase {
     func testInsertItemAfterNextItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemInsertionBeforeTests.swift
+++ b/Tests/PlayerTests/ItemInsertionBeforeTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemInsertionBeforeTests: XCTestCase {
+final class ItemInsertionBeforeTests: TestCase {
     func testInsertItemBeforeNextItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemMoveAfterTests.swift
+++ b/Tests/PlayerTests/ItemMoveAfterTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemMoveAfterTests: XCTestCase {
+final class ItemMoveAfterTests: TestCase {
     func testMovePreviousItemAfterNextItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemMoveBeforeTests.swift
+++ b/Tests/PlayerTests/ItemMoveBeforeTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemMoveBeforeTests: XCTestCase {
+final class ItemMoveBeforeTests: TestCase {
     func testMovePreviousItemBeforeNextItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemRemovalTests.swift
+++ b/Tests/PlayerTests/ItemRemovalTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemRemovalTests: XCTestCase {
+final class ItemRemovalTests: TestCase {
     func testRemovePreviousItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemStatePublisherQueueTests: XCTestCase {
+final class ItemStatePublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)

--- a/Tests/PlayerTests/ItemStatePublisherTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemStatePublisherTests: XCTestCase {
+final class ItemStatePublisherTests: TestCase {
     // swiftlint:disable:next weak_delegate
     private let resourceLoaderDelegate = FailingResourceLoaderDelegate()
 

--- a/Tests/PlayerTests/ItemStateTests.swift
+++ b/Tests/PlayerTests/ItemStateTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemStateTests: XCTestCase {
+final class ItemStateTests: TestCase {
     func testEquality() {
         expect(ItemState.unknown).to(equal(.unknown))
         expect(ItemState.readyToPlay).to(equal(.readyToPlay))

--- a/Tests/PlayerTests/ItemTests.swift
+++ b/Tests/PlayerTests/ItemTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemTests: XCTestCase {
+final class ItemTests: TestCase {
     func testItemsOnFirstItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemTimeRangePublisherQueueTests: XCTestCase {
+final class ItemTimeRangePublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemTimeRangePublisherTests: XCTestCase {
+final class ItemTimeRangePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectEqualPublished(

--- a/Tests/PlayerTests/ItemUpdateTests.swift
+++ b/Tests/PlayerTests/ItemUpdateTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class ItemUpdateTests: XCTestCase {
+final class ItemUpdateTests: TestCase {
     func testUpdateWithCurrentItem() {
         let item1 = PlayerItem.simple(url: Stream.item(numbered: 1).url)
         let item2 = PlayerItem.simple(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/NowPlayingInfoMetadataPublisherTests.swift
+++ b/Tests/PlayerTests/NowPlayingInfoMetadataPublisherTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import MediaPlayer
 import XCTest
 
-final class NowPlayingInfoMetadataPublisherTests: XCTestCase {
+final class NowPlayingInfoMetadataPublisherTests: TestCase {
     func testEmpty() {
         let player = Player()
         expectAtLeastSimilarPublished(

--- a/Tests/PlayerTests/PeriodicTimePublisherTests.swift
+++ b/Tests/PlayerTests/PeriodicTimePublisherTests.swift
@@ -12,7 +12,7 @@ import Combine
 import Nimble
 import XCTest
 
-final class PeriodicTimePublisherTests: XCTestCase {
+final class PeriodicTimePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectPublished(

--- a/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class PlaybackStatePublisherQueueTests: XCTestCase {
+final class PlaybackStatePublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)

--- a/Tests/PlayerTests/PlaybackStatePublisherTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class PlaybackStatePublisherTests: XCTestCase {
+final class PlaybackStatePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
         expectEqualPublished(values: [.idle], from: player.playbackStatePublisher(), during: 2)

--- a/Tests/PlayerTests/PlaybackStateTests.swift
+++ b/Tests/PlayerTests/PlaybackStateTests.swift
@@ -10,7 +10,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class PlaybackStateTests: XCTestCase {
+final class PlaybackStateTests: TestCase {
     func testEquality() {
         expect(PlaybackState.idle).to(equal(.idle))
         expect(PlaybackState.playing).to(equal(.playing))

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -9,7 +9,7 @@
 import Nimble
 import XCTest
 
-final class PlayerConfigurationTests: XCTestCase {
+final class PlayerConfigurationTests: TestCase {
     func testPlayerConfigurationDefaultValues() {
         let configuration = PlayerConfiguration()
         let player = Player(configuration: configuration)

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerCurrentIndexTests: XCTestCase {
+final class PlayerCurrentIndexTests: TestCase {
     func testCurrentIndex() {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class PlayerItemDurationPublisherTests: XCTestCase {
+final class PlayerItemDurationPublisherTests: TestCase {
     func testDuration() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/PlayerItemPublishersTests.swift
+++ b/Tests/PlayerTests/PlayerItemPublishersTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class PlayerItemPublishersTests: XCTestCase {
+final class PlayerItemPublishersTests: TestCase {
     func testValidItemStateWithoutPlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         _ = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Circumspect
 import XCTest
 
-final class ItemStreamTypePublisherTests: XCTestCase {
+final class ItemStreamTypePublisherTests: TestCase {
     func testOnDemand() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)

--- a/Tests/PlayerTests/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItemTests.swift
@@ -12,7 +12,7 @@ import Combine
 import Nimble
 import XCTest
 
-final class PlayerItemsTests: XCTestCase {
+final class PlayerItemsTests: TestCase {
     func testGenericItem() {
         let publisher = Just(Asset.simple(url: Stream.onDemand.url))
         let item = PlayerItem(publisher: publisher)

--- a/Tests/PlayerTests/PlayerSeekChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSeekChecksTests.swift
@@ -10,12 +10,7 @@ import AVFoundation
 import Nimble
 import XCTest
 
-final class PlayerSeekChecksTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSeekChecksTests: TestCase {
     func testCannotSeekWithEmptyPlayer() {
         let player = Player()
         expect(player.canSeek(to: .zero)).to(beFalse())

--- a/Tests/PlayerTests/PlayerSeekChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSeekChecksTests.swift
@@ -11,6 +11,11 @@ import Nimble
 import XCTest
 
 final class PlayerSeekChecksTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCannotSeekWithEmptyPlayer() {
         let player = Player()
         expect(player.canSeek(to: .zero)).to(beFalse())

--- a/Tests/PlayerTests/PlayerSeekTests.swift
+++ b/Tests/PlayerTests/PlayerSeekTests.swift
@@ -100,7 +100,7 @@ final class PlayerSeekTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
         player.play()
         player.seek(near(CMTime(value: -10, timescale: 1)))
-        expect(player.time).toAlways(beGreaterThanOrEqualTo(player.timeRange.start))
+        expect(player.time).toAlways(beGreaterThanOrEqualTo(player.timeRange.start), until: .seconds(1))
     }
 
     func testTimesDuringSeekAfterTimeRangeEnd() {

--- a/Tests/PlayerTests/PlayerSeekTests.swift
+++ b/Tests/PlayerTests/PlayerSeekTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSeekTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testSeekWhenEmpty() {
         let player = Player()
         waitUntil { done in
@@ -103,6 +108,6 @@ final class PlayerSeekTests: XCTestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
         player.play()
         player.seek(near(player.timeRange.end + CMTime(value: 10, timescale: 1)))
-        expect(player.time).toAlways(beLessThanOrEqualTo(player.timeRange.end))
+        expect(player.time).toAlways(beLessThanOrEqualTo(player.timeRange.end), until: .seconds(1))
     }
 }

--- a/Tests/PlayerTests/PlayerSeekTests.swift
+++ b/Tests/PlayerTests/PlayerSeekTests.swift
@@ -11,12 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class PlayerSeekTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSeekTests: TestCase {
     func testSeekWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipBackwardChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipBackwardChecksTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipBackwardChecksTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipBackward()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipBackwardChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipBackwardChecksTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipBackwardChecksTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipBackwardChecksTests: TestCase {
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipBackward()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipBackwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipBackwardTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipBackwardTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipBackwardTests: TestCase {
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipBackwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipBackwardTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipBackwardTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipForwardChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardChecksTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipForwardChecksTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipForward()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipForwardChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardChecksTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipForwardChecksTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipForwardChecksTests: TestCase {
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipForward()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipForwardTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipForwardTests: TestCase {
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipForwardTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipToDefaultChecksTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipToDefaultChecksTests: TestCase {
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipToDefault()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultChecksTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipToDefaultChecksTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCannotSkipWhenEmpty() {
         let player = Player()
         expect(player.canSkipToDefault()).to(beFalse())

--- a/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
@@ -11,6 +11,11 @@ import Nimble
 import XCTest
 
 final class PlayerSkipToDefaultTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
+++ b/Tests/PlayerTests/PlayerSkipToDefaultTests.swift
@@ -10,12 +10,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerSkipToDefaultTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class PlayerSkipToDefaultTests: TestCase {
     func testSkipWhenEmpty() {
         let player = Player()
         waitUntil { done in

--- a/Tests/PlayerTests/PlayerTests.swift
+++ b/Tests/PlayerTests/PlayerTests.swift
@@ -11,7 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PlayerTests: XCTestCase {
+final class PlayerTests: TestCase {
     func testConstants() {
         expect(Player.startTimeThreshold).to(equal(3))
     }

--- a/Tests/PlayerTests/PlayerTests.swift
+++ b/Tests/PlayerTests/PlayerTests.swift
@@ -36,7 +36,7 @@ final class PlayerTests: TestCase {
         let player = Player(item: .simple(url: Stream.live.url))
         expect(player.timeRange).toEventuallyNot(equal(.invalid))
         player.play()
-        expect(player.time).toNever(equal(.invalid))
+        expect(player.time).toNever(equal(.invalid), until: .seconds(1))
     }
 
     func testTimesStayInRange() {
@@ -52,6 +52,6 @@ final class PlayerTests: TestCase {
     func testStabilityAtStart() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
-        expect(player.streamType).toNever(equal(.dvr), pollInterval: .microseconds(1))
+        expect(player.streamType).toNever(equal(.dvr), until: .seconds(1), pollInterval: .microseconds(1))
     }
 }

--- a/Tests/PlayerTests/PlayerTests.swift
+++ b/Tests/PlayerTests/PlayerTests.swift
@@ -29,7 +29,7 @@ final class PlayerTests: XCTestCase {
 
     func testTimesWhenEmpty() {
         let player = Player()
-        expect(player.time).toAlways(equal(.invalid))
+        expect(player.time).toAlways(equal(.invalid), until: .seconds(1))
     }
 
     func testTimesInEmptyRange() {

--- a/Tests/PlayerTests/PositionTests.swift
+++ b/Tests/PlayerTests/PositionTests.swift
@@ -10,7 +10,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class PositionTests: XCTestCase {
+final class PositionTests: TestCase {
     func testPositionTo() {
         let position = to(CMTime(value: 1, timescale: 1), toleranceBefore: CMTime(value: 2, timescale: 1), toleranceAfter: CMTime(value: 3, timescale: 1))
         expect(position.time).to(equal(CMTime(value: 1, timescale: 1)))

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerProgressAvailabilityTests: XCTestCase {
+final class ProgressTrackerProgressAvailabilityTests: TestCase {
     func testForUnboundTracker() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerProgressTests: XCTestCase {
+final class ProgressTrackerProgressTests: TestCase {
     func testForUnboundTracker() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerRangeTests: XCTestCase {
+final class ProgressTrackerRangeTests: TestCase {
     func testForUnboundTracker() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerSeekBehaviorTests: XCTestCase {
+final class ProgressTrackerSeekBehaviorTests: TestCase {
     func testImmediateSeek() {
         let progressTracker = ProgressTracker(
             interval: CMTime(value: 1, timescale: 4),

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -12,7 +12,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerTimeTests: XCTestCase {
+final class ProgressTrackerTimeTests: TestCase {
     func testForUnboundTracker() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerValueTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerValueTests.swift
@@ -10,7 +10,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class ProgressTrackerValueTests: XCTestCase {
+final class ProgressTrackerValueTests: TestCase {
     func testProgressValueInRange() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/QueuePlayerItemTests.swift
+++ b/Tests/PlayerTests/QueuePlayerItemTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class QueuePlayerItemTests: XCTestCase {
+final class QueuePlayerItemTests: TestCase {
     func testReplaceItemsWithEmptyList() {
         let item1 = AVPlayerItem(url: Stream.item(numbered: 1).url)
         let item2 = AVPlayerItem(url: Stream.item(numbered: 2).url)

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -21,7 +21,7 @@ private class QueuePlayerMock: QueuePlayer {
     }
 }
 
-final class QueuePlayerSeekTests: XCTestCase {
+final class QueuePlayerSeekTests: TestCase {
     func testNotificationsForSeekWithInvalidTime() {
         guard nimbleThrowAssertionsEnabled() else { return }
         let item = AVPlayerItem(url: Stream.onDemand.url)

--- a/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
@@ -12,7 +12,7 @@ import Nimble
 import OrderedCollections
 import XCTest
 
-final class QueuePlayerSmoothSeekTests: XCTestCase {
+final class QueuePlayerSmoothSeekTests: TestCase {
     func testNotificationsForSeekWithEmptyPlayer() {
         let player = QueuePlayer()
         expect {

--- a/Tests/PlayerTests/SeekTimePublisherTests.swift
+++ b/Tests/PlayerTests/SeekTimePublisherTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class SeekTimePublisherTests: XCTestCase {
+final class SeekTimePublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
         expectEqualPublished(

--- a/Tests/PlayerTests/SeekingPublisherTests.swift
+++ b/Tests/PlayerTests/SeekingPublisherTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class SeekingPublisherTests: XCTestCase {
+final class SeekingPublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
         expectEqualPublished(

--- a/Tests/PlayerTests/SmartBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartBackwardNavigationTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class SmartBackwardNavigationTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCanReturnForOnDemandAtBeginningWithoutPreviousItem() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)

--- a/Tests/PlayerTests/SmartBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartBackwardNavigationTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class SmartBackwardNavigationTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class SmartBackwardNavigationTests: TestCase {
     func testCanReturnForOnDemandAtBeginningWithoutPreviousItem() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)

--- a/Tests/PlayerTests/SmartForwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartForwardNavigationTests.swift
@@ -12,6 +12,11 @@ import Nimble
 import XCTest
 
 final class SmartForwardNavigationTests: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.pollInterval = .milliseconds(10)
+    }
+
     func testCanAdvanceForOnDemandWithNextItem() {
         let item1 = PlayerItem.simple(url: Stream.onDemand.url)
         let item2 = PlayerItem.simple(url: Stream.live.url)

--- a/Tests/PlayerTests/SmartForwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartForwardNavigationTests.swift
@@ -11,12 +11,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class SmartForwardNavigationTests: XCTestCase {
-    override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
-        AsyncDefaults.pollInterval = .milliseconds(10)
-    }
-
+final class SmartForwardNavigationTests: TestCase {
     func testCanAdvanceForOnDemandWithNextItem() {
         let item1 = PlayerItem.simple(url: Stream.onDemand.url)
         let item2 = PlayerItem.simple(url: Stream.live.url)

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class SmoothCurrentTimePublisherQueueTests: XCTestCase {
+final class SmoothCurrentTimePublisherQueueTests: TestCase {
     func testItems() {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class SmoothCurrentTimePublisherTests: XCTestCase {
+final class SmoothCurrentTimePublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
         expectEqualPublished(

--- a/Tests/PlayerTests/SourceTests.swift
+++ b/Tests/PlayerTests/SourceTests.swift
@@ -11,7 +11,7 @@ import Circumspect
 import Nimble
 import XCTest
 
-final class SourceTests: XCTestCase {
+final class SourceTests: TestCase {
     func testSourceEquality() {
         expect(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))).to(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))
         expect(Source(id: UUID("1"), asset: .simple(url: Stream.live.url))).notTo(equal(Source(id: UUID("1"), asset: .simple(url: Stream.dvr.url))))

--- a/Tests/PlayerTests/StreamTypeTests.swift
+++ b/Tests/PlayerTests/StreamTypeTests.swift
@@ -10,7 +10,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class StreamTypeTests: XCTestCase {
+final class StreamTypeTests: TestCase {
     func testUnknown() {
         let streamType = StreamType(for: .invalid, itemDuration: .invalid)
         expect(streamType).to(equal(.unknown))

--- a/Tests/PlayerTests/TestCase.swift
+++ b/Tests/PlayerTests/TestCase.swift
@@ -7,6 +7,8 @@
 import Nimble
 import XCTest
 
+/// A simple test suite with more tolerant Nimble settings. Beware that `toAlways` and `toNever` expectations appearing
+/// in tests will use the same value by default and should likely always provide an explicit `until` parameter.
 class TestCase: XCTestCase {
     override class func setUp() {
         AsyncDefaults.timeout = .seconds(10)

--- a/Tests/PlayerTests/TestCase.swift
+++ b/Tests/PlayerTests/TestCase.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Nimble
+import XCTest
+
+class TestCase: XCTestCase {
+    override class func setUp() {
+        AsyncDefaults.timeout = .seconds(10)
+    }
+
+    override class func tearDown() {
+        AsyncDefaults.timeout = .seconds(1)
+    }
+}

--- a/Tests/PlayerTests/TimeTests.swift
+++ b/Tests/PlayerTests/TimeTests.swift
@@ -10,7 +10,7 @@ import CoreMedia
 import Nimble
 import XCTest
 
-final class TimeTests: XCTestCase {
+final class TimeTests: TestCase {
     func testClampedWithNonEmptyRange() {
         let range = CMTimeRange(start: CMTime(value: 1, timescale: 1), end: CMTime(value: 10, timescale: 1))
         expect(CMTime.zero.clamped(to: range)).to(equal(CMTime(value: 1, timescale: 1)))

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -77,8 +77,7 @@ In the general project settings:
 2. Disable _Allow rebase merging_.
 3. Enable _Allow squash merging_ with _Default to pull request title_.
 4. Enable _Always suggest updating pull request branches_.
-5. Enable _Allow auto-merge_.
-6. Enable _Automatically delete head branches_.
+5. Enable _Automatically delete head branches_.
 
 ## Continuous integration user
 


### PR DESCRIPTION
# Pull request

## Description

This PR mitigates CI reliability issues by setting looser timings for player test suites. Our CI agents are namely sometimes a bit slower than our development Macs which makes tests failing after 1 second (the default Nimble timeout) flaky when run on our CI.

## Changes made

- Introduce a `TestCase` class for player tests, using a more tolerant timeout (10 seconds).
- Updated all `toAlways` and `toNever` call sites to use an explicit timeout, as this value is the same as for `toEventually`. We should propose a PR to Nimble to have separate constants since they serve different purposes.
- Approaches mentioned in [Nimble documnentation](https://github.com/Quick/Nimble#changing-default-timeout-and-poll-intervals) cannot sadly be applied since we are neither using Quick nor packaging the test bundle ourselves (SPM does it for us).
- Test suites for other packages have been left untouched.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
