### PR TITLE
Improve view wrappers

### DIFF
--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -16,7 +16,7 @@ private struct MainView: View {
     @StateObject private var visibilityTracker = VisibilityTracker()
 
     @State private var layoutInfo: LayoutInfo = .none
-    @State private var gravity: AVLayerVideoGravity = .resizeAspect
+    @State private var selectedGravity: AVLayerVideoGravity = .resizeAspect
 
     var body: some View {
         InteractionView(action: visibilityTracker.reset) {
@@ -31,6 +31,10 @@ private struct MainView: View {
         .debugBodyCounter()
     }
 
+    private var gravity: AVLayerVideoGravity {
+        layoutInfo.isMaximized ? selectedGravity : .resizeAspect
+    }
+
     private var magnificationGestureMask: GestureMask {
         layoutInfo.isMaximized ? .all : .subviews
     }
@@ -38,7 +42,7 @@ private struct MainView: View {
     private func magnificationGesture() -> some Gesture {
         MagnificationGesture()
             .onChanged { scale in
-                gravity = scale > 1.0 ? .resizeAspectFill : .resizeAspect
+                selectedGravity = scale > 1.0 ? .resizeAspectFill : .resizeAspect
             }
     }
 

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -15,7 +15,7 @@ private struct MainView: View {
     @ObservedObject var player: Player
     @StateObject private var visibilityTracker = VisibilityTracker()
 
-    @State private var isMaximized = false
+    @State private var layoutInfo: LayoutInfo = .none
     @State private var gravity: AVLayerVideoGravity = .resizeAspect
 
     var body: some View {
@@ -32,7 +32,7 @@ private struct MainView: View {
     }
 
     private var magnificationGestureMask: GestureMask {
-        isMaximized ? .all : .subviews
+        layoutInfo.isMaximized ? .all : .subviews
     }
 
     private func magnificationGesture() -> some Gesture {
@@ -44,7 +44,7 @@ private struct MainView: View {
 
     @ViewBuilder
     private func main() -> some View {
-        LayoutReader(isMaximized: $isMaximized) {
+        LayoutReader(layoutInfo: $layoutInfo) {
             ZStack {
                 video()
                 controls()

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -14,7 +14,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -35,7 +35,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -55,7 +55,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -77,7 +77,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -99,7 +99,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -121,7 +121,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -180,7 +180,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -201,7 +201,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -221,7 +221,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -243,7 +243,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -265,7 +265,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -287,7 +287,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -566,7 +566,7 @@ public extension XCTestCase {
     /// Expect a publisher to complete successfully.
     func expectSuccess<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -597,7 +597,7 @@ public extension XCTestCase {
     func expectFailure<P: Publisher>(
         _ error: Error? = nil,
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -637,7 +637,7 @@ public extension XCTestCase {
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
         center: NotificationCenter = .default,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -14,7 +14,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -35,7 +35,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -55,7 +55,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -77,7 +77,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -99,7 +99,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -121,7 +121,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -143,7 +143,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval,
+        timeout: DispatchTimeInterval,
         file: StaticString,
         line: UInt,
         while executing: (() -> Void)?
@@ -180,7 +180,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -201,7 +201,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -221,7 +221,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -243,7 +243,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -265,7 +265,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -287,7 +287,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -309,7 +309,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: TimeInterval,
+        timeout: DispatchTimeInterval,
         file: StaticString,
         line: UInt,
         while executing: (() -> Void)?
@@ -566,7 +566,7 @@ public extension XCTestCase {
     /// Expect a publisher to complete successfully.
     func expectSuccess<P: Publisher>(
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -590,14 +590,14 @@ public extension XCTestCase {
             executing()
         }
 
-        waitForExpectations(timeout: timeout)
+        waitForExpectations(timeout: timeout.double())
     }
 
     /// Expect a publisher to complete with a failure.
     func expectFailure<P: Publisher>(
         _ error: Error? = nil,
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -624,7 +624,7 @@ public extension XCTestCase {
             executing()
         }
 
-        waitForExpectations(timeout: timeout)
+        waitForExpectations(timeout: timeout.double())
     }
 }
 
@@ -637,7 +637,7 @@ public extension XCTestCase {
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
         center: NotificationCenter = .default,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -14,7 +14,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -35,7 +35,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -55,7 +55,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -77,7 +77,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -99,7 +99,7 @@ public extension XCTestCase {
     func expectAtLeastEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -121,7 +121,7 @@ public extension XCTestCase {
     func expectAtLeastSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -180,7 +180,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -201,7 +201,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -221,7 +221,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -243,7 +243,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -265,7 +265,7 @@ public extension XCTestCase {
     func expectOnlyEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -287,7 +287,7 @@ public extension XCTestCase {
     func expectOnlySimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -566,7 +566,7 @@ public extension XCTestCase {
     /// Expect a publisher to complete successfully.
     func expectSuccess<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -597,7 +597,7 @@ public extension XCTestCase {
     func expectFailure<P: Publisher>(
         _ error: Error? = nil,
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -637,7 +637,7 @@ public extension XCTestCase {
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
         center: NotificationCenter = .default,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Publishers.swift
+++ b/Sources/Circumspect/Publishers.swift
@@ -20,7 +20,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForResult<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -67,7 +67,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForOutput<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -93,7 +93,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForSingleOutput<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -123,7 +123,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForFailure<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(20),
+        timeout: DispatchTimeInterval = .seconds(10),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Publishers.swift
+++ b/Sources/Circumspect/Publishers.swift
@@ -20,7 +20,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForResult<P: Publisher>(
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -52,7 +52,7 @@ public extension XCTestCase {
             executing()
         }
 
-        waitForExpectations(timeout: timeout)
+        waitForExpectations(timeout: timeout.double())
         return try XCTUnwrap(result, "The publisher did not produce any result", file: file, line: line)
     }
 
@@ -67,7 +67,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForOutput<P: Publisher>(
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -93,7 +93,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForSingleOutput<P: Publisher>(
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -123,7 +123,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForFailure<P: Publisher>(
         from publisher: P,
-        timeout: TimeInterval = 10,
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Publishers.swift
+++ b/Sources/Circumspect/Publishers.swift
@@ -20,7 +20,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForResult<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -67,7 +67,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForOutput<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -93,7 +93,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForSingleOutput<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -123,7 +123,7 @@ public extension XCTestCase {
     @discardableResult
     func waitForFailure<P: Publisher>(
         from publisher: P,
-        timeout: DispatchTimeInterval = .seconds(10),
+        timeout: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/TimeInterval.swift
+++ b/Sources/Circumspect/TimeInterval.swift
@@ -12,11 +12,11 @@ extension DispatchTimeInterval {
         case let .seconds(value):
             return .init(value)
         case let .milliseconds(value):
-            return .init(value) * 0.001
+            return .init(value) * 1e-3
         case let .microseconds(value):
-            return .init(value) * 0.000001
+            return .init(value) * 1e-6
         case let .nanoseconds(value):
-            return .init(value) * 0.000000001
+            return .init(value) * 1e-9
         default:
             return 0
         }

--- a/Sources/Circumspect/TimeInterval.swift
+++ b/Sources/Circumspect/TimeInterval.swift
@@ -10,13 +10,13 @@ extension DispatchTimeInterval {
     func double() -> Double {
         switch self {
         case let .seconds(value):
-            return Double(value)
+            return .init(value)
         case let .milliseconds(value):
-            return Double(value) * 0.001
+            return .init(value) * 0.001
         case let .microseconds(value):
-            return Double(value) * 0.000001
+            return .init(value) * 0.000001
         case let .nanoseconds(value):
-            return Double(value) * 0.000000001
+            return .init(value) * 0.000000001
         default:
             return 0
         }

--- a/Sources/Circumspect/TimeInterval.swift
+++ b/Sources/Circumspect/TimeInterval.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Dispatch
+
+extension DispatchTimeInterval {
+    func double() -> Double {
+        switch self {
+        case let .seconds(value):
+            return Double(value)
+        case let .milliseconds(value):
+            return Double(value) * 0.001
+        case let .microseconds(value):
+            return Double(value) * 0.000001
+        case let .nanoseconds(value):
+            return Double(value) * 0.000000001
+        default:
+            return 0
+        }
+    }
+}

--- a/Sources/Player/InteractionHostView.swift
+++ b/Sources/Player/InteractionHostView.swift
@@ -64,8 +64,8 @@ struct InteractionHostView<Content: View>: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: InteractionHostingController<Content>, context: Context) {
-        uiViewController.rootView = content()
         uiViewController.isInteracting = _isInteracting
         uiViewController.action = action
+        uiViewController.rootView = content()
     }
 }

--- a/Sources/Player/InteractionView.swift
+++ b/Sources/Player/InteractionView.swift
@@ -6,16 +6,17 @@
 
 import SwiftUI
 
-/// A view triggering an action when any kind of touch interaction happens with its content. The view lays out its
-/// children like a `ZStack`.
+/// A view which is able to determine whether interaction occurs with its content. The view lays out its children
+/// like a `ZStack`.
 @available(tvOS, unavailable)
 public struct InteractionView<Content: View>: View {
+    @Binding private var isInteracting: Bool
     private let action: () -> Void
     @Binding private var content: () -> Content
 
     public var body: some View {
         // Ignore the safe area to have support for safe area insets similar to a `ZStack`.
-        InteractionHostView(action: action) {
+        InteractionHostView(isInteracting: _isInteracting, action: action) {
             ZStack {
                 content()
             }
@@ -25,9 +26,11 @@ public struct InteractionView<Content: View>: View {
 
     /// Create the interaction view.
     /// - Parameters:
+    ///   - isInteracting: A binding to a Boolean indicating whether the user is currently interacting with the view.
     ///   - action: The action to trigger when user interaction is detected.
     ///   - content: The wrapped content.
-    public init(action: @escaping () -> Void, @ViewBuilder content: @escaping () -> Content) {
+    public init(isInteracting: Binding<Bool> = .constant(false), action: @escaping () -> Void = {}, @ViewBuilder content: @escaping () -> Content) {
+        _isInteracting = isInteracting
         self.action = action
         _content = .constant(content)
     }
@@ -36,7 +39,7 @@ public struct InteractionView<Content: View>: View {
 @available(tvOS, unavailable)
 struct InteractionView_Previews: PreviewProvider {
     static var previews: some View {
-        InteractionView(action: {}) {
+        InteractionView(isInteracting: .constant(false)) {
             ZStack {
                 Color.red
                     .ignoresSafeArea()
@@ -52,7 +55,7 @@ struct InteractionView_Previews: PreviewProvider {
         }
         .previewDisplayName("Safe area ignored in ZStack")
 
-        InteractionView(action: {}) {
+        InteractionView(isInteracting: .constant(false)) {
             Color.red
             Color.blue
         }

--- a/Sources/Player/InteractionView.swift
+++ b/Sources/Player/InteractionView.swift
@@ -38,33 +38,60 @@ public struct InteractionView<Content: View>: View {
 
 @available(tvOS, unavailable)
 struct InteractionView_Previews: PreviewProvider {
-    static var previews: some View {
-        InteractionView(isInteracting: .constant(false)) {
+    private struct IgnoredSafeAreaInInteractionView: View {
+        @State private var isInteracting = false
+
+        var body: some View {
+            InteractionView(isInteracting: $isInteracting) {
+                ZStack {
+                    Color.red
+                        .ignoresSafeArea()
+                    Color.blue
+                    Text(isInteracting ? "Interacting" : "Not interacting")
+                }
+            }
+        }
+    }
+
+    private struct IgnoredSafeAreaInZStack: View {
+        var body: some View {
             ZStack {
                 Color.red
                     .ignoresSafeArea()
                 Color.blue
             }
         }
-        .previewDisplayName("Safe area ignored in InteractionView")
+    }
 
-        ZStack {
-            Color.red
-                .ignoresSafeArea()
-            Color.blue
-        }
-        .previewDisplayName("Safe area ignored in ZStack")
+    private struct SafeAreaInInteractionView: View {
+        @State private var isInteracting = false
 
-        InteractionView(isInteracting: .constant(false)) {
-            Color.red
-            Color.blue
+        var body: some View {
+            InteractionView(isInteracting: $isInteracting) {
+                Color.red
+                Color.blue
+                Text(isInteracting ? "Interacting" : "Not interacting")
+            }
         }
-        .previewDisplayName("Simple InteractionView")
+    }
 
-        ZStack {
-            Color.red
-            Color.blue
+    private struct SafeAreaInZStack: View {
+        var body: some View {
+            ZStack {
+                Color.red
+                Color.blue
+            }
         }
-        .previewDisplayName("Simple ZStack")
+    }
+
+    static var previews: some View {
+        IgnoredSafeAreaInInteractionView()
+            .previewDisplayName("Safe area ignored in InteractionView")
+        IgnoredSafeAreaInZStack()
+            .previewDisplayName("Safe area ignored in ZStack")
+        SafeAreaInInteractionView()
+            .previewDisplayName("Safe area in InteractionView")
+        SafeAreaInZStack()
+            .previewDisplayName("Safe area in ZStack")
     }
 }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -6,16 +6,29 @@
 
 import SwiftUI
 
-/// A view which is able to determine whether it is maximized in its parent context. The view lays out its children
-/// like a `ZStack`.
+/// Layout information.
+public struct LayoutInfo {
+    /// A placeholder for unfilled layout information.
+    public static var none: Self {
+        .init(isMaximized: false, isFullScreen: false)
+    }
+
+    /// Return whether the view is maximized in its parent context.
+    public let isMaximized: Bool
+    /// Return whether the view covers the whole screen
+    public let isFullScreen: Bool
+}
+
+/// A view which is able to determine whether it is maximized in its parent context or full screen. The view lays out
+/// its children like a `ZStack`.
 @available(tvOS, unavailable)
 public struct LayoutReader<Content: View>: View {
-    @Binding private var isMaximized: Bool
+    @Binding private var layoutInfo: LayoutInfo
     @Binding private var content: () -> Content
 
     public var body: some View {
         // Ignore the safe area to have support for safe area insets similar to a `ZStack`.
-        LayoutReaderHost(isMaximized: $isMaximized) {
+        LayoutReaderHost(layoutInfo: $layoutInfo) {
             ZStack {
                 content()
             }
@@ -25,10 +38,10 @@ public struct LayoutReader<Content: View>: View {
 
     /// Create the layout reader.
     /// - Parameters:
-    ///   - isMaximized: A binding to a Boolean indicating whether the view is maximized in its context.
+    ///   - info: The layout information.
     ///   - content: The wrapped content.
-    public init(isMaximized: Binding<Bool>, @ViewBuilder content: @escaping () -> Content) {
-        _isMaximized = isMaximized
+    public init(layoutInfo: Binding<LayoutInfo>, @ViewBuilder content: @escaping () -> Content) {
+        _layoutInfo = layoutInfo
         _content = .constant(content)
     }
 }
@@ -36,15 +49,18 @@ public struct LayoutReader<Content: View>: View {
 @available(tvOS, unavailable)
 struct LayoutReader_Previews: PreviewProvider {
     private struct IgnoredSafeAreaInLayoutReader: View {
-        @State private var isMaximized = false
+        @State private var layoutInfo: LayoutInfo = .none
 
         var body: some View {
-            LayoutReader(isMaximized: $isMaximized) {
+            LayoutReader(layoutInfo: $layoutInfo) {
                 ZStack {
                     Color.red
                         .ignoresSafeArea()
                     Color.blue
-                    Text(isMaximized ? "Maximized" : "Not maximized")
+                    VStack {
+                        Text(layoutInfo.isMaximized ? "Maximized" : "Not maximized")
+                        Text(layoutInfo.isFullScreen ? "Full screen" : "Not full screen")
+                    }
                 }
             }
         }
@@ -61,13 +77,16 @@ struct LayoutReader_Previews: PreviewProvider {
     }
 
     private struct SafeAreaInLayoutReader: View {
-        @State private var isMaximized = false
+        @State private var layoutInfo: LayoutInfo = .none
 
         var body: some View {
-            LayoutReader(isMaximized: $isMaximized) {
+            LayoutReader(layoutInfo: $layoutInfo) {
                 Color.red
                 Color.blue
-                Text(isMaximized ? "Maximized" : "Not maximized")
+                VStack {
+                    Text(layoutInfo.isMaximized ? "Maximized" : "Not maximized")
+                    Text(layoutInfo.isFullScreen ? "Full screen" : "Not full screen")
+                }
             }
         }
     }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -114,6 +114,7 @@ struct LayoutReader_Previews: PreviewProvider {
             Color.yellow
                 .sheet(isPresented: .constant(true)) {
                     SafeAreaInLayoutReader()
+                        .interactiveDismissDisabled()
                 }
         }
     }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -100,6 +100,24 @@ struct LayoutReader_Previews: PreviewProvider {
         }
     }
 
+    private struct NonMaximizedLayoutReader: View {
+        var body: some View {
+            ZStack {
+                SafeAreaInLayoutReader()
+                    .frame(width: 400, height: 400)
+            }
+        }
+    }
+
+    private struct NonFullScreenLayoutReader: View {
+        var body: some View {
+            Color.yellow
+                .sheet(isPresented: .constant(true)) {
+                    SafeAreaInLayoutReader()
+                }
+        }
+    }
+
     static var previews: some View {
         IgnoredSafeAreaInLayoutReader()
             .previewDisplayName("Safe area ignored in LayoutReader")
@@ -109,10 +127,9 @@ struct LayoutReader_Previews: PreviewProvider {
             .previewDisplayName("Safe area in LayoutReader")
         SafeAreaInZStack()
             .previewDisplayName("Safe area in ZStack")
-        VStack {
-            SafeAreaInLayoutReader()
-                .frame(width: 400, height: 400)
-        }
-        .previewDisplayName("Non-maximized LayoutReader")
+        NonMaximizedLayoutReader()
+            .previewDisplayName("Non-maximized LayoutReader")
+        NonFullScreenLayoutReader()
+            .previewDisplayName("Non full-screen LayoutReader")
     }
 }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -58,8 +58,8 @@ struct LayoutReader_Previews: PreviewProvider {
                         .ignoresSafeArea()
                     Color.blue
                     VStack {
-                        Text(layoutInfo.isMaximized ? "Maximized" : "Not maximized")
-                        Text(layoutInfo.isFullScreen ? "Full screen" : "Not full screen")
+                        Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                        Text(layoutInfo.isFullScreen ? "✅ Full screen" : "❌ Not full screen")
                     }
                 }
             }
@@ -84,8 +84,8 @@ struct LayoutReader_Previews: PreviewProvider {
                 Color.red
                 Color.blue
                 VStack {
-                    Text(layoutInfo.isMaximized ? "Maximized" : "Not maximized")
-                    Text(layoutInfo.isFullScreen ? "Full screen" : "Not full screen")
+                    Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                    Text(layoutInfo.isFullScreen ? "✅ Full screen" : "❌ Not full screen")
                 }
             }
         }
@@ -101,20 +101,34 @@ struct LayoutReader_Previews: PreviewProvider {
     }
 
     private struct NonMaximizedLayoutReader: View {
+        @State private var layoutInfo: LayoutInfo = .none
+
         var body: some View {
-            ZStack {
-                SafeAreaInLayoutReader()
-                    .frame(width: 400, height: 400)
+            LayoutReader(layoutInfo: $layoutInfo) {
+                Color.blue
+                VStack {
+                    Text(layoutInfo.isMaximized ? "❌ Maximized" : "✅ Not maximized")
+                    Text(layoutInfo.isFullScreen ? "❌ Full screen" : "✅ Not full screen")
+                }
             }
+            .frame(width: 400, height: 400)
         }
     }
 
     private struct NonFullScreenLayoutReader: View {
+        @State private var layoutInfo: LayoutInfo = .none
+
         var body: some View {
             Color.yellow
                 .sheet(isPresented: .constant(true)) {
-                    SafeAreaInLayoutReader()
-                        .interactiveDismissDisabled()
+                    LayoutReader(layoutInfo: $layoutInfo) {
+                        Color.blue
+                        VStack {
+                            Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                            Text(layoutInfo.isFullScreen ? "❌ Full screen" : "✅ Not full screen")
+                        }
+                    }
+                    .interactiveDismissDisabled()
                 }
         }
     }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -35,33 +35,65 @@ public struct LayoutReader<Content: View>: View {
 
 @available(tvOS, unavailable)
 struct LayoutReader_Previews: PreviewProvider {
-    static var previews: some View {
-        LayoutReader(isMaximized: .constant(true)) {
+    private struct IgnoredSafeAreaInLayoutReader: View {
+        @State private var isMaximized = false
+
+        var body: some View {
+            LayoutReader(isMaximized: $isMaximized) {
+                ZStack {
+                    Color.red
+                        .ignoresSafeArea()
+                    Color.blue
+                    Text(isMaximized ? "Maximized" : "Not maximized")
+                }
+            }
+        }
+    }
+
+    private struct IgnoredSafeAreaInZStack: View {
+        var body: some View {
             ZStack {
                 Color.red
                     .ignoresSafeArea()
                 Color.blue
             }
         }
-        .previewDisplayName("Safe area ignored in LayoutReader")
+    }
 
-        ZStack {
-            Color.red
-                .ignoresSafeArea()
-            Color.blue
-        }
-        .previewDisplayName("Safe area ignored in ZStack")
+    private struct SafeAreaInLayoutReader: View {
+        @State private var isMaximized = false
 
-        LayoutReader(isMaximized: .constant(true)) {
-            Color.red
-            Color.blue
+        var body: some View {
+            LayoutReader(isMaximized: $isMaximized) {
+                Color.red
+                Color.blue
+                Text(isMaximized ? "Maximized" : "Not maximized")
+            }
         }
-        .previewDisplayName("Simple LayoutReader")
+    }
 
-        ZStack {
-            Color.red
-            Color.blue
+    private struct SafeAreaInZStack: View {
+        var body: some View {
+            ZStack {
+                Color.red
+                Color.blue
+            }
         }
-        .previewDisplayName("Simple ZStack")
+    }
+
+    static var previews: some View {
+        IgnoredSafeAreaInLayoutReader()
+            .previewDisplayName("Safe area ignored in LayoutReader")
+        IgnoredSafeAreaInZStack()
+            .previewDisplayName("Safe area ignored in ZStack")
+        SafeAreaInLayoutReader()
+            .previewDisplayName("Safe area in LayoutReader")
+        SafeAreaInZStack()
+            .previewDisplayName("Safe area in ZStack")
+        VStack {
+            SafeAreaInLayoutReader()
+                .frame(width: 400, height: 400)
+        }
+        .previewDisplayName("Non-maximized LayoutReader")
     }
 }

--- a/Sources/Player/LayoutReader.swift
+++ b/Sources/Player/LayoutReader.swift
@@ -38,7 +38,7 @@ public struct LayoutReader<Content: View>: View {
 
     /// Create the layout reader.
     /// - Parameters:
-    ///   - info: The layout information.
+    ///   - layoutInfo: The layout information.
     ///   - content: The wrapped content.
     public init(layoutInfo: Binding<LayoutInfo>, @ViewBuilder content: @escaping () -> Content) {
         _layoutInfo = layoutInfo

--- a/Sources/Player/LayoutReaderHost.swift
+++ b/Sources/Player/LayoutReaderHost.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-/// An internal host controller which can determine if it is maximized in its parent context.
+/// An internal host controller which can determine whether it is maximized in its parent context or full screen.
 @available(tvOS, unavailable)
 final class LayoutReaderHostingController<Content: View>: UIHostingController<Content>, UIGestureRecognizerDelegate {
     var layoutInfo: Binding<LayoutInfo> = .constant(.none)

--- a/Tests/CircumspectTests/ObservableObjectTests.swift
+++ b/Tests/CircumspectTests/ObservableObjectTests.swift
@@ -23,8 +23,7 @@ final class ObservableObjectTests: XCTestCase {
         let object = TestObservableObject()
         expectAtLeastEqualPublished(
             values: [2],
-            from: object.changePublisher(at: \.nonPublishedProperty),
-            timeout: .seconds(2)
+            from: object.changePublisher(at: \.nonPublishedProperty)
         )
     }
 
@@ -32,8 +31,7 @@ final class ObservableObjectTests: XCTestCase {
         let object = TestObservableObject()
         expectAtLeastEqualPublished(
             values: [1],
-            from: object.changePublisher(at: \.publishedProperty1),
-            timeout: .seconds(2)
+            from: object.changePublisher(at: \.publishedProperty1)
         )
     }
 
@@ -41,8 +39,7 @@ final class ObservableObjectTests: XCTestCase {
         let object = TestObservableObject()
         expectAtLeastEqualPublished(
             values: [2, 8, 8],
-            from: object.changePublisher(at: \.nonPublishedProperty),
-            timeout: .seconds(2)
+            from: object.changePublisher(at: \.nonPublishedProperty)
         ) {
             object.publishedProperty1 = 4
             object.publishedProperty2 = "b"
@@ -53,8 +50,7 @@ final class ObservableObjectTests: XCTestCase {
         let object = TestObservableObject()
         expectAtLeastEqualPublished(
             values: [1, 3, 3, 3],
-            from: object.changePublisher(at: \.publishedProperty1),
-            timeout: .seconds(2)
+            from: object.changePublisher(at: \.publishedProperty1)
         ) {
             object.publishedProperty1 = 2
             object.publishedProperty1 = 3

--- a/Tests/CircumspectTests/ObservableObjectTests.swift
+++ b/Tests/CircumspectTests/ObservableObjectTests.swift
@@ -24,7 +24,7 @@ final class ObservableObjectTests: XCTestCase {
         expectAtLeastEqualPublished(
             values: [2],
             from: object.changePublisher(at: \.nonPublishedProperty),
-            timeout: 2
+            timeout: .seconds(2)
         )
     }
 
@@ -33,7 +33,7 @@ final class ObservableObjectTests: XCTestCase {
         expectAtLeastEqualPublished(
             values: [1],
             from: object.changePublisher(at: \.publishedProperty1),
-            timeout: 2
+            timeout: .seconds(2)
         )
     }
 
@@ -42,7 +42,7 @@ final class ObservableObjectTests: XCTestCase {
         expectAtLeastEqualPublished(
             values: [2, 8, 8],
             from: object.changePublisher(at: \.nonPublishedProperty),
-            timeout: 2
+            timeout: .seconds(2)
         ) {
             object.publishedProperty1 = 4
             object.publishedProperty2 = "b"
@@ -54,7 +54,7 @@ final class ObservableObjectTests: XCTestCase {
         expectAtLeastEqualPublished(
             values: [1, 3, 3, 3],
             from: object.changePublisher(at: \.publishedProperty1),
-            timeout: 2
+            timeout: .seconds(2)
         ) {
             object.publishedProperty1 = 2
             object.publishedProperty1 = 3

--- a/Tests/CircumspectTests/TimeIntervalTests.swift
+++ b/Tests/CircumspectTests/TimeIntervalTests.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Circumspect
+
+import Dispatch
+import Nimble
+import XCTest
+
+final class TimeIntervalTests: XCTestCase {
+    func testDoubleConversion() {
+        expect(DispatchTimeInterval.seconds(1).double()).to(equal(1))
+        expect(DispatchTimeInterval.milliseconds(1000).double()).to(equal(1))
+        expect(DispatchTimeInterval.microseconds(1000000).double()).to(equal(1))
+        expect(DispatchTimeInterval.nanoseconds(1000000000).double()).to(equal(1))
+    }
+}

--- a/Tests/CircumspectTests/TimeIntervalTests.swift
+++ b/Tests/CircumspectTests/TimeIntervalTests.swift
@@ -13,8 +13,8 @@ import XCTest
 final class TimeIntervalTests: XCTestCase {
     func testDoubleConversion() {
         expect(DispatchTimeInterval.seconds(1).double()).to(equal(1))
-        expect(DispatchTimeInterval.milliseconds(1000).double()).to(equal(1))
-        expect(DispatchTimeInterval.microseconds(1000000).double()).to(equal(1))
-        expect(DispatchTimeInterval.nanoseconds(1000000000).double()).to(equal(1))
+        expect(DispatchTimeInterval.milliseconds(1_000).double()).to(equal(1))
+        expect(DispatchTimeInterval.microseconds(1_000_000).double()).to(equal(1))
+        expect(DispatchTimeInterval.nanoseconds(1_000_000_000).double()).to(equal(1))
     }
 }

--- a/Tests/CoreTests/TimeTests.swift
+++ b/Tests/CoreTests/TimeTests.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-@testable import Player
+@testable import Core
 
 import CoreMedia
 import Nimble

--- a/Tests/CoreTests/WeakCapturePublisherTests.swift
+++ b/Tests/CoreTests/WeakCapturePublisherTests.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-@testable import Player
+@testable import Core
 
 import Combine
 import Nimble

--- a/Tests/PlayerTests/BackwardNavigationTests.swift
+++ b/Tests/PlayerTests/BackwardNavigationTests.swift
@@ -158,7 +158,7 @@ final class BackwardNavigationTests: TestCase {
         }
         player.returnToPrevious()
         expect(player.currentIndex).to(equal(0))
-        expect(player.time).toEventually(equal(.zero), timeout: .seconds(3))
+        expect(player.time).toEventually(equal(.zero))
     }
 
     func testReturnForLiveWithPreviousItem() {

--- a/Tests/PlayerTests/ItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherTests.swift
@@ -18,7 +18,7 @@ final class ItemDurationPublisherTests: TestCase {
             values: [.invalid, Stream.onDemand.duration],
             from: item.durationPublisher(),
             to: beClose(within: 1),
-            timeout: 2
+            timeout: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/ItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherTests.swift
@@ -17,8 +17,7 @@ final class ItemDurationPublisherTests: TestCase {
         expectAtLeastPublished(
             values: [.invalid, Stream.onDemand.duration],
             from: item.durationPublisher(),
-            to: beClose(within: 1),
-            timeout: .seconds(2)
+            to: beClose(within: 1)
         )
     }
 }

--- a/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
@@ -17,8 +17,7 @@ final class PlayerItemDurationPublisherTests: TestCase {
         expectAtLeastPublished(
             values: [.invalid, Stream.onDemand.duration],
             from: player.currentItemDurationPublisher(),
-            to: beClose(within: 1),
-            timeout: .seconds(2)
+            to: beClose(within: 1)
         )
     }
 }

--- a/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemDurationPublisherTests.swift
@@ -18,7 +18,7 @@ final class PlayerItemDurationPublisherTests: TestCase {
             values: [.invalid, Stream.onDemand.duration],
             from: player.currentItemDurationPublisher(),
             to: beClose(within: 1),
-            timeout: 2
+            timeout: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -84,7 +84,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.isProgressAvailable).toEventually(beTrue(), timeout: .seconds(2))
+        expect(progressTracker.isProgressAvailable).toEventually(beTrue())
 
         expectEqualPublished(
             values: [true, false],
@@ -102,7 +102,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.isProgressAvailable).toEventually(beTrue(), timeout: .seconds(2))
+        expect(progressTracker.isProgressAvailable).toEventually(beTrue())
 
         expectEqualPublished(
             values: [true, false],

--- a/Tests/PlayerTests/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressTests.swift
@@ -86,7 +86,7 @@ final class ProgressTrackerProgressTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.progress).toEventuallyNot(equal(0), timeout: .seconds(2))
+        expect(progressTracker.progress).toEventuallyNot(equal(0))
 
         let progress = progressTracker.progress
         expectEqualPublished(
@@ -105,7 +105,7 @@ final class ProgressTrackerProgressTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.progress).toEventuallyNot(equal(0), timeout: .seconds(2))
+        expect(progressTracker.progress).toEventuallyNot(equal(0))
 
         let progress = progressTracker.progress
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -84,7 +84,7 @@ final class ProgressTrackerRangeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.range).toEventuallyNot(equal(0...0), timeout: .seconds(2))
+        expect(progressTracker.range).toEventuallyNot(equal(0...0))
 
         expectEqualPublished(
             values: [0...1, 0...0],
@@ -102,7 +102,7 @@ final class ProgressTrackerRangeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.range).toEventuallyNot(equal(0...0), timeout: .seconds(2))
+        expect(progressTracker.range).toEventuallyNot(equal(0...0))
 
         expectEqualPublished(
             values: [0...1, 0...0],

--- a/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
@@ -21,7 +21,7 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
-        expect(progressTracker.range).toEventually(equal(0...1), timeout: .seconds(2))
+        expect(progressTracker.range).toEventually(equal(0...1))
 
         expectEqualPublished(
             values: [false, true, false],
@@ -42,7 +42,7 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         progressTracker.player = player
-        expect(progressTracker.range).toEventually(equal(0...1), timeout: .seconds(2))
+        expect(progressTracker.range).toEventually(equal(0...1))
 
         expectEqualPublished(
             values: [false],

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -101,7 +101,7 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.time).toEventuallyNot(beNil(), timeout: .seconds(2))
+        expect(progressTracker.time).toEventuallyNot(beNil())
 
         let time = progressTracker.time
         expectEqualPublished(
@@ -120,7 +120,7 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.time).toEventuallyNot(beNil(), timeout: .seconds(2))
+        expect(progressTracker.time).toEventuallyNot(beNil())
 
         let time = progressTracker.time
         expectEqualPublished(

--- a/Tests/PlayerTests/ProgressTrackerValueTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerValueTests.swift
@@ -17,7 +17,7 @@ final class ProgressTrackerValueTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.range).toEventuallyNot(equal(0...0), timeout: .seconds(2))
+        expect(progressTracker.range).toEventuallyNot(equal(0...0))
         progressTracker.progress = 0.5
         expect(progressTracker.progress).to(beCloseTo(0.5, within: 0.1))
     }
@@ -28,7 +28,7 @@ final class ProgressTrackerValueTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.range).toEventuallyNot(equal(0...0), timeout: .seconds(2))
+        expect(progressTracker.range).toEventuallyNot(equal(0...0))
         progressTracker.progress = -10
         expect(progressTracker.progress).to(beCloseTo(0, within: 0.1))
     }
@@ -39,7 +39,7 @@ final class ProgressTrackerValueTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.range).toEventuallyNot(equal(0...0), timeout: .seconds(2))
+        expect(progressTracker.range).toEventuallyNot(equal(0...0))
         progressTracker.progress = 10
         expect(progressTracker.progress).to(beCloseTo(1, within: 0.1))
     }

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -91,7 +91,7 @@ final class QueuePlayerSeekTests: TestCase {
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
             Notification(name: .didSeek, object: player)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testNotificationsForSeekAfterSmoothSeekWithinTimeRange() {
@@ -112,7 +112,7 @@ final class QueuePlayerSeekTests: TestCase {
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
             Notification(name: .didSeek, object: player)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testCompletionsForMultipleSeeks() {
@@ -210,7 +210,7 @@ final class QueuePlayerSeekTests: TestCase {
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time]),
             Notification(name: .didSeek, object: player),
             Notification(name: notificationName, object: self)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testNotificationCompletionOrderWithMultipleSeeks() {
@@ -235,7 +235,7 @@ final class QueuePlayerSeekTests: TestCase {
             Notification(name: notificationName1, object: self),
             Notification(name: .didSeek, object: player),
             Notification(name: notificationName2, object: self)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testEnqueue() {

--- a/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSmoothSeekTests.swift
@@ -75,7 +75,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
             Notification(name: .didSeek, object: player)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testNotificationsForSmoothSeekAfterSeekWithinTimeRange() {
@@ -96,7 +96,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
             Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
             Notification(name: .didSeek, object: player)
-        ]), from: QueuePlayer.notificationCenter), timeout: .seconds(5))
+        ]), from: QueuePlayer.notificationCenter))
     }
 
     func testCompletionsForMultipleSeeks() {

--- a/Tests/PlayerTests/SmartBackwardNavigationTests.swift
+++ b/Tests/PlayerTests/SmartBackwardNavigationTests.swift
@@ -127,7 +127,7 @@ final class SmartBackwardNavigationTests: TestCase {
 
         player.returnToPrevious()
         expect(player.currentIndex).to(equal(0))
-        expect(player.time).toEventually(equal(.zero), timeout: .seconds(3))
+        expect(player.time).toEventually(equal(.zero))
     }
 
     func testReturnForOnDemandAtBeginningWithPreviousItem() {
@@ -154,7 +154,7 @@ final class SmartBackwardNavigationTests: TestCase {
         }
         player.returnToPrevious()
         expect(player.currentIndex).to(equal(1))
-        expect(player.time).toEventually(equal(.zero), timeout: .seconds(3))
+        expect(player.time).toEventually(equal(.zero))
     }
 
     func testReturnForLiveWithPreviousItem() {

--- a/Tests/PlayerTests/TestCase.swift
+++ b/Tests/PlayerTests/TestCase.swift
@@ -11,7 +11,7 @@ import XCTest
 /// in tests will use the same value by default and should likely always provide an explicit `until` parameter.
 class TestCase: XCTestCase {
     override class func setUp() {
-        AsyncDefaults.timeout = .seconds(10)
+        AsyncDefaults.timeout = .seconds(20)
     }
 
     override class func tearDown() {

--- a/Tests/PlayerTests/TestCase.swift
+++ b/Tests/PlayerTests/TestCase.swift
@@ -11,7 +11,7 @@ import XCTest
 /// in tests will use the same value by default and should likely always provide an explicit `until` parameter.
 class TestCase: XCTestCase {
     override class func setUp() {
-        AsyncDefaults.timeout = .seconds(20)
+        AsyncDefaults.timeout = .seconds(10)
     }
 
     override class func tearDown() {

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -196,9 +196,9 @@ To make it easier to spot where user interface updates can be optimized our `Cor
 
 Sometimes you want to enable behaviors only when a player view fills its parent context, for example zoom gestures which control the `VideoView` gravity.
 
-Pillarbox does not implement such behaviors natively but instead provides a `LayoutReader` wrapper returning its maximization state in the parent context through a binding.
+Pillarbox does not implement such behaviors natively but instead provides a `LayoutReader` wrapper returning its layout information through a binding.
 
-Here is for example how you could implement a pinch gesture only available when the player view is maximized:
+Here is for example how you could implement a pinch gesture only available when the player view is maximized in its parent context:
 
 ```swift
 struct PlayerView: View {
@@ -207,11 +207,11 @@ struct PlayerView: View {
         .urn("urn:rts:video:13444333")
     ])
 
-    @State private var isMaximized = false
+    @State private var layoutInfo: LayoutInfo = .none
     @State private var gravity: AVLayerVideoGravity = .resizeAspect
 
     var body: some View {
-        LayoutReader(isMaximized: $isMaximized) {
+        LayoutReader(layoutInfo: $layoutInfo) {
             VideoView(player: player, gravity: gravity)
                 .gesture(magnificationGesture(), including: magnificationGestureMask)
                 .ignoresSafeArea()
@@ -220,7 +220,7 @@ struct PlayerView: View {
     }
 
     private var magnificationGestureMask: GestureMask {
-        isMaximized ? .all : .subviews
+        layoutInfo.isMaximized ? .all : .subviews
     }
 
     private func magnificationGesture() -> some Gesture {
@@ -231,6 +231,8 @@ struct PlayerView: View {
     }
 }
 ```
+
+You can also use a layout reader to check whether the view covers the full screen.
 
 ## Playlists
 


### PR DESCRIPTION
# Pull request

## Description

This PR improves the `InteractionView` and `LayoutReader` view wrappers to provide them with new capabilities.

## Changes made

- Make it possible to retrieve interaction state from `InteractionView` through a Boolean binding.
- Make it possible to find whether a view covers the full screen from `LayoutReader`. A `LayoutInfo` struct has been introduced to return the existing maximization information as well.
- Check wrapper expected behaviors in revamped Xcode previews.
- Improve demo video gravity management.
- Fix unreliable tests which were using a timeout to small for our CI servers. Some small timeouts useful to test the implementation (e.g. queue player delayed append) have been preserved.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
