### PR TITLE
Add some icons for the list sections

### DIFF
--- a/Demo/Pillarbox.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Demo/Pillarbox.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -17,8 +17,8 @@ struct ListsView: View {
             Self.section(for: .tvShows, image: "rectangle.on.rectangle.angled", vendors: [.SRF, .RTS, .RSI, .RTR])
             Self.section(for: .liveCenterVideos, image: "sportscourt", vendors: [.SRF, .RTS, .RSI])
             Self.section(for: .tvScheduledLivestreams, image: "globe", vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.section(for: .radioLivestreams, image: "waveform", vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.radioShows(image: "antenna.radiowaves.left.and.right")
+            Self.section(for: .radioLivestreams, image: "antenna.radiowaves.left.and.right", vendors: [.SRF, .RTS, .RSI, .RTR])
+            Self.radioShows(image: "waveform")
             Self.latestAudiosSection(image: "music.note.list")
         }
         .navigationTitle("Lists")

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -11,33 +11,48 @@ import SwiftUI
 struct ListsView: View {
     var body: some View {
         List {
-            Self.section(for: .tvTopics, vendors: [.SRF, .RTS, .RSI, .RTR, .SWI])
-            Self.section(for: .tvLatestMedias, vendors: [.SRF, .RTS, .RSI, .RTR, .SWI])
-            Self.section(for: .tvLivestreams, vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.section(for: .tvShows, vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.section(for: .liveCenterVideos, vendors: [.SRF, .RTS, .RSI])
-            Self.section(for: .tvScheduledLivestreams, vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.section(for: .radioLivestreams, vendors: [.SRF, .RTS, .RSI, .RTR])
-            Self.radioShows()
-            Self.latestAudiosSection()
+            Self.section(for: .tvTopics, image: "tv", vendors: [.SRF, .RTS, .RSI, .RTR, .SWI])
+            Self.section(for: .tvLatestMedias, image: "play.tv", vendors: [.SRF, .RTS, .RSI, .RTR, .SWI])
+            Self.section(for: .tvLivestreams, image: "livephoto.play", vendors: [.SRF, .RTS, .RSI, .RTR])
+            Self.section(for: .tvShows, image: "rectangle.on.rectangle.angled", vendors: [.SRF, .RTS, .RSI, .RTR])
+            Self.section(for: .liveCenterVideos, image: "sportscourt", vendors: [.SRF, .RTS, .RSI])
+            Self.section(for: .tvScheduledLivestreams, image: "globe", vendors: [.SRF, .RTS, .RSI, .RTR])
+            Self.section(for: .radioLivestreams, image: "waveform", vendors: [.SRF, .RTS, .RSI, .RTR])
+            Self.radioShows(image: "antenna.radiowaves.left.and.right")
+            Self.latestAudiosSection(image: "music.note.list")
         }
         .navigationTitle("Lists")
     }
 
     @ViewBuilder
-    private static func section(title: String, configurations: [ContentListViewModel.Configuration]) -> some View {
-        Section(title) {
+    private static func section(for kind: ContentListViewModel.Kind, image: String? = nil, vendors: [SRGVendor]) -> some View {
+        let configurations = vendors.map { vendor in
+            ContentListViewModel.Configuration(kind: kind, vendor: vendor)
+        }
+        section(title: kind.name, image: image, configurations: configurations)
+    }
+
+    @ViewBuilder
+    private static func section(title: String, image: String? = nil, configurations: [ContentListViewModel.Configuration]) -> some View {
+        Section {
             ForEach(configurations, id: \.self) { configuration in
                 NavigationLink(configuration.name) {
                     ContentListView(configuration: configuration)
                 }
             }
+        } header: {
+            HStack {
+                if let image {
+                    Image(systemName: image)
+                }
+                Text(title)
+            }
         }
     }
 
     @ViewBuilder
-    private static func radioShows() -> some View {
-        section(title: "Radio Shows", configurations: [
+    private static func radioShows(image: String) -> some View {
+        section(title: "Radio Shows", image: image, configurations: [
             .init(kind: .radioShows(radioChannel: .SRF1), vendor: .SRF),
             .init(kind: .radioShows(radioChannel: .SRF2Kultur), vendor: .SRF),
             .init(kind: .radioShows(radioChannel: .SRF3), vendor: .SRF),
@@ -57,8 +72,8 @@ struct ListsView: View {
     }
 
     @ViewBuilder
-    private static func latestAudiosSection() -> some View {
-        section(title: "Latest Audios", configurations: [
+    private static func latestAudiosSection(image: String) -> some View {
+        section(title: "Latest Audios", image: image, configurations: [
             .init(kind: .radioLatestMedias(radioChannel: .SRF1), vendor: .SRF),
             .init(kind: .radioLatestMedias(radioChannel: .SRF2Kultur), vendor: .SRF),
             .init(kind: .radioLatestMedias(radioChannel: .SRF3), vendor: .SRF),
@@ -75,14 +90,6 @@ struct ListsView: View {
             .init(kind: .radioLatestMedias(radioChannel: .RSIReteTre), vendor: .RSI),
             .init(kind: .radioLatestMedias(radioChannel: .RTR), vendor: .RTR)
         ])
-    }
-
-    @ViewBuilder
-    private static func section(for kind: ContentListViewModel.Kind, vendors: [SRGVendor]) -> some View {
-        let configurations = vendors.map { vendor in
-            ContentListViewModel.Configuration(kind: kind, vendor: vendor)
-        }
-        section(title: kind.name, configurations: configurations)
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to add some SF Symbols icons to the list sections in the `Lists` tab.

## Changes made

- The sections name are now prefixed by an image.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
