### PR TITLE
Keep the controls displayed when AirPlay is enabled

### DIFF
--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -69,7 +69,7 @@ private struct MainView: View {
     @ViewBuilder
     private func timeBar() -> some View {
         TimeBar(player: player)
-            .opacity(isUserInterfaceHidden ? 0 : 1)
+            .opacity(isUserInterfaceHidden && !player.isExternalPlaybackActive ? 0 : 1)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 
@@ -93,7 +93,7 @@ private struct MainView: View {
     @ViewBuilder
     private func controls() -> some View {
         ControlsView(player: player)
-            .opacity(isUserInterfaceHidden ? 0 : 1)
+            .opacity(isUserInterfaceHidden && !player.isExternalPlaybackActive ? 0 : 1)
     }
 
     @ViewBuilder


### PR DESCRIPTION
# Pull request

## Description

Self-explanatory.

## Changes made

- Keep the `controls` and the `timebar` visible when AirPlay is active.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
