### PR TITLE
Add parameter to control device sleep during video playback

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -114,6 +114,7 @@ public final class Player: ObservableObject, Equatable {
     private func configurePlayer() {
         queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
         queuePlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring
+        queuePlayer.preventsDisplaySleepDuringVideoPlayback = configuration.preventsDisplaySleepDuringVideoPlayback
         queuePlayer.audiovisualBackgroundPlaybackPolicy = configuration.audiovisualBackgroundPlaybackPolicy
     }
 

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -16,6 +16,9 @@ public struct PlayerConfiguration {
     /// This property has no effect when `allowsExternalPlayback` is false.
     public let usesExternalPlaybackWhileMirroring: Bool
 
+    /// Indicates whether video playback prevents display and device sleep.
+    public let preventsDisplaySleepDuringVideoPlayback: Bool
+
     /// A policy that determines how playback of audiovisual media continues when the app transitions
     /// to the background.
     public let audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy
@@ -34,6 +37,7 @@ public struct PlayerConfiguration {
     /// - Parameters:
     ///   - allowsExternalPlayback: Allows switching to external playback mode.
     ///   - usesExternalPlaybackWhileMirroring: Allows switching to external playback when mirroring.
+    ///   - preventsDisplaySleepDuringVideoPlayback: Indicates whether video playback prevents display and device sleep.
     ///   - audiovisualBackgroundPlaybackPolicy: Policy that determines how playback of audiovisual media continues
     ///     when the app transitions to the background.
     ///   - smartNavigationEnabled: Enables smart playlist navigation (see `isSmartNavigationEnabled`).
@@ -42,6 +46,7 @@ public struct PlayerConfiguration {
     public init(
         allowsExternalPlayback: Bool = true,
         usesExternalPlaybackWhileMirroring: Bool = false,
+        preventsDisplaySleepDuringVideoPlayback: Bool = true,
         audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic,
         smartNavigationEnabled: Bool = true,
         backwardSkipInterval: TimeInterval = 10,
@@ -51,6 +56,7 @@ public struct PlayerConfiguration {
         assert(forwardSkipInterval > 0)
         self.allowsExternalPlayback = allowsExternalPlayback
         self.usesExternalPlaybackWhileMirroring = usesExternalPlaybackWhileMirroring
+        self.preventsDisplaySleepDuringVideoPlayback = preventsDisplaySleepDuringVideoPlayback
         self.audiovisualBackgroundPlaybackPolicy = audiovisualBackgroundPlaybackPolicy
         self.isSmartNavigationEnabled = smartNavigationEnabled
         self.backwardSkipInterval = backwardSkipInterval

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -15,6 +15,7 @@ final class PlayerConfigurationTests: TestCase {
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beTrue())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
+        expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beTrue())
         expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.automatic))
         expect(player.configuration.isSmartNavigationEnabled).to(beTrue())
         expect(player.configuration.backwardSkipInterval).to(equal(10))
@@ -25,6 +26,7 @@ final class PlayerConfigurationTests: TestCase {
         let configuration = PlayerConfiguration(
             allowsExternalPlayback: false,
             usesExternalPlaybackWhileMirroring: true,
+            preventsDisplaySleepDuringVideoPlayback: false,
             audiovisualBackgroundPlaybackPolicy: .pauses,
             smartNavigationEnabled: false,
             backwardSkipInterval: 42,
@@ -33,6 +35,7 @@ final class PlayerConfigurationTests: TestCase {
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
+        expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beFalse())
         expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.pauses))
         expect(player.configuration.isSmartNavigationEnabled).to(beFalse())
         expect(player.configuration.backwardSkipInterval).to(equal(42))


### PR DESCRIPTION
# Pull request

## Description

This PR adds a flag letting integrators choose how device sleep / lock works when playing a video. It can be useful with animated video backgrounds or in scroll views displaying video content (muted or not).

## Changes made

- Add flag to the player configuration.
- No demo setting was added (does not make sense for a full-fledged player UX).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
