### PR TITLE
Load DRM and token protected examples dynamically

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0E8C362A296DB14600707FA5 /* PlayerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C3629296DB14600707FA5 /* PlayerConfiguration.swift */; };
+		0EC085F129B1DF2800F154D1 /* ExamplesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC085F029B1DF2800F154D1 /* ExamplesViewModel.swift */; };
 		0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324B29506969002E49DC /* PlaylistView.swift */; };
 		0EEB324F29630130002E49DC /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEB324E29630130002E49DC /* PlaylistViewModel.swift */; };
 		0EF42CB329AE2ADF00553165 /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF42CB229AE2ADF00553165 /* ListsView.swift */; };
@@ -53,6 +54,7 @@
 
 /* Begin PBXFileReference section */
 		0E8C3629296DB14600707FA5 /* PlayerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerConfiguration.swift; sourceTree = "<group>"; };
+		0EC085F029B1DF2800F154D1 /* ExamplesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesViewModel.swift; sourceTree = "<group>"; };
 		0EEB324B29506969002E49DC /* PlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistView.swift; sourceTree = "<group>"; };
 		0EEB324E29630130002E49DC /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
 		0EF42CB229AE2ADF00553165 /* ListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsView.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 				6F917C0A2887EA8E004113BA /* DemoApp.swift */,
 				6F48A5DC2932673A00B80393 /* DeveloperTools.swift */,
 				6FCD6A1A28AD1B9200FCE4EA /* ExamplesView.swift */,
+				0EC085F029B1DF2800F154D1 /* ExamplesViewModel.swift */,
 				6FD1F3A228D04AE200DF8CF1 /* LinkView.swift */,
 				0EF42CB229AE2ADF00553165 /* ListsView.swift */,
 				6FD1F3AE28D070CA00DF8CF1 /* Media.swift */,
@@ -338,6 +341,7 @@
 				0EF42CBA29AF25D100553165 /* ContentListView.swift in Sources */,
 				6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */,
 				6FCD6A1928AD158E00FCE4EA /* PlayerView.swift in Sources */,
+				0EC085F129B1DF2800F154D1 /* ExamplesViewModel.swift in Sources */,
 				0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */,
 				6FCD6A1B28AD1B9200FCE4EA /* ExamplesView.swift in Sources */,
 				6F917C0F2887EA8E004113BA /* DemoApp.swift in Sources */,

--- a/Demo/Sources/ContentListViewModel.swift
+++ b/Demo/Sources/ContentListViewModel.swift
@@ -201,7 +201,7 @@ final class ContentListViewModel: ObservableObject {
 
     func refresh() async {
         Task {
-            try await Task.sleep(for: .milliseconds(500))
+            try await Task.sleep(for: .seconds(1))
             trigger.activate(for: TriggerId.reload)
         }
     }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -24,6 +24,7 @@ struct ExamplesView: View {
         }
         .animation(.easeIn, value: model.protectedMedias)
         .navigationTitle("Examples")
+        .refreshable { await model.refresh() }
     }
 
     @ViewBuilder

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -8,55 +8,17 @@ import SwiftUI
 
 // Behavior: h-exp, v-exp
 struct ExamplesView: View {
-    private let urlMedias = Template.medias(from: [
-        URLTemplate.onDemandVideoHLS,
-        URLTemplate.shortOnDemandVideoHLS,
-        URLTemplate.onDemandVideoMP4,
-        URLTemplate.liveVideoHLS,
-        URLTemplate.dvrVideoHLS,
-        URLTemplate.liveTimestampVideoHLS,
-        URLTemplate.onDemandAudioMP3,
-        URLTemplate.liveAudioMP3
-    ])
-
-    private let urnMedias = Template.medias(from: [
-        URNTemplate.liveVideo,
-        URNTemplate.dvrVideo,
-        URNTemplate.dvrAudio
-    ])
-
-    private let aspectRatioMedias = Template.medias(from: [
-        URNTemplate.onDemandHorizontalVideo,
-        URNTemplate.onDemandSquareVideo,
-        URNTemplate.onDemandVerticalVideo
-    ])
-
-    private let unbufferedMedias = Template.medias(from: [
-        UnbufferedURLTemplate.liveVideo,
-        UnbufferedURLTemplate.liveAudio
-    ])
-
-    private let appleMedias = Template.medias(from: [
-        URLTemplate.appleBasic_4_3_HLS,
-        URLTemplate.appleBasic_16_9_TS_HLS,
-        URLTemplate.appleAdvanced_16_9_TS_HLS,
-        URLTemplate.appleAdvanced_16_9_fMP4_HLS,
-        URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS
-    ])
-
-    private let cornerCaseMedias = Template.medias(from: [
-        URNTemplate.expired,
-        URNTemplate.unknown
-    ])
+    @StateObject private var model = ExamplesViewModel()
 
     var body: some View {
         List {
-            section(title: "SRG SSR streams (URLs)", medias: urlMedias)
-            section(title: "SRG SSR streams (URNs)", medias: urnMedias)
-            section(title: "Apple streams", medias: appleMedias)
-            section(title: "Aspect ratios", medias: aspectRatioMedias)
-            section(title: "Unbuffered streams", medias: unbufferedMedias)
-            section(title: "Corner cases", medias: cornerCaseMedias)
+            section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
+            section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
+            section(title: "Protected streams (URNs)", medias: model.protectedMedias)
+            section(title: "Apple streams", medias: model.appleMedias)
+            section(title: "Aspect ratios", medias: model.aspectRatioMedias)
+            section(title: "Unbuffered streams", medias: model.unbufferedMedias)
+            section(title: "Corner cases", medias: model.cornerCaseMedias)
         }
         .navigationTitle("Examples")
     }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -22,6 +22,7 @@ struct ExamplesView: View {
             section(title: "Unbuffered streams", medias: model.unbufferedMedias)
             section(title: "Corner cases", medias: model.cornerCaseMedias)
         }
+        .animation(.easeIn, value: model.protectedMedias)
         .navigationTitle("Examples")
     }
 

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -14,7 +14,9 @@ struct ExamplesView: View {
         List {
             section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
             section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
-            section(title: "Protected streams (URNs)", medias: model.protectedMedias)
+            if !model.protectedMedias.isEmpty {
+                section(title: "Protected streams (URNs)", medias: model.protectedMedias)
+            }
             section(title: "Apple streams", medias: model.appleMedias)
             section(title: "Aspect ratios", medias: model.aspectRatioMedias)
             section(title: "Unbuffered streams", medias: model.unbufferedMedias)

--- a/Demo/Sources/ExamplesViewModel.swift
+++ b/Demo/Sources/ExamplesViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+final class ExamplesViewModel: ObservableObject {
+    let urlMedias = Template.medias(from: [
+        URLTemplate.onDemandVideoHLS,
+        URLTemplate.shortOnDemandVideoHLS,
+        URLTemplate.onDemandVideoMP4,
+        URLTemplate.liveVideoHLS,
+        URLTemplate.dvrVideoHLS,
+        URLTemplate.liveTimestampVideoHLS,
+        URLTemplate.onDemandAudioMP3,
+        URLTemplate.liveAudioMP3
+    ])
+
+    let urnMedias = Template.medias(from: [
+        URNTemplate.liveVideo,
+        URNTemplate.dvrVideo,
+        URNTemplate.dvrAudio
+    ])
+
+    let aspectRatioMedias = Template.medias(from: [
+        URNTemplate.onDemandHorizontalVideo,
+        URNTemplate.onDemandSquareVideo,
+        URNTemplate.onDemandVerticalVideo
+    ])
+
+    let unbufferedMedias = Template.medias(from: [
+        UnbufferedURLTemplate.liveVideo,
+        UnbufferedURLTemplate.liveAudio
+    ])
+
+    let appleMedias = Template.medias(from: [
+        URLTemplate.appleBasic_4_3_HLS,
+        URLTemplate.appleBasic_16_9_TS_HLS,
+        URLTemplate.appleAdvanced_16_9_TS_HLS,
+        URLTemplate.appleAdvanced_16_9_fMP4_HLS,
+        URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS
+    ])
+
+    let cornerCaseMedias = Template.medias(from: [
+        URNTemplate.expired,
+        URNTemplate.unknown
+    ])
+
+    let protectedMedias = [Media]()
+}

--- a/Demo/Sources/ExamplesViewModel.swift
+++ b/Demo/Sources/ExamplesViewModel.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Core
 import SRGDataProviderCombine
 
 final class ExamplesViewModel: ObservableObject {
@@ -51,8 +52,14 @@ final class ExamplesViewModel: ObservableObject {
     @Published private(set) var protectedMedias = [Media]()
 
     init() {
+        Self.protectedStreamPublisher()
+            .receiveOnMainThread()
+            .assign(to: &$protectedMedias)
+    }
+
+    private static func protectedStreamPublisher() -> AnyPublisher<[Media], Never> {
         let topModelsUrn = "urn:rts:show:tv:532539"
-        SRGDataProvider.current!.latestMediasForShow(withUrn: topModelsUrn, pageSize: 4)
+        return SRGDataProvider.current!.latestMediasForShow(withUrn: topModelsUrn, pageSize: 4)
             .replaceError(with: [])
             .map { medias in
                 medias.map { media in
@@ -63,7 +70,6 @@ final class ExamplesViewModel: ObservableObject {
                     )
                 }
             }
-            .receiveOnMainThread()
-            .assign(to: &$protectedMedias)
+            .eraseToAnyPublisher()
     }
 }

--- a/Demo/Sources/ExamplesViewModel.swift
+++ b/Demo/Sources/ExamplesViewModel.swift
@@ -116,7 +116,7 @@ final class ExamplesViewModel: ObservableObject {
 
     func refresh() async {
         Task {
-            try await Task.sleep(for: .milliseconds(500))
+            try await Task.sleep(for: .seconds(1))
             trigger.activate(for: TriggerId.reload)
         }
     }

--- a/Demo/Sources/ExamplesViewModel.swift
+++ b/Demo/Sources/ExamplesViewModel.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-import Foundation
+import SRGDataProviderCombine
 
 final class ExamplesViewModel: ObservableObject {
     let urlMedias = Template.medias(from: [
@@ -48,5 +48,22 @@ final class ExamplesViewModel: ObservableObject {
         URNTemplate.unknown
     ])
 
-    let protectedMedias = [Media]()
+    @Published private(set) var protectedMedias = [Media]()
+
+    init() {
+        let topModelsUrn = "urn:rts:show:tv:532539"
+        SRGDataProvider.current!.latestMediasForShow(withUrn: topModelsUrn, pageSize: 4)
+            .replaceError(with: [])
+            .map { medias in
+                medias.map { media in
+                    Media(
+                        title: media.title,
+                        description: "DRM-protected video",
+                        type: .urn(media.urn)
+                    )
+                }
+            }
+            .receiveOnMainThread()
+            .assign(to: &$protectedMedias)
+    }
 }

--- a/Sources/CoreBusiness/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider.swift
@@ -32,12 +32,20 @@ final class DataProvider {
     }
 
     func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
-        let url = environment.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
-        return session.dataTaskPublisher(for: url)
+        session.dataTaskPublisher(for: mediaCompositionUrl(for: urn))
             .mapHttpErrors()
             .map(\.data)
             .decode(type: MediaComposition.self, decoder: Self.decoder())
             .eraseToAnyPublisher()
+    }
+
+    func mediaCompositionUrl(for urn: String) -> URL {
+        let url = environment.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        components.queryItems = [
+            URLQueryItem(name: "onlyChapters", value: "true")
+        ]
+        return components.url ?? url
     }
 
     func playableMediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {


### PR DESCRIPTION
# Pull request

## Description

Self-explanatory.

## Changes made

- 4 streams has been added dynamically in Examples tab (2 for DRM & 2 for token protection)
- A pull to refresh has been added to reload the dynamic content.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
