### PR TITLE
Improve seek to default behavior for DVR streams

### DIFF
--- a/Demo/Pillarbox.playground/Contents.swift
+++ b/Demo/Pillarbox.playground/Contents.swift
@@ -34,7 +34,7 @@ private struct TimeSlider: View {
 // Behavior: h-exp, v-exp
 struct PlayerView: View {
     @StateObject private var player = Player(
-        item: PlayerItem.simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
+        item: .simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
     )
 
     private var playbackButtonImage: String? {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -199,9 +199,15 @@ public extension Player {
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipToDefault(completion: @escaping (Bool) -> Void = { _ in }) {
-        let time = (streamType == .dvr) ? timeRange.end : .zero
-        seek(near(time)) { finished in
-            completion(finished)
+        switch streamType {
+        case .dvr:
+            seek(after(timeRange.end)) { finished in
+                completion(finished)
+            }
+        default:
+            seek(near(.zero)) { finished in
+                completion(finished)
+            }
         }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR improves the following behavior reported by @svenduvoisin for short DVR streams, reproduced for RSI Live (30 seconds window) in nightly 244 as follows:

1. Open RSI and wait a bit. The slider know more or less stays at the very end of the slider.
2. Seek somewhere into the past, then tap on the LIVE button to return to the live.
3. Wait a bit again. The know now floats somewhere in the middle instead of sticking to the very end, which it likely should for consistency with step 1.

## Changes made

- Adjust tolerances to ensure the player seeks to the very end of the DVR window when returning to the default position.
- No UT written (simple tolerance adjustment).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
