### PR TITLE
Add pinch to zoom support to the demo player

### DIFF
--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -14,6 +14,8 @@ import SwiftUI
 private struct MainView: View {
     @ObservedObject var player: Player
     @StateObject private var visibilityTracker = VisibilityTracker()
+
+    @State private var isMaximized = false
     @State private var gravity: AVLayerVideoGravity = .resizeAspect
 
     var body: some View {
@@ -29,6 +31,10 @@ private struct MainView: View {
         .debugBodyCounter()
     }
 
+    private var magnificationGestureMask: GestureMask {
+        isMaximized ? .all : .subviews
+    }
+
     private func magnificationGesture() -> some Gesture {
         MagnificationGesture()
             .onChanged { scale in
@@ -38,15 +44,18 @@ private struct MainView: View {
 
     @ViewBuilder
     private func main() -> some View {
-        ZStack {
-            video()
-            controls()
-            loadingIndicator()
+        LayoutReader(isMaximized: $isMaximized) {
+            ZStack {
+                video()
+                controls()
+                loadingIndicator()
+            }
+            .animation(.linear(duration: 0.2), value: visibilityTracker.isUserInterfaceHidden)
+            .accessibilityAddTraits(.isButton)
+            .onTapGesture(perform: visibilityTracker.toggle)
+            .gesture(magnificationGesture(), including: magnificationGestureMask)
+            .ignoresSafeArea()
         }
-        .accessibilityAddTraits(.isButton)
-        .onTapGesture(perform: visibilityTracker.toggle)
-        .gesture(magnificationGesture())
-        .ignoresSafeArea()
     }
 
     @ViewBuilder

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import CoreMedia
 import Player
 import SwiftUI
@@ -13,6 +14,7 @@ import SwiftUI
 private struct MainView: View {
     @ObservedObject var player: Player
     @StateObject private var visibilityTracker = VisibilityTracker()
+    @State private var gravity: AVLayerVideoGravity = .resizeAspect
 
     var body: some View {
         InteractionView(action: visibilityTracker.reset) {
@@ -27,6 +29,13 @@ private struct MainView: View {
         .debugBodyCounter()
     }
 
+    private func magnificationGesture() -> some Gesture {
+        MagnificationGesture()
+            .onChanged { scale in
+                gravity = scale > 1.0 ? .resizeAspectFill : .resizeAspect
+            }
+    }
+
     @ViewBuilder
     private func main() -> some View {
         ZStack {
@@ -36,6 +45,7 @@ private struct MainView: View {
         }
         .accessibilityAddTraits(.isButton)
         .onTapGesture(perform: visibilityTracker.toggle)
+        .gesture(magnificationGesture())
         .ignoresSafeArea()
     }
 
@@ -59,7 +69,7 @@ private struct MainView: View {
                 .padding()
         }
         else {
-            VideoView(player: player)
+            VideoView(player: player, gravity: gravity)
         }
     }
 

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -6,16 +6,16 @@
 
 import SwiftUI
 
-/// A view triggering an action when any kind of touch interaction happens with its content. The view lays out its
-/// children like a `ZStack`.
+/// A view which is able to determine whether it is maximized in its parent context. The view lays out its children
+/// like a `ZStack`.
 @available(tvOS, unavailable)
-public struct InteractionView<Content: View>: View {
-    private let action: () -> Void
+public struct LayoutReader<Content: View>: View {
+    @Binding private var isMaximized: Bool
     @Binding private var content: () -> Content
 
     public var body: some View {
         // Ignore the safe area to have support for safe area insets similar to a `ZStack`.
-        InteractionHostView(action: action) {
+        LayoutReaderHost(isMaximized: _isMaximized) {
             ZStack {
                 content()
             }
@@ -23,27 +23,27 @@ public struct InteractionView<Content: View>: View {
         .ignoresSafeArea()
     }
 
-    /// Create the interaction view.
+    /// Create the layout reader.
     /// - Parameters:
-    ///   - action: The action to trigger when user interaction is detected.
+    ///   - isMaximized: A binding to a Boolean indicating whether the view is maximized in its context.
     ///   - content: The wrapped content.
-    public init(action: @escaping () -> Void, @ViewBuilder content: @escaping () -> Content) {
-        self.action = action
+    public init(isMaximized: Binding<Bool>, @ViewBuilder content: @escaping () -> Content) {
+        _isMaximized = isMaximized
         _content = .constant(content)
     }
 }
 
 @available(tvOS, unavailable)
-struct InteractionView_Previews: PreviewProvider {
+struct LayoutReader_Previews: PreviewProvider {
     static var previews: some View {
-        InteractionView(action: {}) {
+        LayoutReader(isMaximized: .constant(true)) {
             ZStack {
                 Color.red
                     .ignoresSafeArea()
                 Color.blue
             }
         }
-        .previewDisplayName("Safe area ignored in InteractionView")
+        .previewDisplayName("Safe area ignored in LayoutReader")
 
         ZStack {
             Color.red
@@ -52,11 +52,11 @@ struct InteractionView_Previews: PreviewProvider {
         }
         .previewDisplayName("Safe area ignored in ZStack")
 
-        InteractionView(action: {}) {
+        LayoutReader(isMaximized: .constant(true)) {
             Color.red
             Color.blue
         }
-        .previewDisplayName("Simple InteractionView")
+        .previewDisplayName("Simple LayoutReader")
 
         ZStack {
             Color.red

--- a/Sources/Player/LayoutReaderHost.swift
+++ b/Sources/Player/LayoutReaderHost.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+/// An internal host controller which can determine if it is maximized in its parent context.
+@available(tvOS, unavailable)
+final class LayoutReaderHostingController<Content: View>: UIHostingController<Content>, UIGestureRecognizerDelegate {
+    var isMaximized: Binding<Bool> = .constant(false)
+
+    private static func parent(for viewController: UIViewController) -> UIViewController {
+        if let parentViewController = viewController.parent {
+            return parent(for: parentViewController)
+        }
+        else {
+            return viewController
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        let frame = view.frame
+        let parentFrame = Self.parent(for: self).view.frame
+        isMaximized.wrappedValue = frame == parentFrame
+    }
+}
+
+@available(tvOS, unavailable)
+struct LayoutReaderHost<Content: View>: UIViewControllerRepresentable {
+    @Binding private var isMaximized: Bool
+    @Binding private var content: () -> Content
+
+    init(isMaximized: Binding<Bool>, @ViewBuilder content: @escaping () -> Content) {
+        _isMaximized = isMaximized
+        _content = .constant(content)
+    }
+
+    // Return a `UIHostingController` directly to ensure correct safe area insets
+    func makeUIViewController(context: Context) -> LayoutReaderHostingController<Content> {
+        LayoutReaderHostingController(rootView: content())
+    }
+
+    func updateUIViewController(_ uiViewController: LayoutReaderHostingController<Content>, context: Context) {
+        uiViewController.rootView = content()
+        uiViewController.isMaximized = _isMaximized
+    }
+}

--- a/Sources/Player/VideoView.swift
+++ b/Sources/Player/VideoView.swift
@@ -38,11 +38,11 @@ public struct VideoView: UIViewRepresentable {
         let view = VideoLayerView()
         view.backgroundColor = .clear
         view.player = player.queuePlayer
-        view.playerLayer.videoGravity = gravity
         return view
     }
 
     public func updateUIView(_ uiView: VideoLayerView, context: Context) {
         uiView.player = player.queuePlayer
+        uiView.playerLayer.videoGravity = gravity
     }
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -143,7 +143,7 @@ struct PlayerView: View {
 }
 ```
 
-## Advanced view layouts
+## Custom view layouts
 
 Pillarbox currently does not provide any standard playback view you can use but you can build one yourself. Since `Player` is an `ObservableObject`, though, implementation of a playback view can be easily achieved in the same was as for any usual SwiftUI layout.
 
@@ -191,6 +191,46 @@ struct PlayerView: View {
 By having the `ProgressTracker` stored in a nested view you ensure that only this part of the view hierarchy gets updated every 1/10th of a second. The main `PlayerView` itself is namely still only updated when the player state changes. This way you can avoid triggering frequent large view updates unnecessarily, which makes it possible to implement layouts in an energy-efficient way. Of course several progress trackers can be used should you want to have different parts of your user interface be updated at different rates.
 
 To make it easier to spot where user interface updates can be optimized our `Core` package provides a `_debugBodyCounter(color:)` modifier which surrounds any view you want to observe with a counter, showing how many times its body has been evaluated. This way you can observe how your layout behaves and visually detects where parts of your user interface could benefit from local progress tracking.
+
+## Maximized layout management (iOS)
+
+Sometimes you want to enable behaviors only when a player view fills its parent context, for example zoom gestures which control the `VideoView` gravity.
+
+Pillarbox does not implement such behaviors natively but instead provides a `LayoutReader` wrapper returning its maximization state in the parent context through a binding.
+
+Here is for example how you could implement a pinch gesture only available when the player view is maximized:
+
+```swift
+struct PlayerView: View {
+    @StateObject private var player = Player(items: [
+        .simple(url: URL(string: "https://server.com/stream.m3u8")!),
+        .urn("urn:rts:video:13444333")
+    ])
+    
+    @State private var isMaximized = false
+    @State private var gravity: AVLayerVideoGravity = .resizeAspect
+
+    var body: some View {
+        LayoutReader(isMaximized: $isMaximized) {
+            VideoView(player: player, gravity: gravity)
+                .gesture(magnificationGesture(), including: magnificationGestureMask)
+                .ignoresSafeArea()
+        }
+        .onAppear(perform: player.play)
+    }
+    
+    private var magnificationGestureMask: GestureMask {
+        isMaximized ? .all : .subviews
+    }
+
+    private func magnificationGesture() -> some Gesture {
+        MagnificationGesture()
+            .onChanged { scale in
+                gravity = scale > 1.0 ? .resizeAspectFill : .resizeAspect
+            }
+    }
+}
+```
 
 ## Playlists
 


### PR DESCRIPTION
# Pull request

## Description

This PR adds pinch to zoom support to the demo player.

## Changes made

Adding a pinch gesture is straightforward but ensuring it only can be used when the player is maximized (usually what we want, as zooming in a small layout like the one of the playlist demo does not make sense) is trickier.

To solve this problem a `LayoutReader` has been introduced, using the same strategy as in #288. This reader provides maximization state information through a binding. This state can then be used to enable or disable behaviors in maximized mode. In the demo player it is simply used to only enable the pinch gesture when the player is maximized.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
