### PR TITLE
Make behavior consistent at the end of a playback

### DIFF
--- a/Demo/Sources/Constant.swift
+++ b/Demo/Sources/Constant.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 let kPageSize: UInt = 50
 
@@ -14,4 +15,10 @@ func constant<T>(iOS: T, tvOS: T) -> T {
 #else
     return iOS
 #endif
+}
+
+extension Animation {
+    static var linear: Animation {
+        .linear(duration: 0.2)
+    }
 }

--- a/Demo/Sources/ContentListView.swift
+++ b/Demo/Sources/ContentListView.swift
@@ -103,7 +103,7 @@ struct ContentListView: View {
                 RefreshableMessageView(model: model, message: error.localizedDescription, icon: .error)
             }
         }
-        .animation(.linear(duration: 0.2), value: model.state)
+        .animation(.linear, value: model.state)
         .onAppear { model.configuration = configuration }
         .navigationTitle(configuration.kind.name)
     }

--- a/Demo/Sources/ExamplesView.swift
+++ b/Demo/Sources/ExamplesView.swift
@@ -83,7 +83,7 @@ struct ExamplesView: View {
             section(title: "Corner cases", medias: model.cornerCaseMedias)
         }
         .scrollDismissesKeyboard(.immediately)
-        .animation(.linear(duration: 0.2), value: model.protectedMedias)
+        .animation(.linear, value: model.protectedMedias)
         .navigationTitle("Examples")
         .refreshable { await model.refresh() }
     }

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -191,12 +191,8 @@ private struct SkipBackwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .opacity(canSkipBackward ? 1 : 0)
-        .animation(.linear(duration: 0.2), value: canSkipBackward)
-    }
-
-    private var canSkipBackward: Bool {
-        player.canSkipBackward()
+        .opacity(player.canSkipBackward() ? 1 : 0)
+        .animation(.linear(duration: 0.2), value: player.canSkipBackward())
     }
 
     private func skipBackward() {
@@ -217,12 +213,8 @@ private struct SkipForwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .opacity(canSkipForward ? 1 : 0)
-        .animation(.linear(duration: 0.2), value: canSkipForward)
-    }
-
-    private var canSkipForward: Bool {
-        player.canSkipForward()
+        .opacity(player.canSkipForward() ? 1 : 0)
+        .animation(.linear(duration: 0.2), value: player.canSkipForward())
     }
 
     private func skipForward() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -24,8 +24,8 @@ private struct MainView: View {
                 main()
                 timeBar()
             }
-            .animation(.linear(duration: 0.2), value: player.isBusy)
-            .animation(.linear(duration: 0.2), value: isUserInterfaceHidden)
+            .animation(.linear, value: player.isBusy)
+            .animation(.linear, value: isUserInterfaceHidden)
         }
         .bind(visibilityTracker, to: player)
         .debugBodyCounter()
@@ -58,7 +58,7 @@ private struct MainView: View {
                 controls()
                 loadingIndicator()
             }
-            .animation(.linear(duration: 0.2), value: isUserInterfaceHidden)
+            .animation(.linear, value: isUserInterfaceHidden)
             .accessibilityAddTraits(.isButton)
             .onTapGesture(perform: visibilityTracker.toggle)
             .gesture(magnificationGesture(), including: magnificationGestureMask)
@@ -119,7 +119,7 @@ private struct ControlsView: View {
             }
             .debugBodyCounter(color: .green)
         }
-        .animation(.linear(duration: 0.2), value: player.playbackState)
+        .animation(.linear, value: player.playbackState)
         .bind(progressTracker, to: player)
     }
 }
@@ -161,8 +161,8 @@ private struct PlaybackButton: View {
                 .resizable()
                 .tint(.white)
                 .opacity(player.isBusy ? 0 : 1)
-                .animation(.linear(duration: 0.2), value: player.playbackState)
-                .animation(.linear(duration: 0.2), value: player.canRestart())
+                .animation(.linear, value: player.playbackState)
+                .animation(.linear, value: player.canRestart())
         }
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
@@ -192,7 +192,7 @@ private struct SkipBackwardButton: View {
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
         .opacity(player.canSkipBackward() ? 1 : 0)
-        .animation(.linear(duration: 0.2), value: player.canSkipBackward())
+        .animation(.linear, value: player.canSkipBackward())
     }
 
     private func skipBackward() {
@@ -214,7 +214,7 @@ private struct SkipForwardButton: View {
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
         .opacity(player.canSkipForward() ? 1 : 0)
-        .animation(.linear(duration: 0.2), value: player.canSkipForward())
+        .animation(.linear, value: player.canSkipForward())
     }
 
     private func skipForward() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -25,7 +25,7 @@ private struct MainView: View {
                 timeBar()
             }
             .animation(.linear(duration: 0.2), value: player.isBusy)
-            .animation(.linear(duration: 0.2), value: visibilityTracker.isUserInterfaceHidden)
+            .animation(.linear(duration: 0.2), value: isUserInterfaceHidden)
         }
         .bind(visibilityTracker, to: player)
         .debugBodyCounter()
@@ -37,6 +37,10 @@ private struct MainView: View {
 
     private var magnificationGestureMask: GestureMask {
         layoutInfo.isMaximized ? .all : .subviews
+    }
+
+    private var isUserInterfaceHidden: Bool {
+        visibilityTracker.isUserInterfaceHidden && !player.canRestart()
     }
 
     private func magnificationGesture() -> some Gesture {
@@ -54,7 +58,7 @@ private struct MainView: View {
                 controls()
                 loadingIndicator()
             }
-            .animation(.linear(duration: 0.2), value: visibilityTracker.isUserInterfaceHidden)
+            .animation(.linear(duration: 0.2), value: isUserInterfaceHidden)
             .accessibilityAddTraits(.isButton)
             .onTapGesture(perform: visibilityTracker.toggle)
             .gesture(magnificationGesture(), including: magnificationGestureMask)
@@ -65,7 +69,7 @@ private struct MainView: View {
     @ViewBuilder
     private func timeBar() -> some View {
         TimeBar(player: player)
-            .opacity(visibilityTracker.isUserInterfaceHidden ? 0 : 1)
+            .opacity(isUserInterfaceHidden ? 0 : 1)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 
@@ -89,7 +93,7 @@ private struct MainView: View {
     @ViewBuilder
     private func controls() -> some View {
         ControlsView(player: player)
-            .opacity(visibilityTracker.isUserInterfaceHidden ? 0 : 1)
+            .opacity(isUserInterfaceHidden ? 0 : 1)
     }
 
     @ViewBuilder

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -142,7 +142,7 @@ private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
     private var imageName: String {
-        if player.canRestart() {
+        if canRestart {
             return "arrow.counterclockwise"
         }
         else {
@@ -155,6 +155,10 @@ private struct PlaybackButton: View {
         }
     }
 
+    private var canRestart: Bool {
+        player.canRestart()
+    }
+
     var body: some View {
         Button(action: play) {
             Image(systemName: imageName)
@@ -162,13 +166,14 @@ private struct PlaybackButton: View {
                 .tint(.white)
                 .opacity(player.isBusy ? 0 : 1)
                 .animation(.linear(duration: 0.2), value: player.playbackState)
+                .animation(.linear(duration: 0.2), value: canRestart)
         }
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
     }
 
     private func play() {
-        if player.canRestart() {
+        if canRestart {
             player.restart()
         }
         else {
@@ -190,7 +195,12 @@ private struct SkipBackwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .opacity(player.canSkipBackward() ? 1 : 0)
+        .opacity(canSkipBackward ? 1 : 0)
+        .animation(.linear(duration: 0.2), value: canSkipBackward)
+    }
+
+    private var canSkipBackward: Bool {
+        player.canSkipBackward()
     }
 
     private func skipBackward() {
@@ -211,7 +221,12 @@ private struct SkipForwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .opacity(player.canSkipForward() ? 1 : 0)
+        .opacity(canSkipForward ? 1 : 0)
+        .animation(.linear(duration: 0.2), value: canSkipForward)
+    }
+
+    private var canSkipForward: Bool {
+        player.canSkipForward()
     }
 
     private func skipForward() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -136,20 +136,32 @@ private struct PlaybackMessageView: View {
 private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
-    private var playbackButtonImageName: String {
-        switch player.playbackState {
-        case .playing:
-            return "pause.circle.fill"
-        default:
-            return "play.circle.fill"
+    private var imageName: String {
+        if isFinished {
+            return "arrow.counterclockwise"
         }
+        else {
+            switch player.playbackState {
+            case .playing:
+                return "pause.circle.fill"
+            default:
+                return "play.circle.fill"
+            }
+        }
+    }
+
+    private var isFinished: Bool {
+        player.currentIndex == nil
     }
 
     var body: some View {
         Button(action: play) {
-            Image(systemName: playbackButtonImageName)
+            Image(systemName: imageName)
                 .resizable()
                 .tint(.white)
+                .transaction { transaction in
+                    transaction.animation = nil
+                }
         }
         .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
@@ -157,7 +169,7 @@ private struct PlaybackButton: View {
     }
 
     private func play() {
-        if player.currentIndex != nil {
+        if !isFinished {
             player.togglePlayPause()
         }
         else {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -119,6 +119,7 @@ private struct ControlsView: View {
             }
             .debugBodyCounter(color: .green)
         }
+        .animation(.linear(duration: 0.2), value: player.playbackState)
         .bind(progressTracker, to: player)
     }
 }
@@ -159,14 +160,11 @@ private struct PlaybackButton: View {
             Image(systemName: imageName)
                 .resizable()
                 .tint(.white)
-                .transaction { transaction in
-                    transaction.animation = nil
-                }
+                .opacity(player.isBusy ? 0 : 1)
+                .animation(.linear(duration: 0.2), value: player.playbackState)
         }
-        .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
-        .frame(height: 90)
-        .frame(minWidth: 120)
+        .frame(minWidth: 120, maxHeight: 90)
     }
 
     private func play() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -192,7 +192,7 @@ private struct SkipBackwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .disabled(!player.canSkipBackward())
+        .opacity(player.canSkipBackward() ? 1 : 0)
     }
 
     private func skipBackward() {
@@ -213,7 +213,7 @@ private struct SkipForwardButton: View {
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
-        .disabled(!player.canSkipForward())
+        .opacity(player.canSkipForward() ? 1 : 0)
     }
 
     private func skipForward() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -146,7 +146,7 @@ private struct PlaybackButton: View {
     }
 
     var body: some View {
-        Button(action: player.togglePlayPause) {
+        Button(action: play) {
             Image(systemName: playbackButtonImageName)
                 .resizable()
                 .tint(.white)
@@ -154,6 +154,15 @@ private struct PlaybackButton: View {
         .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
         .frame(height: constant(iOS: 90, tvOS: 150))
+    }
+
+    private func play() {
+        if player.currentIndex != nil {
+            player.togglePlayPause()
+        }
+        else {
+            try? player.setCurrentIndex(0)
+        }
     }
 }
 

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -356,9 +356,6 @@ struct PlaybackView: View {
             else {
                 PlaybackMessageView(message: "No content")
             }
-            Text("\(player.currentIndex ?? 99999)")
-                .foregroundColor(.pink)
-                .fontWidth(.expanded)
         }
         .background(.black)
         .onAppear(perform: player.play)

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -142,7 +142,7 @@ private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
     private var imageName: String {
-        if canRestart {
+        if player.canRestart() {
             return "arrow.counterclockwise"
         }
         else {
@@ -155,10 +155,6 @@ private struct PlaybackButton: View {
         }
     }
 
-    private var canRestart: Bool {
-        player.canRestart()
-    }
-
     var body: some View {
         Button(action: play) {
             Image(systemName: imageName)
@@ -166,14 +162,14 @@ private struct PlaybackButton: View {
                 .tint(.white)
                 .opacity(player.isBusy ? 0 : 1)
                 .animation(.linear(duration: 0.2), value: player.playbackState)
-                .animation(.linear(duration: 0.2), value: canRestart)
+                .animation(.linear(duration: 0.2), value: player.canRestart())
         }
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
     }
 
     private func play() {
-        if canRestart {
+        if player.canRestart() {
             player.restart()
         }
         else {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -137,7 +137,7 @@ private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
     private var imageName: String {
-        if isFinished {
+        if player.canRestart() {
             return "arrow.counterclockwise"
         }
         else {
@@ -148,10 +148,6 @@ private struct PlaybackButton: View {
                 return "play.circle.fill"
             }
         }
-    }
-
-    private var isFinished: Bool {
-        player.currentIndex == nil
     }
 
     var body: some View {
@@ -169,11 +165,11 @@ private struct PlaybackButton: View {
     }
 
     private func play() {
-        if !isFinished {
-            player.togglePlayPause()
+        if player.canRestart() {
+            try? player.restart()
         }
         else {
-            try? player.setCurrentIndex(0)
+            player.togglePlayPause()
         }
     }
 }

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -143,7 +143,7 @@ private struct PlaybackButton: View {
 
     private var imageName: String {
         if player.canRestart() {
-            return "arrow.counterclockwise"
+            return "arrow.counterclockwise.circle.fill"
         }
         else {
             switch player.playbackState {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -356,6 +356,9 @@ struct PlaybackView: View {
             else {
                 PlaybackMessageView(message: "No content")
             }
+            Text("\(player.currentIndex ?? 99999)")
+                .foregroundColor(.pink)
+                .fontWidth(.expanded)
         }
         .background(.black)
         .onAppear(perform: player.play)

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -166,6 +166,7 @@ private struct PlaybackButton: View {
         .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
         .frame(height: 90)
+        .frame(minWidth: 120)
     }
 
     private func play() {

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -165,7 +165,7 @@ private struct PlaybackButton: View {
         }
         .opacity(player.isBusy ? 0 : 1)
         .aspectRatio(contentMode: .fit)
-        .frame(height: constant(iOS: 90, tvOS: 150))
+        .frame(height: 90)
     }
 
     private func play() {
@@ -190,7 +190,7 @@ private struct SkipBackwardButton: View {
                 .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
-        .frame(height: constant(iOS: 45, tvOS: 75))
+        .frame(height: 45)
         .disabled(!player.canSkipBackward())
     }
 
@@ -211,7 +211,7 @@ private struct SkipForwardButton: View {
                 .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
-        .frame(height: constant(iOS: 45, tvOS: 75))
+        .frame(height: 45)
         .disabled(!player.canSkipForward())
     }
 

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -169,7 +169,7 @@ private struct PlaybackButton: View {
 
     private func play() {
         if player.canRestart() {
-            try? player.restart()
+            player.restart()
         }
         else {
             player.togglePlayPause()

--- a/Demo/Sources/SearchView.swift
+++ b/Demo/Sources/SearchView.swift
@@ -23,7 +23,7 @@ struct SearchView: View {
                 RefreshableMessageView(model: model, message: error.localizedDescription, icon: .error)
             }
         }
-        .animation(.linear(duration: 0.2), value: model.state)
+        .animation(.linear, value: model.state)
         .navigationTitle("Search")
         .searchable(text: $model.text)
 #if os(iOS)

--- a/Demo/Sources/StoriesView.swift
+++ b/Demo/Sources/StoriesView.swift
@@ -21,7 +21,7 @@ private struct StoryView: View {
             TimeProgress(player: player)
         }
         .tint(.white)
-        .animation(.linear(duration: 0.2), value: player.isBusy)
+        .animation(.linear, value: player.isBusy)
     }
 }
 

--- a/Sources/Circumspect/Expectations.swift
+++ b/Sources/Circumspect/Expectations.swift
@@ -346,7 +346,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -367,7 +367,7 @@ public extension XCTestCase {
     func expectEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -388,7 +388,7 @@ public extension XCTestCase {
     func expectSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -412,7 +412,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -435,7 +435,7 @@ public extension XCTestCase {
     func expectEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -458,7 +458,7 @@ public extension XCTestCase {
     func expectSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -480,7 +480,7 @@ public extension XCTestCase {
         values: [P.Output],
         from publisher: P,
         to satisfy: @escaping (P.Output, P.Output) -> Bool,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -507,7 +507,7 @@ public extension XCTestCase {
     /// Ensure a publisher does not emit any value during some time interval.
     func expectNothingPublished<P: Publisher>(
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -525,7 +525,7 @@ public extension XCTestCase {
     /// Ensure a publisher does not emit any value during some time interval.
     func expectNothingPublishedNext<P: Publisher>(
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -543,7 +543,7 @@ public extension XCTestCase {
     private func expectNothingPublished<P: Publisher>(
         next: Bool,
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -632,7 +632,7 @@ public extension XCTestCase {
 ///         collection.
 public extension XCTestCase {
     /// Wait until a list of notifications has been received.
-    func expectReceived(
+    func expectAtLeastReceived(
         notifications: [Notification],
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
@@ -661,7 +661,7 @@ public extension XCTestCase {
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
         center: NotificationCenter = .default,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -684,7 +684,7 @@ public extension XCTestCase {
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,
         center: NotificationCenter = .default,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil

--- a/Sources/Circumspect/Publishers.swift
+++ b/Sources/Circumspect/Publishers.swift
@@ -154,7 +154,7 @@ public extension XCTestCase {
     /// - Returns: The collected output.
     func collectOutput<P: Publisher>(
         from publisher: P,
-        during interval: TimeInterval,
+        during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,
         line: UInt = #line,
         while executing: (() -> Void)? = nil
@@ -176,7 +176,7 @@ public extension XCTestCase {
             executing()
         }
 
-        _ = XCTWaiter.wait(for: [expectation], timeout: interval)
+        _ = XCTWaiter.wait(for: [expectation], timeout: interval.double())
         return values
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -584,6 +584,9 @@ extension Player {
     private struct ItemUpdate {
         let items: Deque<PlayerItem>
         let currentItem: AVPlayerItem?
+        var isLast: Bool {
+            items.last?.matches(currentItem) == true
+        }
 
         func currentIndex() -> Int? {
             items.firstIndex { $0.matches(currentItem) }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -637,9 +637,10 @@ extension Player {
                     return nil
                 }
             case .failed:
-                if previousAndCurrent.current == nil {
-                    return previousAndCurrent.previous??.index
+                if items.count - 1 == previousAndCurrent.previous??.index {
+                    return nil
                 }
+                return previousAndCurrent.previous??.index
             default:
                 break
             }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -595,7 +595,8 @@ public extension Player {
     /// Check whether the player has finished playing its content and can be restarted.
     /// - Returns: `true` if possible.
     func canRestart() -> Bool {
-        Self.smoothCurrentItem(for: itemResult, in: storedItems) == nil
+        guard !storedItems.isEmpty else { return false }
+        return Self.smoothCurrentItem(for: itemResult, in: storedItems) == nil
     }
 
     /// Restart playback if possible.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -576,12 +576,15 @@ extension Player {
 }
 
 public extension Player {
+    /// Check whether the player has finished playing its content and can be restarted.
+    /// - Returns: `true` if possible.
     func canRestart() -> Bool {
         playbackState == .ended && currentIndex == nil
     }
 
-    func restart() throws {
-        try setCurrentIndex(0)
+    /// Restart playback if possible.
+    func restart() {
+        try? setCurrentIndex(0)
     }
 }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -600,6 +600,7 @@ public extension Player {
 
     /// Restart playback if possible.
     func restart() {
+        guard canRestart() else { return }
         try? setCurrentIndex(0)
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -625,7 +625,8 @@ extension Player {
 
     private func configureCurrentIndexPublisher() {
         currentPublisher()
-            .map(\.?.index)
+            .compactMap { $0 }
+            .map { $0.index }
             .receiveOnMainThread()
             .lane("player_current_index")
             .assign(to: &$currentIndex)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -578,17 +578,6 @@ extension Player {
 }
 
 public extension Player {
-    /// Check whether the player has finished playing its content and can be restarted.
-    /// - Returns: `true` if possible.
-    func canRestart() -> Bool {
-        Self.currentItem(for: itemResult, in: storedItems) == nil
-    }
-
-    /// Restart playback if possible.
-    func restart() {
-        try? setCurrentIndex(0)
-    }
-
     private static func currentItem(for itemResult: ItemResult, in items: Deque<PlayerItem>) -> AVPlayerItem? {
         switch itemResult {
         case let .failed(playerItem):
@@ -601,6 +590,17 @@ public extension Player {
         case let .finished(playerItem):
             return playerItem
         }
+    }
+
+    /// Check whether the player has finished playing its content and can be restarted.
+    /// - Returns: `true` if possible.
+    func canRestart() -> Bool {
+        Self.currentItem(for: itemResult, in: storedItems) == nil
+    }
+
+    /// Restart playback if possible.
+    func restart() {
+        try? setCurrentIndex(0)
     }
 }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -632,12 +632,16 @@ extension Player {
                 .map { $0.index }
         )
         .map { items, state, currentIndex in
-            if state == .ended || items.isEmpty {
+            if state == .ended {
+                return items.count - 1
+            }
+            else if items.isEmpty {
                 return nil
             } else {
                 return currentIndex
             }
         }
+        .removeDuplicates()
         .receiveOnMainThread()
         .lane("player_current_index")
         .assign(to: &$currentIndex)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -708,11 +708,6 @@ extension Player {
 
     private func itemUpdatePublisher() -> AnyPublisher<ItemUpdate, Never> {
         Publishers.CombineLatest($storedItems, queuePlayer.publisher(for: \.currentItem))
-            .filter { storedItems, currentItem in
-                // The current item is automatically set to `nil` when a failure is encountered. If this is the case
-                // preserve the previous value, provided the player is loaded with items.
-                storedItems.isEmpty || currentItem != nil
-            }
             .map { ItemUpdate(items: $0, currentItem: $1) }
             .eraseToAnyPublisher()
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -31,7 +31,7 @@ public final class Player: ObservableObject, Equatable {
     /// Indicates whether the player is currently playing video in external playback mode.
     @Published public private(set) var isExternalPlaybackActive = false
 
-    @Published private var itemResult: ItemResult = .finished(nil)
+    @Published private var itemResult: CurrentItem = .good(nil)
     @Published private var storedItems: Deque<PlayerItem>
 
     /// The type of stream currently played.
@@ -578,16 +578,16 @@ extension Player {
 }
 
 public extension Player {
-    private static func smoothCurrentItem(for itemResult: ItemResult, in items: Deque<PlayerItem>) -> AVPlayerItem? {
+    private static func smoothCurrentItem(for itemResult: CurrentItem, in items: Deque<PlayerItem>) -> AVPlayerItem? {
         switch itemResult {
-        case let .failed(playerItem):
+        case let .bad(playerItem):
             if let lastItem = items.last, lastItem.matches(playerItem) {
                 return nil
             }
             else {
                 return playerItem
             }
-        case let .finished(playerItem):
+        case let .good(playerItem):
             return playerItem
         }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -578,7 +578,7 @@ extension Player {
 }
 
 public extension Player {
-    private static func currentItem(for itemResult: ItemResult, in items: Deque<PlayerItem>) -> AVPlayerItem? {
+    private static func smoothCurrentItem(for itemResult: ItemResult, in items: Deque<PlayerItem>) -> AVPlayerItem? {
         switch itemResult {
         case let .failed(playerItem):
             if let lastItem = items.last, lastItem.matches(playerItem) {
@@ -595,7 +595,7 @@ public extension Player {
     /// Check whether the player has finished playing its content and can be restarted.
     /// - Returns: `true` if possible.
     func canRestart() -> Bool {
-        Self.currentItem(for: itemResult, in: storedItems) == nil
+        Self.smoothCurrentItem(for: itemResult, in: storedItems) == nil
     }
 
     /// Restart playback if possible.
@@ -744,7 +744,7 @@ extension Player {
     private func itemUpdatePublisher() -> AnyPublisher<ItemUpdate, Never> {
         Publishers.CombineLatest($storedItems, $itemResult)
             .map { items, itemResult in
-                let playerItem = Self.currentItem(for: itemResult, in: items)
+                let playerItem = Self.smoothCurrentItem(for: itemResult, in: items)
                 return ItemUpdate(items: items, currentItem: playerItem)
             }
             .eraseToAnyPublisher()

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -640,7 +640,7 @@ extension Player {
                 if items.count - 1 == previousAndCurrent.previous??.index {
                     return nil
                 }
-                return previousAndCurrent.previous??.index
+                return previousAndCurrent.previous??.index ?? previousAndCurrent.current?.index
             default:
                 break
             }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -575,6 +575,16 @@ extension Player {
     }
 }
 
+public extension Player {
+    func canRestart() -> Bool {
+        playbackState == .ended && currentIndex == nil
+    }
+
+    func restart() throws {
+        try setCurrentIndex(0)
+    }
+}
+
 extension Player {
     private struct Current: Equatable {
         let item: PlayerItem

--- a/Sources/Player/PlayerItemPublishers.swift
+++ b/Sources/Player/PlayerItemPublishers.swift
@@ -12,11 +12,11 @@ extension AVPlayerItem {
         Publishers.Merge3(
             publisher(for: \.status)
                 .weakCapture(self)
-                .map { ItemState.itemState(for: $0.1) },
+                .map { ItemState(for: $0.1) },
             NotificationCenter.default.weakPublisher(for: .AVPlayerItemDidPlayToEndTime, object: self)
                 .map { _ in .ended },
             NotificationCenter.default.weakPublisher(for: .AVPlayerItemFailedToPlayToEndTime, object: self)
-                .compactMap { ItemState.itemState(for: $0) }
+                .compactMap { ItemState(for: $0) }
         )
         .eraseToAnyPublisher()
     }

--- a/Sources/Player/PlayerPublishers.swift
+++ b/Sources/Player/PlayerPublishers.swift
@@ -6,6 +6,7 @@
 
 import AVFoundation
 import Combine
+import Core
 import TimelaneCombine
 
 extension AVPlayer {
@@ -89,6 +90,23 @@ extension AVPlayer {
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
+            .eraseToAnyPublisher()
+    }
+
+    func smoothCurrentItemPublisher() -> AnyPublisher<AVPlayerItem?, Never> {
+        publisher(for: \.currentItem)
+            .withPrevious()
+            .map { previousItem, currentItem -> AVPlayerItem? in
+                if let previousItem, currentItem == nil {
+                    switch ItemState.itemState(for: previousItem) {
+                    case .failed:
+                        return previousItem
+                    default:
+                        break
+                    }
+                }
+                return currentItem
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/PlayerPublishers.swift
+++ b/Sources/Player/PlayerPublishers.swift
@@ -9,7 +9,7 @@ import Combine
 import Core
 import TimelaneCombine
 
-enum ItemResult {
+enum ItemResult: Equatable {
     case finished(AVPlayerItem?)
     case failed(AVPlayerItem?)
 }

--- a/Sources/Player/PlayerPublishers.swift
+++ b/Sources/Player/PlayerPublishers.swift
@@ -20,7 +20,7 @@ extension AVPlayer {
             .compactMap { $0 }
             .map { $0.itemStatePublisher() }
             .switchToLatest()
-            .prepend(ItemState.itemState(for: currentItem))
+            .prepend(ItemState(for: currentItem))
             .removeDuplicates()
             .lane("player_item_state")
             .eraseToAnyPublisher()
@@ -106,7 +106,7 @@ extension AVPlayer {
                     return .finished(currentItem)
                 }
                 else if let previousItem {
-                    switch ItemState.itemState(for: previousItem) {
+                    switch ItemState(for: previousItem) {
                     case .failed:
                         return .failed(previousItem)
                     default:

--- a/Sources/Player/PlayerPublishers.swift
+++ b/Sources/Player/PlayerPublishers.swift
@@ -9,9 +9,9 @@ import Combine
 import Core
 import TimelaneCombine
 
-enum ItemResult: Equatable {
-    case finished(AVPlayerItem?)
-    case failed(AVPlayerItem?)
+enum CurrentItem: Equatable {
+    case good(AVPlayerItem?)
+    case bad(AVPlayerItem?)
 }
 
 extension AVPlayer {
@@ -98,23 +98,23 @@ extension AVPlayer {
             .eraseToAnyPublisher()
     }
 
-    func smoothCurrentItemPublisher() -> AnyPublisher<ItemResult, Never> {
+    func smoothCurrentItemPublisher() -> AnyPublisher<CurrentItem, Never> {
         publisher(for: \.currentItem)
             .withPrevious()
             .map { previousItem, currentItem in
                 if let currentItem {
-                    return .finished(currentItem)
+                    return .good(currentItem)
                 }
                 else if let previousItem {
                     switch ItemState(for: previousItem) {
                     case .failed:
-                        return .failed(previousItem)
+                        return .bad(previousItem)
                     default:
-                        return .finished(currentItem)
+                        return .good(currentItem)
                     }
                 }
                 else {
-                    return .finished(currentItem)
+                    return .good(currentItem)
                 }
             }
             .eraseToAnyPublisher()

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -136,17 +136,11 @@ extension AVQueuePlayer {
 
         if let firstItem = items.first {
             if firstItem !== self.items().first {
-                if self.items().count > 1 {
-                    self.items().suffix(from: 1).forEach { item in
-                        remove(item)
-                    }
-                }
+                removeAll(from: 1)
                 replaceCurrentItem(with: firstItem)
             }
-            else if self.items().count > 1 {
-                self.items().suffix(from: 1).forEach { item in
-                    remove(item)
-                }
+            else {
+                removeAll(from: 1)
             }
             if items.count > 1 {
                 perform(#selector(append(_:)), with: Array(items.suffix(from: 1)), afterDelay: 1, inModes: [.common])
@@ -154,6 +148,13 @@ extension AVQueuePlayer {
         }
         else {
             removeAllItems()
+        }
+    }
+
+    private func removeAll(from index: Int) {
+        guard items().count > index else { return }
+        items().suffix(from: index).forEach { item in
+            remove(item)
         }
     }
 

--- a/Sources/Player/QueuePlayer.swift
+++ b/Sources/Player/QueuePlayer.swift
@@ -136,7 +136,11 @@ extension AVQueuePlayer {
 
         if let firstItem = items.first {
             if firstItem !== self.items().first {
-                removeAllItems()
+                if self.items().count > 1 {
+                    self.items().suffix(from: 1).forEach { item in
+                        remove(item)
+                    }
+                }
                 replaceCurrentItem(with: firstItem)
             }
             else if self.items().count > 1 {

--- a/Tests/CircumspectTests/ExpectationsTests.swift
+++ b/Tests/CircumspectTests/ExpectationsTests.swift
@@ -57,7 +57,7 @@ final class ExpectationTests: XCTestCase {
         expectEqualPublished(
             values: [0, 1, 2],
             from: counter.$count,
-            during: 0.5
+            during: .milliseconds(500)
         )
     }
 
@@ -67,7 +67,7 @@ final class ExpectationTests: XCTestCase {
         expectEqualPublished(
             values: [4, 7, 8],
             from: subject,
-            during: 0.5
+            during: .milliseconds(500)
         ) {
             subject.send(4)
             subject.send(7)
@@ -80,7 +80,7 @@ final class ExpectationTests: XCTestCase {
         expectEqualPublishedNext(
             values: [1, 2],
             from: counter.$count,
-            during: 0.5
+            during: .milliseconds(500)
         )
     }
 
@@ -90,7 +90,7 @@ final class ExpectationTests: XCTestCase {
         expectEqualPublishedNext(
             values: [7, 8],
             from: subject,
-            during: 0.5
+            during: .milliseconds(500)
         ) {
             subject.send(4)
             subject.send(7)
@@ -101,13 +101,13 @@ final class ExpectationTests: XCTestCase {
     func testExpectNothingPublished() {
         // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
-        expectNothingPublished(from: subject, during: 1)
+        expectNothingPublished(from: subject, during: .seconds(1))
     }
 
     func testExpectNothingPublishedNext() {
         // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
-        expectNothingPublishedNext(from: subject, during: 1) {
+        expectNothingPublishedNext(from: subject, during: .seconds(1)) {
             subject.send(4)
         }
     }
@@ -124,8 +124,8 @@ final class ExpectationTests: XCTestCase {
         expectFailure(StructError(), from: Fail<Int, Error>(error: StructError()))
     }
 
-    func testExpectReceivedNotifications() {
-        expectReceived(
+    func testExpectAtLeastReceivedNotifications() {
+        expectAtLeastReceived(
             notifications: [
                 Notification(name: .testNotification, object: self)
             ],
@@ -141,7 +141,7 @@ final class ExpectationTests: XCTestCase {
                 Notification(name: .testNotification, object: self)
             ],
             for: [.testNotification],
-            during: 0.5
+            during: .milliseconds(500)
         ) {
             NotificationCenter.default.post(name: .testNotification, object: self)
         }

--- a/Tests/CircumspectTests/PublishersTests.swift
+++ b/Tests/CircumspectTests/PublishersTests.swift
@@ -81,14 +81,14 @@ final class PublisherTests: XCTestCase {
 
     func testCollectOutput() {
         let counter = Counter()
-        let values = collectOutput(from: counter.$count, during: 0.5)
+        let values = collectOutput(from: counter.$count, during: .milliseconds(500))
         expect(values).to(equal([0, 1, 2]))
     }
 
     func testCollectOutputWhileExecuting() {
         // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
-        let values = collectOutput(from: subject, during: 0.5) {
+        let values = collectOutput(from: subject, during: .milliseconds(500)) {
             subject.send(4)
             subject.send(7)
         }
@@ -98,7 +98,7 @@ final class PublisherTests: XCTestCase {
     func testCollectOutputImmediately() {
         let values = collectOutput(
             from: [1, 2, 3, 4, 5].publisher,
-            during: 0
+            during: .never
         )
         expect(values).to(equal([1, 2, 3, 4, 5]))
     }

--- a/Tests/CoreTests/NotificationPublisherTests.swift
+++ b/Tests/CoreTests/NotificationPublisherTests.swift
@@ -40,7 +40,7 @@ final class NotificationPublisherTests: XCTestCase {
 
         // We were interested in notifications from `object` only. After its release we should not receive other
         // notifications from any other source anymore.
-        expectNothingPublished(from: publisher, during: 1) {
+        expectNothingPublished(from: publisher, during: .seconds(1)) {
             notificationCenter.post(name: .testNotification, object: nil)
         }
     }

--- a/Tests/CoreTests/PublishAndRepeatOnOutputFromTests.swift
+++ b/Tests/CoreTests/PublishAndRepeatOnOutputFromTests.swift
@@ -17,21 +17,21 @@ final class PublishAndRepeatOnOutputFromTests: XCTestCase {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: Optional<AnyPublisher<Void, Never>>.none) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: 1)
+        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1))
     }
 
     func testInactiveSignal() {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: 1)
+        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1))
     }
 
     func testActiveSignal() {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out", "out"], from: publisher, during: 1) { [trigger] in
+        expectEqualPublished(values: ["out", "out"], from: publisher, during: .seconds(1)) { [trigger] in
             trigger.activate(for: 1)
         }
     }

--- a/Tests/CoreTests/PublishAndRepeatOnOutputFromTests.swift
+++ b/Tests/CoreTests/PublishAndRepeatOnOutputFromTests.swift
@@ -17,21 +17,21 @@ final class PublishAndRepeatOnOutputFromTests: XCTestCase {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: Optional<AnyPublisher<Void, Never>>.none) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1))
+        expectAtLeastEqualPublished(values: ["out"], from: publisher)
     }
 
     func testInactiveSignal() {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1))
+        expectAtLeastEqualPublished(values: ["out"], from: publisher)
     }
 
     func testActiveSignal() {
         let publisher = Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out", "out"], from: publisher, during: .seconds(1)) { [trigger] in
+        expectAtLeastEqualPublished(values: ["out", "out"], from: publisher) { [trigger] in
             trigger.activate(for: 1)
         }
     }

--- a/Tests/CoreTests/PublishOnOutputFromTests.swift
+++ b/Tests/CoreTests/PublishOnOutputFromTests.swift
@@ -31,7 +31,7 @@ final class PublishOnOutputFromTests: XCTestCase {
         let publisher = Publishers.Publish(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1)) { [trigger] in
+        expectAtLeastEqualPublished(values: ["out"], from: publisher) { [trigger] in
             trigger.activate(for: 1)
         }
     }

--- a/Tests/CoreTests/PublishOnOutputFromTests.swift
+++ b/Tests/CoreTests/PublishOnOutputFromTests.swift
@@ -17,21 +17,21 @@ final class PublishOnOutputFromTests: XCTestCase {
         let publisher = Publishers.Publish(onOutputFrom: Optional<AnyPublisher<Void, Never>>.none) {
             Just("out")
         }
-        expectNothingPublished(from: publisher, during: 1)
+        expectNothingPublished(from: publisher, during: .seconds(1))
     }
 
     func testInactiveSignal() {
         let publisher = Publishers.Publish(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectNothingPublished(from: publisher, during: 1)
+        expectNothingPublished(from: publisher, during: .seconds(1))
     }
 
     func testActiveSignal() {
         let publisher = Publishers.Publish(onOutputFrom: trigger.signal(activatedBy: 1)) {
             Just("out")
         }
-        expectEqualPublished(values: ["out"], from: publisher, during: 1) { [trigger] in
+        expectEqualPublished(values: ["out"], from: publisher, during: .seconds(1)) { [trigger] in
             trigger.activate(for: 1)
         }
     }

--- a/Tests/CoreTests/TriggerTests.swift
+++ b/Tests/CoreTests/TriggerTests.swift
@@ -18,14 +18,14 @@ final class TriggerTests: XCTestCase {
 
     func testActiveWithSignal() {
         let trigger = Trigger()
-        expectEqualPublished(values: ["out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: .seconds(1)) {
+        expectAtLeastEqualPublished(values: ["out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }) {
             trigger.activate(for: 1)
         }
     }
 
     func testMultipleActivations() {
         let trigger = Trigger()
-        expectEqualPublished(values: ["out", "out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: .seconds(1)) {
+        expectAtLeastEqualPublished(values: ["out", "out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }) {
             trigger.activate(for: 1)
             trigger.activate(for: 1)
         }

--- a/Tests/CoreTests/TriggerTests.swift
+++ b/Tests/CoreTests/TriggerTests.swift
@@ -13,19 +13,19 @@ import XCTest
 final class TriggerTests: XCTestCase {
     func testInactive() {
         let trigger = Trigger()
-        expectNothingPublished(from: trigger.signal(activatedBy: 1), during: 1)
+        expectNothingPublished(from: trigger.signal(activatedBy: 1), during: .seconds(1))
     }
 
     func testActiveWithSignal() {
         let trigger = Trigger()
-        expectEqualPublished(values: ["out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: 1) {
+        expectEqualPublished(values: ["out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: .seconds(1)) {
             trigger.activate(for: 1)
         }
     }
 
     func testMultipleActivations() {
         let trigger = Trigger()
-        expectEqualPublished(values: ["out", "out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: 1) {
+        expectEqualPublished(values: ["out", "out"], from: trigger.signal(activatedBy: 1).map { _ in "out" }, during: .seconds(1)) {
             trigger.activate(for: 1)
             trigger.activate(for: 1)
         }
@@ -33,14 +33,14 @@ final class TriggerTests: XCTestCase {
 
     func testDifferentActivationIndex() {
         let trigger = Trigger()
-        expectNothingPublished(from: trigger.signal(activatedBy: 1), during: 1) {
+        expectNothingPublished(from: trigger.signal(activatedBy: 1), during: .seconds(1)) {
             trigger.activate(for: 2)
         }
     }
 
     func testHashableActivationIndex() {
         let trigger = Trigger()
-        expectEqualPublished(values: ["out"], from: trigger.signal(activatedBy: "index").map { _ in "out" }, during: 1) {
+        expectEqualPublished(values: ["out"], from: trigger.signal(activatedBy: "index").map { _ in "out" }, during: .seconds(1)) {
             trigger.activate(for: "index")
         }
     }

--- a/Tests/CoreTests/WeakCapturePublisherTests.swift
+++ b/Tests/CoreTests/WeakCapturePublisherTests.swift
@@ -22,7 +22,7 @@ final class WeakCapturePublisherTests: XCTestCase {
         }
         expect(weakObject).to(beNil())
 
-        expectNothingPublished(from: publisher, during: 1)
+        expectNothingPublished(from: publisher, during: .seconds(1))
     }
 
     func testDelivery() {

--- a/Tests/CoreTests/WithPreviousPublisherTests.swift
+++ b/Tests/CoreTests/WithPreviousPublisherTests.swift
@@ -12,14 +12,14 @@ import XCTest
 
 final class WithPreviousPublisherTests: XCTestCase {
     func testEmpty() {
-        expectNothingPublished(from: Empty<Int, Never>().withPrevious(), during: 1)
+        expectNothingPublished(from: Empty<Int, Never>().withPrevious(), during: .seconds(1))
     }
 
     func testPreviousValues() {
         expectEqualPublished(
             values: [nil, 1, 2, 3, 4],
             from: (1...5).publisher.withPrevious().map(\.previous),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -27,7 +27,7 @@ final class WithPreviousPublisherTests: XCTestCase {
         expectEqualPublished(
             values: [1, 2, 3, 4, 5],
             from: (1...5).publisher.withPrevious().map(\.current),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -35,7 +35,7 @@ final class WithPreviousPublisherTests: XCTestCase {
         expectEqualPublished(
             values: [-1, 1, 2, 3, 4],
             from: (1...5).publisher.withPrevious(-1).map(\.previous),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -43,7 +43,7 @@ final class WithPreviousPublisherTests: XCTestCase {
         expectEqualPublished(
             values: [1, 2, 3, 4, 5],
             from: (1...5).publisher.withPrevious(-1).map(\.current),
-            during: 1
+            during: .seconds(1)
         )
     }
 }

--- a/Tests/CoreTests/WithPreviousPublisherTests.swift
+++ b/Tests/CoreTests/WithPreviousPublisherTests.swift
@@ -16,34 +16,30 @@ final class WithPreviousPublisherTests: XCTestCase {
     }
 
     func testPreviousValues() {
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, 1, 2, 3, 4],
-            from: (1...5).publisher.withPrevious().map(\.previous),
-            during: .seconds(1)
+            from: (1...5).publisher.withPrevious().map(\.previous)
         )
     }
 
     func testCurrentValues() {
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [1, 2, 3, 4, 5],
-            from: (1...5).publisher.withPrevious().map(\.current),
-            during: .seconds(1)
+            from: (1...5).publisher.withPrevious().map(\.current)
         )
     }
 
     func testOptionalPreviousValues() {
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [-1, 1, 2, 3, 4],
-            from: (1...5).publisher.withPrevious(-1).map(\.previous),
-            during: .seconds(1)
+            from: (1...5).publisher.withPrevious(-1).map(\.previous)
         )
     }
 
     func testOptionalCurrentValues() {
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [1, 2, 3, 4, 5],
-            from: (1...5).publisher.withPrevious(-1).map(\.current),
-            during: .seconds(1)
+            from: (1...5).publisher.withPrevious(-1).map(\.current)
         )
     }
 }

--- a/Tests/PlayerTests/AssetTests.swift
+++ b/Tests/PlayerTests/AssetTests.swift
@@ -41,7 +41,7 @@ final class AssetTests: TestCase {
         expectEqualPublished(
             values: [false, true],
             from: item.publisher(for: \.isPlaybackLikelyToKeepUp),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -51,7 +51,7 @@ final class AssetTests: TestCase {
         expectEqualPublished(
             values: [false],
             from: item.publisher(for: \.isPlaybackLikelyToKeepUp),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -70,7 +70,7 @@ final class AssetTests: TestCase {
                 ))
             ],
             from: item.itemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/AssetTests.swift
+++ b/Tests/PlayerTests/AssetTests.swift
@@ -38,27 +38,25 @@ final class AssetTests: TestCase {
     func testNativePlayerItem() {
         let item = Asset.simple(url: Stream.onDemand.url).playerItem()
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true],
-            from: item.publisher(for: \.isPlaybackLikelyToKeepUp),
-            during: .seconds(2)
+            from: item.publisher(for: \.isPlaybackLikelyToKeepUp)
         )
     }
 
     func testLoadingPlayerItem() {
         let item = Asset.loading.playerItem()
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
-            from: item.publisher(for: \.isPlaybackLikelyToKeepUp),
-            during: .seconds(2)
+            from: item.publisher(for: \.isPlaybackLikelyToKeepUp)
         )
     }
 
     func testFailingPlayerItem() {
         let item = Asset.failed(error: StructError()).playerItem()
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .unknown,
                 .failed(error: NSError(
@@ -69,8 +67,7 @@ final class AssetTests: TestCase {
                     ]
                 ))
             ],
-            from: item.itemStatePublisher(),
-            during: .seconds(2)
+            from: item.itemStatePublisher()
         )
     }
 }

--- a/Tests/PlayerTests/BoundaryTimePublisherTests.swift
+++ b/Tests/PlayerTests/BoundaryTimePublisherTests.swift
@@ -20,7 +20,7 @@ final class BoundaryTimePublisherTests: TestCase {
                 for: player,
                 times: [CMTimeMake(value: 1, timescale: 2)]
             ),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -32,7 +32,7 @@ final class BoundaryTimePublisherTests: TestCase {
                 for: player,
                 times: [CMTimeMake(value: 1, timescale: 2)]
             ),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -51,7 +51,7 @@ final class BoundaryTimePublisherTests: TestCase {
                 ]
             )
             .map { "tick" },
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/BoundaryTimePublisherTests.swift
+++ b/Tests/PlayerTests/BoundaryTimePublisherTests.swift
@@ -39,7 +39,7 @@ final class BoundaryTimePublisherTests: TestCase {
     func testPlayback() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 "tick", "tick"
             ],
@@ -50,8 +50,7 @@ final class BoundaryTimePublisherTests: TestCase {
                     CMTimeMake(value: 2, timescale: 2)
                 ]
             )
-            .map { "tick" },
-            during: .seconds(2)
+            .map { "tick" }
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/BufferingPublisherQueueTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherQueueTests.swift
@@ -19,7 +19,7 @@ final class BufferingPublisherQueueTests: TestCase {
             // Next media can be buffered in advance
             values: [false, true, false],
             from: player.bufferingPublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }
@@ -34,7 +34,7 @@ final class BufferingPublisherQueueTests: TestCase {
             // Next media cannot be buffered in advance because of the failure
             values: [false, true, false, true, false],
             from: player.bufferingPublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/BufferingPublisherQueueTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherQueueTests.swift
@@ -15,11 +15,10 @@ final class BufferingPublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // Next media can be buffered in advance
             values: [false, true, false],
-            from: player.bufferingPublisher(),
-            during: .seconds(4)
+            from: player.bufferingPublisher()
         ) {
             player.play()
         }
@@ -30,11 +29,10 @@ final class BufferingPublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // Next media cannot be buffered in advance because of the failure
             values: [false, true, false, true, false],
-            from: player.bufferingPublisher(),
-            during: .seconds(4)
+            from: player.bufferingPublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/BufferingPublisherTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherTests.swift
@@ -16,7 +16,7 @@ final class BufferingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false],
             from: player.bufferingPublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -35,7 +35,7 @@ final class BufferingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false, true, false],
             from: player.bufferingPublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/BufferingPublisherTests.swift
+++ b/Tests/PlayerTests/BufferingPublisherTests.swift
@@ -13,10 +13,9 @@ import XCTest
 final class BufferingPublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
-            from: player.bufferingPublisher(),
-            during: .seconds(2)
+            from: player.bufferingPublisher()
         )
     }
 
@@ -32,10 +31,9 @@ final class BufferingPublisherTests: TestCase {
     func testEntirePlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
-            from: player.bufferingPublisher(),
-            during: .seconds(2)
+            from: player.bufferingPublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ChunkDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ChunkDurationPublisherTests.swift
@@ -17,7 +17,7 @@ final class ChunkDurationPublisherTests: TestCase {
         expectEqualPublished(
             values: [.invalid, CMTime(value: 1, timescale: 1)],
             from: player.chunkDurationPublisher(),
-            during: 3
+            during: .seconds(3)
         )
     }
 
@@ -68,7 +68,7 @@ final class ChunkDurationPublisherTests: TestCase {
                 CMTime(value: 4, timescale: 1)
             ],
             from: player.chunkDurationPublisher(),
-            during: 3
+            during: .seconds(3)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ChunkDurationPublisherTests.swift
+++ b/Tests/PlayerTests/ChunkDurationPublisherTests.swift
@@ -14,10 +14,9 @@ final class ChunkDurationPublisherTests: TestCase {
     func testChunkDuration() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.invalid, CMTime(value: 1, timescale: 1)],
-            from: player.chunkDurationPublisher(),
-            during: .seconds(3)
+            from: player.chunkDurationPublisher()
         )
     }
 
@@ -60,15 +59,14 @@ final class ChunkDurationPublisherTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .invalid,
                 CMTime(value: 1, timescale: 1),
                 .invalid,
                 CMTime(value: 4, timescale: 1)
             ],
-            from: player.chunkDurationPublisher(),
-            during: .seconds(3)
+            from: player.chunkDurationPublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemBufferingPublisherTests.swift
+++ b/Tests/PlayerTests/ItemBufferingPublisherTests.swift
@@ -26,7 +26,7 @@ final class ItemBufferingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false, true, false],
             from: item.bufferingPublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemBufferingPublisherTests.swift
+++ b/Tests/PlayerTests/ItemBufferingPublisherTests.swift
@@ -23,10 +23,9 @@ final class ItemBufferingPublisherTests: TestCase {
     func testEntirePlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
-            from: item.bufferingPublisher(),
-            during: .seconds(2)
+            from: item.bufferingPublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
@@ -15,7 +15,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .invalid,
                 Stream.shortOnDemand.duration,
@@ -24,8 +24,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
             ],
             from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
-            to: beClose(within: 1),
-            during: .seconds(4)
+            to: beClose(within: 1)
         ) {
             player.play()
         }
@@ -36,7 +35,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .invalid,
                 Stream.shortOnDemand.duration,
@@ -46,8 +45,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
             ],
             from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
-            to: beClose(within: 1),
-            during: .seconds(4)
+            to: beClose(within: 1)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemDurationPublisherQueueTests.swift
@@ -25,7 +25,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
             from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
             to: beClose(within: 1),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }
@@ -47,7 +47,7 @@ final class ItemDurationPublisherQueueTests: TestCase {
             from: player.currentItemDurationPublisher()
                 .removeDuplicates(by: CMTime.close(within: 1)),
             to: beClose(within: 1),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
@@ -19,7 +19,7 @@ final class ItemStatePublisherQueueTests: TestCase {
             // The second item can be pre-buffered and is immediately ready
             values: [.unknown, .readyToPlay, .ended, .readyToPlay, .ended],
             from: player.currentItemStatePublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }
@@ -38,7 +38,7 @@ final class ItemStatePublisherQueueTests: TestCase {
                 .unknown, .readyToPlay, .ended
             ],
             from: player.currentItemStatePublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherQueueTests.swift
@@ -15,11 +15,10 @@ final class ItemStatePublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // The second item can be pre-buffered and is immediately ready
             values: [.unknown, .readyToPlay, .ended, .readyToPlay, .ended],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(4)
+            from: player.currentItemStatePublisher()
         ) {
             player.play()
         }
@@ -30,15 +29,14 @@ final class ItemStatePublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // The third item cannot be pre-buffered and goes through the usual states
             values: [
                 .unknown, .readyToPlay, .ended,
                 .failed(error: PlayerError.resourceNotFound),
                 .unknown, .readyToPlay, .ended
             ],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(4)
+            from: player.currentItemStatePublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemStatePublisherTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherTests.swift
@@ -19,7 +19,7 @@ final class ItemStatePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown],
             from: player.currentItemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -29,7 +29,7 @@ final class ItemStatePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .readyToPlay],
             from: player.currentItemStatePublisher(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -39,7 +39,7 @@ final class ItemStatePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .readyToPlay, .ended],
             from: player.currentItemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }
@@ -54,7 +54,7 @@ final class ItemStatePublisherTests: TestCase {
                 .failed(error: PlayerError.resourceNotFound)
             ],
             from: player.currentItemStatePublisher(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -67,7 +67,7 @@ final class ItemStatePublisherTests: TestCase {
                 .failed(error: PlayerError.segmentNotFound)
             ],
             from: player.currentItemStatePublisher(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -88,7 +88,7 @@ final class ItemStatePublisherTests: TestCase {
                 ))
             ],
             from: player.currentItemStatePublisher(),
-            during: 1
+            during: .seconds(1)
         )
     }
 }

--- a/Tests/PlayerTests/ItemStatePublisherTests.swift
+++ b/Tests/PlayerTests/ItemStatePublisherTests.swift
@@ -16,30 +16,27 @@ final class ItemStatePublisherTests: TestCase {
 
     func testEmpty() {
         let player = AVPlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(2)
+            from: player.currentItemStatePublisher()
         )
     }
 
     func testNoPlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .readyToPlay],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(1)
+            from: player.currentItemStatePublisher()
         )
     }
 
     func testEntirePlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .readyToPlay, .ended],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(2)
+            from: player.currentItemStatePublisher()
         ) {
             player.play()
         }
@@ -48,26 +45,24 @@ final class ItemStatePublisherTests: TestCase {
     func testUnavailableStream() {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .unknown,
                 .failed(error: PlayerError.resourceNotFound)
             ],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(1)
+            from: player.currentItemStatePublisher()
         )
     }
 
     func testCorruptStream() {
         let item = AVPlayerItem(url: Stream.corruptOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .unknown,
                 .failed(error: PlayerError.segmentNotFound)
             ],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(1)
+            from: player.currentItemStatePublisher()
         )
     }
 
@@ -76,7 +71,7 @@ final class ItemStatePublisherTests: TestCase {
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: .global())
         let item = AVPlayerItem(asset: asset)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .unknown,
                 .failed(error: NSError(
@@ -87,8 +82,7 @@ final class ItemStatePublisherTests: TestCase {
                     ]
                 ))
             ],
-            from: player.currentItemStatePublisher(),
-            during: .seconds(1)
+            from: player.currentItemStatePublisher()
         )
     }
 }

--- a/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
@@ -15,15 +15,14 @@ final class ItemTimeRangePublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
                 CMTimeRange(start: .zero, duration: Stream.onDemand.duration)
             ],
             from: player.currentItemTimeRangePublisher(),
-            to: beClose(within: 1),
-            during: .seconds(3)
+            to: beClose(within: 1)
         ) {
             player.play()
         }
@@ -34,7 +33,7 @@ final class ItemTimeRangePublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
@@ -42,8 +41,7 @@ final class ItemTimeRangePublisherQueueTests: TestCase {
                 CMTimeRange(start: .zero, duration: Stream.onDemand.duration)
             ],
             from: player.currentItemTimeRangePublisher(),
-            to: beClose(within: 1),
-            during: .seconds(3)
+            to: beClose(within: 1)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherQueueTests.swift
@@ -23,7 +23,7 @@ final class ItemTimeRangePublisherQueueTests: TestCase {
             ],
             from: player.currentItemTimeRangePublisher(),
             to: beClose(within: 1),
-            during: 3
+            during: .seconds(3)
         ) {
             player.play()
         }
@@ -43,7 +43,7 @@ final class ItemTimeRangePublisherQueueTests: TestCase {
             ],
             from: player.currentItemTimeRangePublisher(),
             to: beClose(within: 1),
-            during: 3
+            during: .seconds(3)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
@@ -13,10 +13,9 @@ import XCTest
 final class ItemTimeRangePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.invalid],
-            from: player.currentItemTimeRangePublisher(),
-            during: .seconds(2)
+            from: player.currentItemTimeRangePublisher()
         )
     }
 
@@ -43,14 +42,13 @@ final class ItemTimeRangePublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(playerItem: item)
         player.actionAtItemEnd = .advance
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration),
                 .invalid
             ],
-            from: player.currentItemTimeRangePublisher(),
-            during: .seconds(2)
+            from: player.currentItemTimeRangePublisher()
         ) {
             player.play()
         }
@@ -60,13 +58,12 @@ final class ItemTimeRangePublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(playerItem: item)
         player.actionAtItemEnd = .none
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .invalid,
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration)
             ],
-            from: player.currentItemTimeRangePublisher(),
-            during: .seconds(2)
+            from: player.currentItemTimeRangePublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
+++ b/Tests/PlayerTests/ItemTimeRangePublisherTests.swift
@@ -16,7 +16,7 @@ final class ItemTimeRangePublisherTests: TestCase {
         expectEqualPublished(
             values: [.invalid],
             from: player.currentItemTimeRangePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -50,7 +50,7 @@ final class ItemTimeRangePublisherTests: TestCase {
                 .invalid
             ],
             from: player.currentItemTimeRangePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }
@@ -66,7 +66,7 @@ final class ItemTimeRangePublisherTests: TestCase {
                 CMTimeRange(start: .zero, duration: Stream.shortOnDemand.duration)
             ],
             from: player.currentItemTimeRangePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/ItemUpdateTests.swift
+++ b/Tests/PlayerTests/ItemUpdateTests.swift
@@ -28,7 +28,7 @@ final class ItemUpdateTests: TestCase {
         let item3 = PlayerItem.simple(url: Stream.item(numbered: 3).url)
         let item4 = PlayerItem.simple(url: Stream.item(numbered: 4).url)
         let player = Player(items: [item1, item2, item3])
-        expectNothingPublishedNext(from: player.queuePlayer.publisher(for: \.currentItem), during: 2) {
+        expectNothingPublishedNext(from: player.queuePlayer.publisher(for: \.currentItem), during: .seconds(2)) {
             player.items = [item4, item3, item1]
         }
     }

--- a/Tests/PlayerTests/NowPlayingInfoMetadataPublisherTests.swift
+++ b/Tests/PlayerTests/NowPlayingInfoMetadataPublisherTests.swift
@@ -106,4 +106,14 @@ final class NowPlayingInfoMetadataPublisherTests: TestCase {
             player.append(.networkLoaded(metadata: .media1))
         }
     }
+
+    func testEntirePlayback() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url, metadata: .init(title: "title")))
+        expectAtLeastSimilarPublished(
+            values: [[MPMediaItemPropertyTitle: "title"], [:]],
+            from: player.nowPlayingInfoMetadataPublisher()
+        ) {
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/PeriodicTimePublisherTests.swift
+++ b/Tests/PlayerTests/PeriodicTimePublisherTests.swift
@@ -22,7 +22,7 @@ final class PeriodicTimePublisherTests: TestCase {
                 interval: CMTimeMake(value: 1, timescale: 2)
             ),
             to: beClose(within: 0.5),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -35,7 +35,7 @@ final class PeriodicTimePublisherTests: TestCase {
             interval: CMTimeMake(value: 1, timescale: 10)
         )
 
-        let times = collectOutput(from: publisher, during: 2)
+        let times = collectOutput(from: publisher, during: .seconds(2))
         expect(times).to(allPass { $0.isValid })
     }
 
@@ -51,7 +51,7 @@ final class PeriodicTimePublisherTests: TestCase {
             player.currentItemTimeRangePublisher()
         )
 
-        let times = collectOutput(from: publisher, during: 2)
+        let times = collectOutput(from: publisher, during: .seconds(2))
         expect(times).to(allPass { time, timeRange in
             guard time.isValid, timeRange.isValid else { return true }
             return timeRange.start <= time && time <= timeRange.end
@@ -68,7 +68,7 @@ final class PeriodicTimePublisherTests: TestCase {
                 interval: CMTimeMake(value: 1, timescale: 2)
             ),
             to: beClose(within: 0.5),
-            during: 2
+            during: .seconds(2)
         )
     }
 

--- a/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
@@ -15,11 +15,10 @@ final class PlaybackStatePublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // The second item can be pre-buffered and is immediately played
             values: [.idle, .playing, .ended, .playing, .ended],
-            from: player.playbackStatePublisher(),
-            during: .seconds(4)
+            from: player.playbackStatePublisher()
         ) {
             player.play()
         }
@@ -30,15 +29,14 @@ final class PlaybackStatePublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVQueuePlayer(items: [item1, item2, item3])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             // The third item cannot be pre-buffered and goes through the usual states
             values: [
                 .idle, .playing, .ended,
                 .failed(error: PlayerError.resourceNotFound),
                 .idle, .playing, .ended
             ],
-            from: player.playbackStatePublisher(),
-            during: .seconds(4)
+            from: player.playbackStatePublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherQueueTests.swift
@@ -19,7 +19,7 @@ final class PlaybackStatePublisherQueueTests: TestCase {
             // The second item can be pre-buffered and is immediately played
             values: [.idle, .playing, .ended, .playing, .ended],
             from: player.playbackStatePublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }
@@ -38,7 +38,7 @@ final class PlaybackStatePublisherQueueTests: TestCase {
                 .idle, .playing, .ended
             ],
             from: player.playbackStatePublisher(),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/PlaybackStatePublisherTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherTests.swift
@@ -13,19 +13,19 @@ import XCTest
 final class PlaybackStatePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
-        expectEqualPublished(values: [.idle], from: player.playbackStatePublisher(), during: .seconds(2))
+        expectAtLeastEqualPublished(values: [.idle], from: player.playbackStatePublisher())
     }
 
     func testNoPlayback() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(values: [.idle, .paused], from: player.playbackStatePublisher(), during: .seconds(2))
+        expectAtLeastEqualPublished(values: [.idle, .paused], from: player.playbackStatePublisher())
     }
 
     func testPlayback() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher(), during: .seconds(2)) {
+        expectAtLeastEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher()) {
             player.play()
         }
     }
@@ -36,7 +36,7 @@ final class PlaybackStatePublisherTests: TestCase {
         expectAtLeastEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher()) {
             player.play()
         }
-        expectEqualPublishedNext(values: [.paused], from: player.playbackStatePublisher(), during: .seconds(2)) {
+        expectAtLeastEqualPublishedNext(values: [.paused], from: player.playbackStatePublisher()) {
             player.pause()
         }
     }
@@ -44,10 +44,9 @@ final class PlaybackStatePublisherTests: TestCase {
     func testEntirePlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.idle, .playing, .ended],
-            from: player.playbackStatePublisher(),
-            during: .seconds(2)
+            from: player.playbackStatePublisher()
         ) {
             player.play()
         }
@@ -56,13 +55,12 @@ final class PlaybackStatePublisherTests: TestCase {
     func testPlaybackFailure() {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .idle,
                 .failed(error: PlayerError.resourceNotFound)
             ],
-            from: player.playbackStatePublisher(),
-            during: .seconds(2)
+            from: player.playbackStatePublisher()
         )
     }
 }

--- a/Tests/PlayerTests/PlaybackStatePublisherTests.swift
+++ b/Tests/PlayerTests/PlaybackStatePublisherTests.swift
@@ -13,19 +13,19 @@ import XCTest
 final class PlaybackStatePublisherTests: TestCase {
     func testEmpty() {
         let player = AVPlayer()
-        expectEqualPublished(values: [.idle], from: player.playbackStatePublisher(), during: 2)
+        expectEqualPublished(values: [.idle], from: player.playbackStatePublisher(), during: .seconds(2))
     }
 
     func testNoPlayback() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(values: [.idle, .paused], from: player.playbackStatePublisher(), during: 2)
+        expectEqualPublished(values: [.idle, .paused], from: player.playbackStatePublisher(), during: .seconds(2))
     }
 
     func testPlayback() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher(), during: 2) {
+        expectEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher(), during: .seconds(2)) {
             player.play()
         }
     }
@@ -36,7 +36,7 @@ final class PlaybackStatePublisherTests: TestCase {
         expectAtLeastEqualPublished(values: [.idle, .playing], from: player.playbackStatePublisher()) {
             player.play()
         }
-        expectEqualPublishedNext(values: [.paused], from: player.playbackStatePublisher(), during: 2) {
+        expectEqualPublishedNext(values: [.paused], from: player.playbackStatePublisher(), during: .seconds(2)) {
             player.pause()
         }
     }
@@ -47,7 +47,7 @@ final class PlaybackStatePublisherTests: TestCase {
         expectEqualPublished(
             values: [.idle, .playing, .ended],
             from: player.playbackStatePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }
@@ -62,7 +62,7 @@ final class PlaybackStatePublisherTests: TestCase {
                 .failed(error: PlayerError.resourceNotFound)
             ],
             from: player.playbackStatePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -105,7 +105,7 @@ final class PlayerCurrentIndexTests: TestCase {
         let player = Player(item: item)
         let publisher = player.queuePlayer.publisher(for: \.currentItem)
 
-        expectNothingPublishedNext(from: publisher, during: 1) {
+        expectNothingPublishedNext(from: publisher, during: .seconds(1)) {
             try! player.setCurrentIndex(0)
         }
     }

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -35,6 +35,7 @@ final class PlayerCurrentIndexTests: TestCase {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.unavailable.url)
         let player = Player(items: [item1, item2])
+
         expectAtLeastEqualPublished(values: [0, 1, nil], from: player.$currentIndex) {
             player.play()
         }

--- a/Tests/PlayerTests/PlayerCurrentIndexTests.swift
+++ b/Tests/PlayerTests/PlayerCurrentIndexTests.swift
@@ -15,11 +15,34 @@ import XCTest
 final class PlayerCurrentIndexTests: TestCase {
     func testCurrentIndex() {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
-        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
-        expectAtLeastEqualPublished(values: [0, 1], from: player.$currentIndex) {
+        expectAtLeastEqualPublished(values: [0, 1, nil], from: player.$currentIndex) {
             player.play()
         }
+    }
+
+    func testCurrentIndexWithFirstFailedItem() {
+        let item1 = PlayerItem.simple(url: Stream.unavailable.url)
+        let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let player = Player(items: [item1, item2])
+        expectAtLeastEqualPublished(values: [0, 1, nil], from: player.$currentIndex) {
+            player.play()
+        }
+    }
+
+    func testCurrentIndexWithLastFailedItem() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.unavailable.url)
+        let player = Player(items: [item1, item2])
+        expectAtLeastEqualPublished(values: [0, 1, nil], from: player.$currentIndex) {
+            player.play()
+        }
+    }
+
+    func testCurrentIndexWithFailedItem() {
+        let player = Player(item: .simple(url: Stream.unavailable.url))
+        expectAtLeastEqualPublished(values: [0, nil], from: player.$currentIndex)
     }
 
     func testCurrentIndexWithEmptyPlayer() {

--- a/Tests/PlayerTests/PlayerItemPublishersTests.swift
+++ b/Tests/PlayerTests/PlayerItemPublishersTests.swift
@@ -18,7 +18,7 @@ final class PlayerItemPublishersTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .readyToPlay],
             from: item.itemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -28,7 +28,7 @@ final class PlayerItemPublishersTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .readyToPlay, .ended],
             from: item.itemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }
@@ -43,7 +43,7 @@ final class PlayerItemPublishersTests: TestCase {
                 .failed(error: PlayerError.segmentNotFound)
             ],
             from: item.itemStatePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/PlayerItemPublishersTests.swift
+++ b/Tests/PlayerTests/PlayerItemPublishersTests.swift
@@ -15,20 +15,18 @@ final class PlayerItemPublishersTests: TestCase {
     func testValidItemStateWithoutPlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .readyToPlay],
-            from: item.itemStatePublisher(),
-            during: .seconds(2)
+            from: item.itemStatePublisher()
         )
     }
 
     func testValidItemStateWithPlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .readyToPlay, .ended],
-            from: item.itemStatePublisher(),
-            during: .seconds(2)
+            from: item.itemStatePublisher()
         ) {
             player.play()
         }
@@ -37,13 +35,12 @@ final class PlayerItemPublishersTests: TestCase {
     func testCorruptStream() {
         let item = AVPlayerItem(url: Stream.corruptOnDemand.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [
                 .unknown,
                 .failed(error: PlayerError.segmentNotFound)
             ],
-            from: item.itemStatePublisher(),
-            during: .seconds(2)
+            from: item.itemStatePublisher()
         )
     }
 }

--- a/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
@@ -14,30 +14,27 @@ final class ItemStreamTypePublisherTests: TestCase {
     func testOnDemand() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .onDemand],
-            from: item.streamTypePublisher(),
-            during: .seconds(2)
+            from: item.streamTypePublisher()
         )
     }
 
     func testLive() {
         let item = AVPlayerItem(url: Stream.live.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .live],
-            from: item.streamTypePublisher(),
-            during: .seconds(2)
+            from: item.streamTypePublisher()
         )
     }
 
     func testDVR() {
         let item = AVPlayerItem(url: Stream.dvr.url)
         _ = AVPlayer(playerItem: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.unknown, .dvr],
-            from: item.streamTypePublisher(),
-            during: .seconds(2)
+            from: item.streamTypePublisher()
         )
     }
 }

--- a/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
+++ b/Tests/PlayerTests/PlayerItemStreamTypePublisherTests.swift
@@ -17,7 +17,7 @@ final class ItemStreamTypePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .onDemand],
             from: item.streamTypePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -27,7 +27,7 @@ final class ItemStreamTypePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .live],
             from: item.streamTypePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -37,7 +37,7 @@ final class ItemStreamTypePublisherTests: TestCase {
         expectEqualPublished(
             values: [.unknown, .dvr],
             from: item.streamTypePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -25,4 +25,9 @@ final class PlayerRestartChecksTests: TestCase {
         player.play()
         expect(player.canRestart()).toEventually(beTrue())
     }
+
+    func testWithOneBadItem() {
+        let player = Player(item: .simple(url: Stream.unavailable.url))
+        expect(player.canRestart()).toEventually(beTrue())
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Foundation
+import Nimble
+
+final class PlayerRestartChecksTests: TestCase {
+    func testEmptyPlayer() {
+        let player = Player()
+        expect(player.canRestart()).to(beFalse())
+    }
+}

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -19,4 +19,10 @@ final class PlayerRestartChecksTests: TestCase {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
         expect(player.canRestart()).to(beFalse())
     }
+
+    func testWithOneGoodItemEnded() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url))
+        player.play()
+        expect(player.canRestart()).toEventually(beTrue())
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -30,4 +30,13 @@ final class PlayerRestartChecksTests: TestCase {
         let player = Player(item: .simple(url: Stream.unavailable.url))
         expect(player.canRestart()).toEventually(beTrue())
     }
+
+    func testWithManyGoodItems() {
+        let player = Player(items: [
+            .simple(url: Stream.shortOnDemand.url),
+            .simple(url: Stream.shortOnDemand.url)
+        ])
+        player.play()
+        expect(player.canRestart()).toEventually(beTrue())
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -40,6 +40,15 @@ final class PlayerRestartChecksTests: TestCase {
         expect(player.canRestart()).toEventually(beTrue())
     }
 
+    func testWithManyBadItems() {
+        let player = Player(items: [
+            .simple(url: Stream.unavailable.url),
+            .simple(url: Stream.unavailable.url)
+        ])
+        player.play()
+        expect(player.canRestart()).toEventually(beTrue())
+    }
+
     func testWithOneGoodItemAndOneBadItem() {
         let player = Player(items: [
             .simple(url: Stream.shortOnDemand.url),

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -14,4 +14,9 @@ final class PlayerRestartChecksTests: TestCase {
         let player = Player()
         expect(player.canRestart()).to(beFalse())
     }
+
+    func testWithOneGoodItem() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url))
+        expect(player.canRestart()).to(beFalse())
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -39,4 +39,13 @@ final class PlayerRestartChecksTests: TestCase {
         player.play()
         expect(player.canRestart()).toEventually(beTrue())
     }
+
+    func testWithOneGoodItemAndOneBadItem() {
+        let player = Player(items: [
+            .simple(url: Stream.shortOnDemand.url),
+            .simple(url: Stream.unavailable.url)
+        ])
+        player.play()
+        expect(player.canRestart()).toEventually(beTrue())
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartChecksTests.swift
+++ b/Tests/PlayerTests/PlayerRestartChecksTests.swift
@@ -20,7 +20,7 @@ final class PlayerRestartChecksTests: TestCase {
         expect(player.canRestart()).to(beFalse())
     }
 
-    func testWithOneGoodItemEnded() {
+    func testWithOneGoodItemPlayedEntirely() {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
         player.play()
         expect(player.canRestart()).toEventually(beTrue())

--- a/Tests/PlayerTests/PlayerRestartTests.swift
+++ b/Tests/PlayerTests/PlayerRestartTests.swift
@@ -4,7 +4,63 @@
 //  License information is available from the LICENSE file.
 //
 
+@testable import Player
+
 import Foundation
+import Nimble
 
 final class PlayerRestartTests: TestCase {
+    func testWithOneGoodItem() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url))
+        player.restart()
+        expect(player.currentIndex).to(equal(0))
+    }
+
+    func testWithOneGoodItemEnded() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url))
+        player.play()
+        expect(player.currentIndex).toEventually(beNil())
+        player.restart()
+        expect(player.currentIndex).toEventually(equal(0))
+    }
+
+    func testWithOneBadItem() {
+        let player = Player(item: .simple(url: Stream.unavailable.url))
+        expect(player.currentIndex).toEventually(beNil())
+        player.restart()
+        expect(player.currentIndex).toEventually(equal(0))
+    }
+
+    func testWithManyGoodItems() {
+        let player = Player(items: [
+            .simple(url: Stream.shortOnDemand.url),
+            .simple(url: Stream.shortOnDemand.url)
+        ])
+        player.play()
+        expect(player.currentIndex).toEventually(equal(1))
+        player.restart()
+        expect(player.currentIndex).to(equal(1))
+    }
+
+    func testWithManyBadItems() {
+        let player = Player(items: [
+            .simple(url: Stream.unavailable.url),
+            .simple(url: Stream.unavailable.url)
+        ])
+        player.play()
+        expect(player.currentIndex).toEventually(beNil())
+        player.restart()
+        expect(player.currentIndex).to(equal(0))
+    }
+
+    func testWithOneGoodItemAndOneBadItem() {
+        let player = Player(items: [
+            .simple(url: Stream.shortOnDemand.url),
+            .simple(url: Stream.unavailable.url)
+        ])
+        player.play()
+        expect(player.currentIndex).toEventually(beNil())
+        player.restart()
+        expect(player.currentIndex).to(equal(0))
+    }
 }

--- a/Tests/PlayerTests/PlayerRestartTests.swift
+++ b/Tests/PlayerTests/PlayerRestartTests.swift
@@ -1,0 +1,10 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+final class PlayerRestartTests: TestCase {
+}

--- a/Tests/PlayerTests/PlayerRestartTests.swift
+++ b/Tests/PlayerTests/PlayerRestartTests.swift
@@ -16,7 +16,7 @@ final class PlayerRestartTests: TestCase {
         expect(player.currentIndex).to(equal(0))
     }
 
-    func testWithOneGoodItemEnded() {
+    func testWithOneGoodItemPlayedEntirely() {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
         player.play()
         expect(player.currentIndex).toEventually(beNil())

--- a/Tests/PlayerTests/PlayerSkipForwardTests.swift
+++ b/Tests/PlayerTests/PlayerSkipForwardTests.swift
@@ -90,7 +90,7 @@ final class PlayerSkipForwardTests: TestCase {
             }
         }
 
-        expectNothingPublishedNext(from: player.$isSeeking, during: 2) {
+        expectNothingPublishedNext(from: player.$isSeeking, during: .seconds(2)) {
             player.skipForward()
         }
     }

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -19,7 +19,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -29,7 +29,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -43,7 +43,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }
@@ -57,7 +57,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false, true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.player = player
             player.play()
@@ -72,7 +72,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 5
+            during: .seconds(5)
         ) {
             progressTracker.player = player
         }
@@ -90,7 +90,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -108,7 +108,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = nil
         }
@@ -132,7 +132,7 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressAvailabilityTests.swift
@@ -15,21 +15,19 @@ import XCTest
 final class ProgressTrackerProgressAvailabilityTests: TestCase {
     func testUnbound() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         )
     }
 
     func testEmptyPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -39,11 +37,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -53,11 +50,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(2)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
             player.play()
@@ -68,11 +64,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(5)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -86,11 +81,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         player.play()
         expect(progressTracker.isProgressAvailable).toEventually(beTrue())
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -104,11 +98,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
         player.play()
         expect(progressTracker.isProgressAvailable).toEventually(beTrue())
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [true, false],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = nil
         }
@@ -128,11 +121,10 @@ final class ProgressTrackerProgressAvailabilityTests: TestCase {
             }
         }
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true],
             from: progressTracker.changePublisher(at: \.isProgressAvailable)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressTests.swift
@@ -15,21 +15,19 @@ import XCTest
 final class ProgressTrackerProgressTests: TestCase {
     func testUnbound() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         )
     }
 
     func testEmptyPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -39,11 +37,10 @@ final class ProgressTrackerProgressTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -57,8 +54,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [0, 0.25, 0.5, 0.75, 1, 0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(2)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
             player.play()
@@ -69,12 +65,11 @@ final class ProgressTrackerProgressTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
-        expectPublished(
+        expectAtLeastPublished(
             values: [0, 1, 0.95, 0.9, 0.85, 0.8],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(5)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
         }
@@ -89,11 +84,10 @@ final class ProgressTrackerProgressTests: TestCase {
         expect(progressTracker.progress).toEventuallyNot(equal(0))
 
         let progress = progressTracker.progress
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [progress, 0],
             from: progressTracker.changePublisher(at: \.progress)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -108,11 +102,10 @@ final class ProgressTrackerProgressTests: TestCase {
         expect(progressTracker.progress).toEventuallyNot(equal(0))
 
         let progress = progressTracker.progress
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [progress, 0],
             from: progressTracker.changePublisher(at: \.progress)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = nil
         }
@@ -137,8 +130,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [0, progress],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(1)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerProgressTests.swift
@@ -19,7 +19,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -29,7 +29,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -43,7 +43,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }
@@ -58,7 +58,7 @@ final class ProgressTrackerProgressTests: TestCase {
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.player = player
             player.play()
@@ -74,7 +74,7 @@ final class ProgressTrackerProgressTests: TestCase {
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 5
+            during: .seconds(5)
         ) {
             progressTracker.player = player
         }
@@ -93,7 +93,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [progress, 0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -112,7 +112,7 @@ final class ProgressTrackerProgressTests: TestCase {
             values: [progress, 0],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = nil
         }
@@ -138,7 +138,7 @@ final class ProgressTrackerProgressTests: TestCase {
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -19,7 +19,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -29,7 +29,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -43,7 +43,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }
@@ -57,7 +57,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0, 0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.player = player
             player.play()
@@ -72,7 +72,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 5
+            during: .seconds(5)
         ) {
             progressTracker.player = player
         }
@@ -90,7 +90,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -108,7 +108,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = nil
         }
@@ -132,7 +132,7 @@ final class ProgressTrackerRangeTests: TestCase {
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerRangeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerRangeTests.swift
@@ -15,21 +15,19 @@ import XCTest
 final class ProgressTrackerRangeTests: TestCase {
     func testUnbound() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         )
     }
 
     func testEmptyPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -39,11 +37,10 @@ final class ProgressTrackerRangeTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -53,11 +50,10 @@ final class ProgressTrackerRangeTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0, 0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(2)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
             player.play()
@@ -68,11 +64,10 @@ final class ProgressTrackerRangeTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(5)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -86,11 +81,10 @@ final class ProgressTrackerRangeTests: TestCase {
         player.play()
         expect(progressTracker.range).toEventuallyNot(equal(0...0))
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -104,11 +98,10 @@ final class ProgressTrackerRangeTests: TestCase {
         player.play()
         expect(progressTracker.range).toEventuallyNot(equal(0...0))
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...1, 0...0],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = nil
         }
@@ -128,11 +121,10 @@ final class ProgressTrackerRangeTests: TestCase {
             }
         }
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [0...0, 0...1],
             from: progressTracker.changePublisher(at: \.range)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
@@ -23,10 +23,9 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         progressTracker.player = player
         expect(progressTracker.range).toEventually(equal(0...1))
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
-            from: player.$isSeeking,
-            during: .seconds(2)
+            from: player.$isSeeking
         ) {
             progressTracker.isInteracting = true
             progressTracker.progress = 0.5
@@ -44,19 +43,17 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         progressTracker.player = player
         expect(progressTracker.range).toEventually(equal(0...1))
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
-            from: player.$isSeeking,
-            during: .seconds(2)
+            from: player.$isSeeking
         ) {
             progressTracker.isInteracting = true
             progressTracker.progress = 0.5
         }
 
-        expectEqualPublishedNext(
+        expectAtLeastEqualPublishedNext(
             values: [true, false],
-            from: player.$isSeeking,
-            during: .seconds(2)
+            from: player.$isSeeking
         ) {
             progressTracker.isInteracting = false
         }

--- a/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerSeekBehaviorTests.swift
@@ -26,7 +26,7 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         expectEqualPublished(
             values: [false, true, false],
             from: player.$isSeeking,
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.isInteracting = true
             progressTracker.progress = 0.5
@@ -47,7 +47,7 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         expectEqualPublished(
             values: [false],
             from: player.$isSeeking,
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.isInteracting = true
             progressTracker.progress = 0.5
@@ -56,7 +56,7 @@ final class ProgressTrackerSeekBehaviorTests: TestCase {
         expectEqualPublishedNext(
             values: [true, false],
             from: player.$isSeeking,
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.isInteracting = false
         }

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -19,7 +19,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [nil],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         )
     }
 
@@ -29,7 +29,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [nil],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -43,7 +43,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [nil, .zero],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }
@@ -66,7 +66,7 @@ final class ProgressTrackerTimeTests: TestCase {
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 2
+            during: .seconds(2)
         ) {
             progressTracker.player = player
             player.play()
@@ -89,7 +89,7 @@ final class ProgressTrackerTimeTests: TestCase {
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 5
+            during: .seconds(5)
         ) {
             progressTracker.player = player
         }
@@ -108,7 +108,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [time, nil],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = Player()
         }
@@ -127,7 +127,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [time, nil],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = nil
         }
@@ -152,7 +152,7 @@ final class ProgressTrackerTimeTests: TestCase {
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
             to: beClose(within: 0.1),
-            during: 1
+            during: .seconds(1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTrackerTimeTests.swift
@@ -15,21 +15,19 @@ import XCTest
 final class ProgressTrackerTimeTests: TestCase {
     func testUnbound() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil],
             from: progressTracker.changePublisher(at: \.time)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         )
     }
 
     func testEmptyPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil],
             from: progressTracker.changePublisher(at: \.time)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -39,11 +37,10 @@ final class ProgressTrackerTimeTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, .zero],
             from: progressTracker.changePublisher(at: \.time)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = player
         }
@@ -65,8 +62,7 @@ final class ProgressTrackerTimeTests: TestCase {
             ],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(2)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
             player.play()
@@ -77,7 +73,7 @@ final class ProgressTrackerTimeTests: TestCase {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         let item = PlayerItem.simple(url: Stream.dvr.url)
         let player = Player(item: item)
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 nil,
                 CMTime(value: 17, timescale: 1),
@@ -88,8 +84,7 @@ final class ProgressTrackerTimeTests: TestCase {
             ],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(5)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
         }
@@ -104,11 +99,10 @@ final class ProgressTrackerTimeTests: TestCase {
         expect(progressTracker.time).toEventuallyNot(beNil())
 
         let time = progressTracker.time
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [time, nil],
             from: progressTracker.changePublisher(at: \.time)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = Player()
         }
@@ -123,11 +117,10 @@ final class ProgressTrackerTimeTests: TestCase {
         expect(progressTracker.time).toEventuallyNot(beNil())
 
         let time = progressTracker.time
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [time, nil],
             from: progressTracker.changePublisher(at: \.time)
-                .removeDuplicates(),
-            during: .seconds(1)
+                .removeDuplicates()
         ) {
             progressTracker.player = nil
         }
@@ -151,8 +144,7 @@ final class ProgressTrackerTimeTests: TestCase {
             values: [nil, time],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
-            to: beClose(within: 0.1),
-            during: .seconds(1)
+            to: beClose(within: 0.1)
         ) {
             progressTracker.player = player
         }

--- a/Tests/PlayerTests/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayerSeekTests.swift
@@ -181,7 +181,7 @@ final class QueuePlayerSeekTests: TestCase {
         player.play()
         expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
-        let values = collectOutput(from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 10), queue: .main), during: 3) {
+        let values = collectOutput(from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 10), queue: .main), during: .seconds(3)) {
             player.seek(to: CMTime(value: 8, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
                 player.seek(to: CMTime(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in
                     player.seek(to: CMTime(value: 12, timescale: 1), toleranceBefore: .zero, toleranceAfter: .positiveInfinity) { _ in

--- a/Tests/PlayerTests/SeekTimePublisherTests.swift
+++ b/Tests/PlayerTests/SeekTimePublisherTests.swift
@@ -17,7 +17,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -28,7 +28,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil, time, nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time)
         }
@@ -42,7 +42,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil, time1, nil, time2, nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -56,7 +56,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil, time, nil, time, nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time)
             player.seek(to: time)
@@ -74,7 +74,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil, time1, time2, nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -91,7 +91,7 @@ final class SeekTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [nil, time, nil],
             from: player.seekTimePublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time)
             player.seek(to: time)

--- a/Tests/PlayerTests/SeekTimePublisherTests.swift
+++ b/Tests/PlayerTests/SeekTimePublisherTests.swift
@@ -14,10 +14,9 @@ import XCTest
 final class SeekTimePublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         )
     }
 
@@ -25,10 +24,9 @@ final class SeekTimePublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         let time = CMTime(value: 1, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, time, nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         ) {
             player.seek(to: time)
         }
@@ -39,10 +37,9 @@ final class SeekTimePublisherTests: TestCase {
         let player = QueuePlayer(playerItem: item)
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, time1, nil, time2, nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -53,10 +50,9 @@ final class SeekTimePublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         let time = CMTime(value: 1, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, time, nil, time, nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         ) {
             player.seek(to: time)
             player.seek(to: time)
@@ -71,10 +67,9 @@ final class SeekTimePublisherTests: TestCase {
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, time1, time2, nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -88,10 +83,9 @@ final class SeekTimePublisherTests: TestCase {
         expect(item.timeRange).toEventuallyNot(equal(.invalid))
 
         let time = CMTime(value: 1, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [nil, time, nil],
-            from: player.seekTimePublisher(),
-            during: .seconds(2)
+            from: player.seekTimePublisher()
         ) {
             player.seek(to: time)
             player.seek(to: time)

--- a/Tests/PlayerTests/SeekingPublisherTests.swift
+++ b/Tests/PlayerTests/SeekingPublisherTests.swift
@@ -17,7 +17,7 @@ final class SeekingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false],
             from: player.seekingPublisher(),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -28,7 +28,7 @@ final class SeekingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false, true, false],
             from: player.seekingPublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time)
         }
@@ -42,7 +42,7 @@ final class SeekingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false, true, false, true, false],
             from: player.seekingPublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -60,7 +60,7 @@ final class SeekingPublisherTests: TestCase {
         expectEqualPublished(
             values: [false, true, false],
             from: player.seekingPublisher(),
-            during: 2
+            during: .seconds(2)
         ) {
             player.seek(to: time1)
             player.seek(to: time2)

--- a/Tests/PlayerTests/SeekingPublisherTests.swift
+++ b/Tests/PlayerTests/SeekingPublisherTests.swift
@@ -14,10 +14,9 @@ import XCTest
 final class SeekingPublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false],
-            from: player.seekingPublisher(),
-            during: .seconds(2)
+            from: player.seekingPublisher()
         )
     }
 
@@ -25,10 +24,9 @@ final class SeekingPublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         let time = CMTime(value: 1, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
-            from: player.seekingPublisher(),
-            during: .seconds(2)
+            from: player.seekingPublisher()
         ) {
             player.seek(to: time)
         }
@@ -39,10 +37,9 @@ final class SeekingPublisherTests: TestCase {
         let player = QueuePlayer(playerItem: item)
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false, true, false],
-            from: player.seekingPublisher(),
-            during: .seconds(2)
+            from: player.seekingPublisher()
         ) {
             player.seek(to: time1)
             player.seek(to: time2)
@@ -57,10 +54,9 @@ final class SeekingPublisherTests: TestCase {
 
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [false, true, false],
-            from: player.seekingPublisher(),
-            during: .seconds(2)
+            from: player.seekingPublisher()
         ) {
             player.seek(to: time1)
             player.seek(to: time2)

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -53,4 +53,18 @@ final class SmoothCurrentItemPublisherTests: TestCase {
             during: 2
         )
     }
+
+    func testWithTwoGoodItems() {
+        let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let item2 = AVPlayerItem(url: Stream.onDemand.url)
+        let player = QueuePlayer(items: [item1, item2])
+
+        expectEqualPublished(
+            values: [.good(item1), .good(item2)],
+            from: player.smoothCurrentItemPublisher(),
+            during: 2
+        ) {
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -12,10 +12,9 @@ import Foundation
 final class SmoothCurrentItemPublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.good(nil)],
-            from: player.smoothCurrentItemPublisher(),
-            during: 2
+            from: player.smoothCurrentItemPublisher()
         )
     }
 
@@ -23,10 +22,9 @@ final class SmoothCurrentItemPublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.good(item)],
-            from: player.smoothCurrentItemPublisher(),
-            during: 2
+            from: player.smoothCurrentItemPublisher()
         )
     }
 
@@ -34,10 +32,9 @@ final class SmoothCurrentItemPublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(playerItem: item)
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.good(item), .good(nil)],
-            from: player.smoothCurrentItemPublisher(),
-            during: 2
+            from: player.smoothCurrentItemPublisher()
         ) {
             player.play()
         }
@@ -47,10 +44,9 @@ final class SmoothCurrentItemPublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         let player = QueuePlayer(playerItem: item)
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.good(item), .bad(item)],
-            from: player.smoothCurrentItemPublisher(),
-            during: 2
+            from: player.smoothCurrentItemPublisher()
         )
     }
 
@@ -59,10 +55,9 @@ final class SmoothCurrentItemPublisherTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(items: [item1, item2])
 
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [.good(item1), .good(item2)],
-            from: player.smoothCurrentItemPublisher(),
-            during: 2
+            from: player.smoothCurrentItemPublisher()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import AVFoundation
+import Foundation
+
+final class SmoothCurrentItemPublisherTests: TestCase {
+    func testEmpty() {
+        let player = QueuePlayer()
+        expectEqualPublished(
+            values: [.finished(nil)],
+            from: player.smoothCurrentItemPublisher(),
+            during: 2
+        )
+    }
+
+    func testWithOneGoodItem() {
+        let item = AVPlayerItem(url: Stream.onDemand.url)
+        let player = QueuePlayer(playerItem: item)
+
+        expectEqualPublished(
+            values: [.finished(item)],
+            from: player.smoothCurrentItemPublisher(),
+            during: 2
+        ) {
+            player.play()
+        }
+    }
+}

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -27,6 +27,17 @@ final class SmoothCurrentItemPublisherTests: TestCase {
             values: [.good(item)],
             from: player.smoothCurrentItemPublisher(),
             during: 2
+        )
+    }
+
+    func testWithOneGoodItemPlayedEntirely() {
+        let item = AVPlayerItem(url: Stream.shortOnDemand.url)
+        let player = QueuePlayer(playerItem: item)
+
+        expectEqualPublished(
+            values: [.good(item), .good(nil)],
+            from: player.smoothCurrentItemPublisher(),
+            during: 2
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -13,7 +13,7 @@ final class SmoothCurrentItemPublisherTests: TestCase {
     func testEmpty() {
         let player = QueuePlayer()
         expectEqualPublished(
-            values: [.finished(nil)],
+            values: [.good(nil)],
             from: player.smoothCurrentItemPublisher(),
             during: 2
         )
@@ -24,7 +24,7 @@ final class SmoothCurrentItemPublisherTests: TestCase {
         let player = QueuePlayer(playerItem: item)
 
         expectEqualPublished(
-            values: [.finished(item)],
+            values: [.good(item)],
             from: player.smoothCurrentItemPublisher(),
             during: 2
         ) {

--- a/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentItemPublisherTests.swift
@@ -42,4 +42,15 @@ final class SmoothCurrentItemPublisherTests: TestCase {
             player.play()
         }
     }
+
+    func testWithOneBadItem() {
+        let item = AVPlayerItem(url: Stream.unavailable.url)
+        let player = QueuePlayer(playerItem: item)
+
+        expectEqualPublished(
+            values: [.good(item), .bad(item)],
+            from: player.smoothCurrentItemPublisher(),
+            during: 2
+        )
+    }
 }

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
@@ -23,7 +23,7 @@ final class SmoothCurrentTimePublisherQueueTests: TestCase {
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.3),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }
@@ -41,7 +41,7 @@ final class SmoothCurrentTimePublisherQueueTests: TestCase {
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.3),
-            during: 4
+            during: .seconds(4)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherQueueTests.swift
@@ -16,14 +16,13 @@ final class SmoothCurrentTimePublisherQueueTests: TestCase {
         let item1 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let item2 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(items: [item1, item2])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
-            to: beClose(within: 0.3),
-            during: .seconds(4)
+            to: beClose(within: 0.3)
         ) {
             player.play()
         }
@@ -34,14 +33,13 @@ final class SmoothCurrentTimePublisherQueueTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.unavailable.url)
         let item3 = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(items: [item1, item2, item3])
-        expectPublished(
+        expectAtLeastPublished(
             values: [
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1),
                 .zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)
             ],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
-            to: beClose(within: 0.3),
-            during: .seconds(4)
+            to: beClose(within: 0.3)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
@@ -16,19 +16,17 @@ final class SmoothCurrentTimePublisherTests: TestCase {
         let player = QueuePlayer()
         expectEqualPublished(
             values: [],
-            from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1), queue: .main),
-            during: .seconds(2)
+            from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1), queue: .main)
         )
     }
 
     func testPlayback() {
         let item = AVPlayerItem(url: Stream.shortOnDemand.url)
         let player = QueuePlayer(playerItem: item)
-        expectPublished(
+        expectAtLeastPublished(
             values: [.zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
-            to: beClose(within: 0.1),
-            during: .seconds(2)
+            to: beClose(within: 0.1)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
+++ b/Tests/PlayerTests/SmoothCurrentTimePublisherTests.swift
@@ -17,7 +17,7 @@ final class SmoothCurrentTimePublisherTests: TestCase {
         expectEqualPublished(
             values: [],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1), queue: .main),
-            during: 2
+            during: .seconds(2)
         )
     }
 
@@ -28,7 +28,7 @@ final class SmoothCurrentTimePublisherTests: TestCase {
             values: [.zero, CMTime(value: 1, timescale: 2), CMTime(value: 1, timescale: 1)],
             from: player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 2), queue: .main),
             to: beClose(within: 0.1),
-            during: 2
+            during: .seconds(2)
         ) {
             player.play()
         }
@@ -38,7 +38,7 @@ final class SmoothCurrentTimePublisherTests: TestCase {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         let publisher = player.smoothCurrentTimePublisher(interval: CMTime(value: 1, timescale: 1000), queue: .main)
-        let times = collectOutput(from: publisher, during: 3) {
+        let times = collectOutput(from: publisher, during: .seconds(3)) {
             player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in }
         }
         expect(times.contains(CMTime(value: 5, timescale: 1))).to(beTrue())
@@ -55,7 +55,7 @@ final class SmoothCurrentTimePublisherTests: TestCase {
         ) {
             player.play()
         }
-        let times = collectOutput(from: publisher, during: 3) {
+        let times = collectOutput(from: publisher, during: .seconds(3)) {
             player.seek(to: CMTime(value: 5, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero) { _ in }
         }
         expect(times.contains(CMTime(value: 5, timescale: 1))).to(beTrue())

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -77,8 +77,9 @@ In the general project settings:
 1. Disable _Allow merge commits_.
 2. Disable _Allow rebase merging_.
 3. Enable _Allow squash merging_ with _Default to pull request title_.
-4. Enable _Always suggest updating pull request branches_.
-5. Enable _Automatically delete head branches_.
+4. Enable _Allow auto-merge_.
+5. Enable _Always suggest updating pull request branches_.
+6. Enable _Automatically delete head branches_.
 
 ## Continuous integration user
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -86,7 +86,7 @@ struct PlayerView: View {
             VideoView(player: player)
             controls()
         }
-        .animation(.linear(duration: 0.2), value: visibilityTracker.isUserInterfaceHidden)
+        .animation(.linear, value: visibilityTracker.isUserInterfaceHidden)
         .onTapGesture(perform: visibilityTracker.toggle)
         .onAppear(perform: player.play)
         .bind(visibilityTracker, to: player)
@@ -134,7 +134,7 @@ struct PlayerView: View {
                 VideoView(player: player)
                 controls()
             }
-            .animation(.linear(duration: 0.2), value: visibilityTracker.isUserInterfaceHidden)
+            .animation(.linear, value: visibilityTracker.isUserInterfaceHidden)
             .onTapGesture(perform: visibilityTracker.toggle)
         }
         .onAppear(perform: player.play)


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to have a consistent playback end experience.

## Changes made

- New concept (`CurrentItem`) have been introduce to avoid to loose the current item.
- `canRestart` & `restart` methods has been added, which allows us to respectively, check if the player content can be restarted and to restart the player content.
- The method `replaceItems` has been updated.
- Demo App improved.
- Many tests have been refined.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
