### PR TITLE
Direct url and urn entry in the demo

### DIFF
--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -6,12 +6,29 @@
 
 import SwiftUI
 
+// Behavior: h-exp, v-hug
+private struct TextFieldView: View {
+    @State private var text: String = ""
+
+    var body: some View {
+        HStack {
+            TextField(text: $text) { Text("Enter URL or URN") }
+            Button(action: play) {
+                Image(systemName: "play.circle.fill")
+            }
+        }
+    }
+
+    private func play() {}
+}
+
 // Behavior: h-exp, v-exp
 struct ExamplesView: View {
     @StateObject private var model = ExamplesViewModel()
 
     var body: some View {
         List {
+            TextFieldView()
             section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
             section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
             if !model.protectedMedias.isEmpty {

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -45,12 +45,16 @@ private struct MediaEntryView: View {
     var body: some View {
         VStack {
             TextFieldView(text: $text)
-            Button(action: play) {
-                Text("Play")
+            if !text.isEmpty {
+                Button(action: play) {
+                    Text("Play")
+                }
+                .foregroundColor(Color.accentColor)
             }
-            .sheet(isPresented: $isPresented) {
-                PlayerView(media: media)
-            }
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $isPresented) {
+            PlayerView(media: media)
         }
     }
 
@@ -66,7 +70,6 @@ struct ExamplesView: View {
     var body: some View {
         List {
             MediaEntryView()
-                .buttonStyle(.plain)
             section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
             section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
             if !model.protectedMedias.isEmpty {
@@ -77,6 +80,7 @@ struct ExamplesView: View {
             section(title: "Unbuffered streams", medias: model.unbufferedMedias)
             section(title: "Corner cases", medias: model.cornerCaseMedias)
         }
+        .scrollDismissesKeyboard(.immediately)
         .animation(.linear(duration: 0.2), value: model.protectedMedias)
         .navigationTitle("Examples")
         .refreshable { await model.refresh() }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -9,6 +9,15 @@ import SwiftUI
 // Behavior: h-exp, v-hug
 private struct TextFieldView: View {
     @State private var text: String = ""
+    @State private var isPresented = false
+    private var media: Media {
+        if !text.hasPrefix("urn"), let url = URL(string: text) {
+            return .init(title: "URL", type: .url(url))
+        }
+        else {
+            return .init(title: "URN", type: .urn(text))
+        }
+    }
 
     var body: some View {
         HStack {
@@ -16,10 +25,15 @@ private struct TextFieldView: View {
             Button(action: play) {
                 Image(systemName: "play.circle.fill")
             }
+            .sheet(isPresented: $isPresented) {
+                PlayerView(media: media)
+            }
         }
     }
 
-    private func play() {}
+    private func play() {
+        isPresented.toggle()
+    }
 }
 
 // Behavior: h-exp, v-exp

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -8,16 +8,7 @@ import SwiftUI
 
 // Behavior: h-exp, v-hug
 private struct TextFieldView: View {
-    @State private var text: String = ""
-    @State private var isPresented = false
-    private var media: Media {
-        if !text.hasPrefix("urn"), let url = URL(string: text) {
-            return .init(title: "URL", type: .url(url))
-        }
-        else {
-            return .init(title: "URN", type: .urn(text))
-        }
-    }
+    @Binding var text: String
 
     var body: some View {
         HStack {
@@ -30,14 +21,37 @@ private struct TextFieldView: View {
             }
             .tint(.white)
             .opacity(text.isEmpty ? 0 : 1)
-            .sheet(isPresented: $isPresented) {
-                PlayerView(media: media)
-            }
         }
     }
 
     private func clear() {
         text = ""
+    }
+}
+
+private struct MediaEntryView: View {
+    @State private var text = ""
+    @State private var isPresented = false
+
+    private var media: Media {
+        if !text.hasPrefix("urn"), let url = URL(string: text) {
+            return .init(title: "URL", type: .url(url))
+        }
+        else {
+            return .init(title: "URN", type: .urn(text))
+        }
+    }
+
+    var body: some View {
+        VStack {
+            TextFieldView(text: $text)
+            Button(action: play) {
+                Text("Play")
+            }
+            .sheet(isPresented: $isPresented) {
+                PlayerView(media: media)
+            }
+        }
     }
 
     private func play() {
@@ -51,7 +65,7 @@ struct ExamplesView: View {
 
     var body: some View {
         List {
-            TextFieldView()
+            MediaEntryView()
             section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
             section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
             if !model.protectedMedias.isEmpty {

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -34,11 +34,12 @@ private struct MediaEntryView: View {
     @State private var isPresented = false
 
     private var media: Media {
-        if !text.hasPrefix("urn"), let url = URL(string: text) {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedText.hasPrefix("urn"), let url = URL(string: trimmedText) {
             return .init(title: "URL", type: .url(url))
         }
         else {
-            return .init(title: "URN", type: .urn(text))
+            return .init(title: "URN", type: .urn(trimmedText))
         }
     }
 

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -22,13 +22,22 @@ private struct TextFieldView: View {
     var body: some View {
         HStack {
             TextField(text: $text) { Text("Enter URL or URN") }
-            Button(action: play) {
-                Image(systemName: "play.circle.fill")
+                .keyboardType(.URL)
+                .autocapitalization(.none)
+                .autocorrectionDisabled()
+            Button(action: clear) {
+                Image(systemName: "xmark.circle.fill")
             }
+            .tint(.white)
+            .opacity(text.isEmpty ? 0 : 1)
             .sheet(isPresented: $isPresented) {
                 PlayerView(media: media)
             }
         }
+    }
+
+    private func clear() {
+        text = ""
     }
 
     private func play() {

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -12,7 +12,7 @@ private struct TextFieldView: View {
 
     var body: some View {
         HStack {
-            TextField(text: $text) { Text("Enter URL or URN") }
+            TextField("Enter URL or URN", text: $text)
                 .keyboardType(.URL)
                 .autocapitalization(.none)
                 .autocorrectionDisabled()

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -66,6 +66,7 @@ struct ExamplesView: View {
     var body: some View {
         List {
             MediaEntryView()
+                .buttonStyle(.plain)
             section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
             section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
             if !model.protectedMedias.isEmpty {


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to play a content directly via an URL or an URN.

## Changes made

- A `TextField` has been added at the top of the __Example__ list.
- A clear button has been added at the right of the `TextField`.
- Start typing text (url or urn) shows us a play button.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
