### PR TITLE
Fix test instabilities with ephemeral sessions

### DIFF
--- a/Tests/CoreBusinessTests/PublishersTests.swift
+++ b/Tests/CoreBusinessTests/PublishersTests.swift
@@ -13,7 +13,7 @@ final class PublishersTests: XCTestCase {
     func testHttpError() {
         expectFailure(
             DataError.http(withStatusCode: 404),
-            from: URLSession.shared.dataTaskPublisher(for: URL(string: "http://localhost:8123/not_found")!)
+            from: URLSession(configuration: .ephemeral).dataTaskPublisher(for: URL(string: "http://localhost:8123/not_found")!)
                 .mapHttpErrors()
         )
     }

--- a/Tests/PlayerTests/PlayerItem.swift
+++ b/Tests/PlayerTests/PlayerItem.swift
@@ -50,7 +50,7 @@ extension PlayerItem {
 
     static func networkLoaded(metadata: Metadata) -> Self {
         let url = URL(string: "http://localhost:8123/\(metadata).json")!
-        let publisher = URLSession.shared.dataTaskPublisher(for: url)
+        let publisher = URLSession(configuration: .ephemeral).dataTaskPublisher(for: url)
             .map(\.data)
             .decode(type: AssetMetadata.self, decoder: JSONDecoder())
             .map { metadata in


### PR DESCRIPTION
# Pull request

## Description

This PR fixes remaining network-related test instabilities due to the shared URL session being used.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
