### PR TITLE
Display version information in the demo settings

### DIFF
--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -26,12 +26,19 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicyKey)
     private var audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
 
+    private var version: String {
+        Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
+    }
+
+    private var buildVersion: String {
+        Bundle.main.infoDictionary!["CFBundleVersion"] as! String
+    }
+
     var body: some View {
         List {
             applicationSection()
             playerSection()
             debuggingSection()
-            versionSection()
         }
         .navigationTitle("Settings")
     }
@@ -65,9 +72,13 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func debuggingSection() -> some View {
-        Section("Debugging") {
+        Section {
             Button("Simulate memory warning", action: simulateMemoryWarning)
             Button("Clear URL cache", action: clearUrlCache)
+        } header: {
+            Text("Debugging")
+        } footer: {
+            debuggingFooter()
         }
     }
 
@@ -89,16 +100,11 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func versionSection() -> some View {
-        Section {
-            EmptyView()
-        } footer: {
-            HStack {
-                Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")")
-                Text("Build \(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "")")
-            }
-            .frame(maxWidth: .infinity)
+    private func debuggingFooter() -> some View {
+        HStack {
+            Text("Version \(version) Build \(buildVersion)")
         }
+        .frame(maxWidth: .infinity)
     }
 
     private func simulateMemoryWarning() {

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -31,6 +31,7 @@ struct SettingsView: View {
             applicationSection()
             playerSection()
             debuggingSection()
+            versionSection()
         }
         .navigationTitle("Settings")
     }
@@ -84,6 +85,19 @@ struct SettingsView: View {
             Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
             Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
             Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
+        }
+    }
+
+    @ViewBuilder
+    private func versionSection() -> some View {
+        Section {
+            EmptyView()
+        } footer: {
+            HStack {
+                Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")")
+                Text("Build \(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "")")
+            }
+            .frame(maxWidth: .infinity)
         }
     }
 


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to display the version and the build number within the demo app settings.

## Changes made

- Display version and build number

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
