### PR TITLE
Add server selection to demo

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 				0EF42CBF29AF926B00553165 /* RadioChannel.swift */,
 				0EC085F429B1F90800F154D1 /* SearchView.swift */,
 				0EC085F629B1FB1300F154D1 /* SearchViewModel.swift */,
+				0E38099629BE2B6200EE0EB9 /* ServiceUrl.swift */,
 				6FCA4748292CC101008C2812 /* SettingsView.swift */,
 				6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */,
 				6F7750D528EABD5100E80196 /* SimplePlayerView.swift */,
@@ -240,7 +241,6 @@
 				0EF42CC129AF92DB00553165 /* Vendor.swift */,
 				6FD1F3AA28D0655800DF8CF1 /* WrappedView.swift */,
 				6FD1F3AC28D0657300DF8CF1 /* WrappedViewModel.swift */,
-				0E38099629BE2B6200EE0EB9 /* ServiceUrl.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E38099729BE2B6200EE0EB9 /* ServiceUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E38099629BE2B6200EE0EB9 /* ServiceUrl.swift */; };
 		0E8C362A296DB14600707FA5 /* PlayerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C3629296DB14600707FA5 /* PlayerConfiguration.swift */; };
 		0EC085F129B1DF2800F154D1 /* ExamplesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC085F029B1DF2800F154D1 /* ExamplesViewModel.swift */; };
 		0EC085F529B1F90800F154D1 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC085F429B1F90800F154D1 /* SearchView.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E38099629BE2B6200EE0EB9 /* ServiceUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceUrl.swift; sourceTree = "<group>"; };
 		0E8C3629296DB14600707FA5 /* PlayerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerConfiguration.swift; sourceTree = "<group>"; };
 		0EC085F029B1DF2800F154D1 /* ExamplesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesViewModel.swift; sourceTree = "<group>"; };
 		0EC085F429B1F90800F154D1 /* SearchView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				0EF42CC129AF92DB00553165 /* Vendor.swift */,
 				6FD1F3AA28D0655800DF8CF1 /* WrappedView.swift */,
 				6FD1F3AC28D0657300DF8CF1 /* WrappedViewModel.swift */,
+				0E38099629BE2B6200EE0EB9 /* ServiceUrl.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -358,6 +361,7 @@
 				6FB553B228C3AF020067CFC4 /* StoriesView.swift in Sources */,
 				6FCD6A1928AD158E00FCE4EA /* PlayerView.swift in Sources */,
 				0EC085F129B1DF2800F154D1 /* ExamplesViewModel.swift in Sources */,
+				0E38099729BE2B6200EE0EB9 /* ServiceUrl.swift in Sources */,
 				0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */,
 				6FCD6A1B28AD1B9200FCE4EA /* ExamplesView.swift in Sources */,
 				6F917C0F2887EA8E004113BA /* DemoApp.swift in Sources */,

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         try? AVAudioSession.sharedInstance().setCategory(.playback)
         UserDefaults.standard.registerDefaults()
         configureShowTime()
-        SRGDataProvider.current = SRGDataProvider(serviceURL: SRGIntegrationLayerProductionServiceURL())
+        configureDataProvider()
         return true
     }
 
@@ -28,6 +28,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             .receiveOnMainThread()
             .sink { isEnabled in
                 ShowTime.enabled = isEnabled ? .always : .never
+            }
+            .store(in: &cancellables)
+    }
+
+    private func configureDataProvider() {
+        UserDefaults.standard.publisher(for: \.serviceUrlEnvironment)
+            .receiveOnMainThread()
+            .sink { serviceUrl in
+                SRGDataProvider.current = SRGDataProvider(serviceURL: serviceUrl.url)
             }
             .store(in: &cancellables)
     }

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     private func configureDataProvider() {
-        UserDefaults.standard.publisher(for: \.serviceUrlEnvironment)
+        UserDefaults.standard.publisher(for: \.serviceUrl)
             .receiveOnMainThread()
             .sink { serviceUrl in
                 SRGDataProvider.current = SRGDataProvider(serviceURL: serviceUrl.url)

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -22,6 +22,16 @@ struct ListsView: View {
             Self.latestAudiosSection(image: "music.note.list")
         }
         .navigationTitle("Lists")
+        .toolbarTitleMenu {
+            Self.titlesMenu()
+        }
+    }
+
+    @ViewBuilder
+    private static func titlesMenu() -> some View {
+        ForEach(ServiceUrl.allCases, id: \.self) { serviceUrl in
+            Button(serviceUrl.title) {}
+        }
     }
 
     @ViewBuilder

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 // Behavior: h-exp, v-exp
 struct ListsView: View {
-    @AppStorage(UserDefaults.serviceUrlEnvironmentKey)
+    @AppStorage(UserDefaults.serviceUrlKey)
     private var serviceUrl: ServiceUrl = .production
 
     var body: some View {

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 // Behavior: h-exp, v-exp
 struct ListsView: View {
+    @AppStorage(UserDefaults.serviceUrlEnvironmentKey)
+    private var serviceUrl: ServiceUrl = .production
+
     var body: some View {
         List {
             Self.section(for: .tvTopics, image: "tv", vendors: [.SRF, .RTS, .RSI, .RTR, .SWI])
@@ -23,14 +26,7 @@ struct ListsView: View {
         }
         .navigationTitle("Lists")
         .toolbarTitleMenu {
-            Self.titlesMenu()
-        }
-    }
-
-    @ViewBuilder
-    private static func titlesMenu() -> some View {
-        ForEach(ServiceUrl.allCases, id: \.self) { serviceUrl in
-            Button(serviceUrl.title) {}
+            titlesMenu()
         }
     }
 
@@ -100,6 +96,22 @@ struct ListsView: View {
             .init(kind: .radioLatestMedias(radioChannel: .RSIReteTre), vendor: .RSI),
             .init(kind: .radioLatestMedias(radioChannel: .RTR), vendor: .RTR)
         ])
+    }
+
+    @ViewBuilder
+    private func titlesMenu() -> some View {
+        ForEach(ServiceUrl.allCases, id: \.self) { service in
+            Button {
+                serviceUrl = service
+            } label: {
+                HStack {
+                    Text(service.title)
+                    if serviceUrl == service {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Demo/Sources/ListsView.swift
+++ b/Demo/Sources/ListsView.swift
@@ -24,7 +24,7 @@ struct ListsView: View {
             Self.radioShows(image: "waveform")
             Self.latestAudiosSection(image: "music.note.list")
         }
-        .navigationTitle("Lists")
+        .navigationTitle("Lists (\(serviceUrl.title))")
         .toolbarTitleMenu {
             titlesMenu()
         }

--- a/Demo/Sources/ServiceUrl.swift
+++ b/Demo/Sources/ServiceUrl.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SRGDataProvider
+
+enum ServiceUrl: String, CaseIterable {
+    case production
+    case staging
+    case test
+
+    var title: String {
+        self.rawValue.capitalized
+    }
+
+    var url: URL {
+        switch self {
+        case .production:
+            return SRGIntegrationLayerProductionServiceURL()
+        case .staging:
+            return SRGIntegrationLayerStagingServiceURL()
+        case .test:
+            return SRGIntegrationLayerTestServiceURL()
+        }
+    }
+}

--- a/Demo/Sources/ServiceUrl.swift
+++ b/Demo/Sources/ServiceUrl.swift
@@ -6,13 +6,21 @@
 
 import SRGDataProvider
 
-enum ServiceUrl: String, CaseIterable {
+@objc
+enum ServiceUrl: Int, CaseIterable {
     case production
     case staging
     case test
 
     var title: String {
-        self.rawValue.capitalized
+        switch self {
+        case .production:
+            return "Production"
+        case .staging:
+            return "Staging"
+        case .test:
+            return "Test"
+        }
     }
 
     var url: URL {

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -25,6 +25,7 @@ extension UserDefaults {
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
+    static let serviceUrlEnvironmentKey = "serviceUrlEnvironment"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -59,6 +60,10 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicyKey)) ?? .automatic
     }
 
+    @objc dynamic var serviceUrlEnvironment: ServiceUrl {
+        .init(rawValue: integer(forKey: Self.serviceUrlEnvironmentKey)) ?? .production
+    }
+
     func registerDefaults() {
         register(defaults: [
             Self.presenterModeEnabledKey: false,
@@ -66,7 +71,8 @@ extension UserDefaults {
             Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
             Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
-            Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue
+            Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue,
+            Self.serviceUrlEnvironmentKey: ServiceUrl.production.rawValue
         ])
     }
 }

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -25,7 +25,7 @@ extension UserDefaults {
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
-    static let serviceUrlEnvironmentKey = "serviceUrlEnvironment"
+    static let serviceUrlKey = "serviceUrlKey"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -60,8 +60,8 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicyKey)) ?? .automatic
     }
 
-    @objc dynamic var serviceUrlEnvironment: ServiceUrl {
-        .init(rawValue: integer(forKey: Self.serviceUrlEnvironmentKey)) ?? .production
+    @objc dynamic var serviceUrl: ServiceUrl {
+        .init(rawValue: integer(forKey: Self.serviceUrlKey)) ?? .production
     }
 
     func registerDefaults() {
@@ -72,7 +72,7 @@ extension UserDefaults {
             Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
             Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue,
-            Self.serviceUrlEnvironmentKey: ServiceUrl.production.rawValue
+            Self.serviceUrlKey: ServiceUrl.production.rawValue
         ])
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to select via our demo app the server used by the `SRGDataProvider`.

## Changes made

- A `.toolbarTitleMenu` has been added to select an environment.
- The environment is stored in the `UserDefault`

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
