### PR TITLE
Inhibit layout info updates during rotation

### DIFF
--- a/Sources/Player/LayoutReaderHost.swift
+++ b/Sources/Player/LayoutReaderHost.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @available(tvOS, unavailable)
 final class LayoutReaderHostingController<Content: View>: UIHostingController<Content>, UIGestureRecognizerDelegate {
     var layoutInfo: Binding<LayoutInfo> = .constant(.none)
+    private var isTransitioning = false
 
     private static func parent(for viewController: UIViewController) -> UIViewController {
         if let parentViewController = viewController.parent {
@@ -25,8 +26,22 @@ final class LayoutReaderHostingController<Content: View>: UIHostingController<Co
         view.backgroundColor = .clear
     }
 
-    override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateLayoutInfo()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        isTransitioning = true
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            self?.isTransitioning = false
+        }
+    }
+
+    private func updateLayoutInfo() {
+        guard !isTransitioning else { return }
+
         let frame = view.frame
 
         let parentFrame = Self.parent(for: self).view.frame


### PR DESCRIPTION
# Pull request

## Description

This PR fixes issues due to incorrect layout information returned during rotation.

## Changes made

- Introduce Boolean to inhibit layout information updates during rotation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
