### PR TITLE
Add player layout selection setting to the iOS demo

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0EF42CC029AF926B00553165 /* RadioChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF42CBF29AF926B00553165 /* RadioChannel.swift */; };
 		0EF42CC229AF92DB00553165 /* Vendor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF42CC129AF92DB00553165 /* Vendor.swift */; };
 		6F016D9B296C960000C4148E /* VanillaPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F016D9A296C960000C4148E /* VanillaPlayerView.swift */; };
+		6F12653F29C5B899004D2A66 /* PlayerLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F12653E29C5B899004D2A66 /* PlayerLayout.swift */; };
 		6F36C62D28910538000DD160 /* CoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6F36C62C28910538000DD160 /* CoreBusiness */; };
 		6F3F15A728CEEC6900CA2BD1 /* ShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */; };
 		6F48A5DD2932673A00B80393 /* DeveloperTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F48A5DC2932673A00B80393 /* DeveloperTools.swift */; };
@@ -77,6 +78,7 @@
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F016D9A296C960000C4148E /* VanillaPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VanillaPlayerView.swift; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F12653E29C5B899004D2A66 /* PlayerLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerLayout.swift; sourceTree = "<group>"; };
 		6F3F15A628CEEC6900CA2BD1 /* ShowcaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowcaseView.swift; sourceTree = "<group>"; };
 		6F45DB9A2893B773008ACCE6 /* Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Application.xcconfig; sourceTree = "<group>"; };
 		6F45DB9B2893B773008ACCE6 /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 				6FD1F3A028D0490200DF8CF1 /* MultiView.swift */,
 				6F65FA2028D0CE8A0081ACD1 /* PlaybackView.swift */,
 				0E8C3629296DB14600707FA5 /* PlayerConfiguration.swift */,
+				6F12653E29C5B899004D2A66 /* PlayerLayout.swift */,
 				6FCD6A1828AD158E00FCE4EA /* PlayerView.swift */,
 				6FA83B81296834FE001578DB /* Playlist.swift */,
 				0EEB324B29506969002E49DC /* PlaylistView.swift */,
@@ -365,6 +368,7 @@
 				0EEB324C29506969002E49DC /* PlaylistView.swift in Sources */,
 				6FCD6A1B28AD1B9200FCE4EA /* ExamplesView.swift in Sources */,
 				6F917C0F2887EA8E004113BA /* DemoApp.swift in Sources */,
+				6F12653F29C5B899004D2A66 /* PlayerLayout.swift in Sources */,
 				6FAB36BD29A754AA009E1F45 /* Constant.swift in Sources */,
 				0EC085F929B223B700F154D1 /* CopyButton.swift in Sources */,
 				6F7750D628EABD5100E80196 /* SimplePlayerView.swift in Sources */,

--- a/Demo/Sources/PlaybackView.swift
+++ b/Demo/Sources/PlaybackView.swift
@@ -387,7 +387,12 @@ struct PlaybackView: View {
     @ViewBuilder
     private func videoView() -> some View {
 #if os(iOS)
-        MainView(player: player)
+        switch UserDefaults.standard.playerLayout {
+        case .custom:
+            MainView(player: player)
+        case .system:
+            SystemVideoView(player: player)
+        }
 #else
         VideoView(player: player)
 #endif

--- a/Demo/Sources/PlayerLayout.swift
+++ b/Demo/Sources/PlayerLayout.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+@objc
+enum PlayerLayout: Int {
+    case custom
+    case system
+}

--- a/Demo/Sources/PlayerLayout.swift
+++ b/Demo/Sources/PlayerLayout.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 @objc
+@available(tvOS, unavailable)
 enum PlayerLayout: Int {
     case custom
     case system

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -78,7 +78,7 @@ struct SettingsView: View {
 
     @available(tvOS, unavailable) @ViewBuilder
     private func playerLayoutPicker() -> some View {
-        Picker("Player layout", selection: $playerLayout) {
+        Picker("Layout", selection: $playerLayout) {
             Text("Custom").tag(PlayerLayout.custom)
             Text("System").tag(PlayerLayout.system)
         }

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -14,14 +14,17 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.bodyCountersEnabledKey)
     private var areBodyCountersEnabled = false
 
-    @AppStorage(UserDefaults.seekBehaviorSettingKey)
-    private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
+    @AppStorage(UserDefaults.playerLayoutKey)
+    private var playerLayout: PlayerLayout = .custom
 
     @AppStorage(UserDefaults.allowsExternalPlaybackKey)
     private var allowsExternalPlayback = true
 
     @AppStorage(UserDefaults.smartNavigationEnabledKey)
     private var isSmartNavigationEnabled = true
+
+    @AppStorage(UserDefaults.seekBehaviorSettingKey)
+    private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
 
     @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicyKey)
     private var audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
@@ -60,6 +63,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func playerSection() -> some View {
         Section("Player") {
+            playerLayoutPicker()
             Toggle("Allows external playback", isOn: $allowsExternalPlayback)
             Toggle(isOn: $isSmartNavigationEnabled) {
                 Text("Smart navigation")
@@ -71,14 +75,10 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func debuggingSection() -> some View {
-        Section {
-            Button("Simulate memory warning", action: simulateMemoryWarning)
-            Button("Clear URL cache", action: clearUrlCache)
-        } header: {
-            Text("Debugging")
-        } footer: {
-            debuggingFooter()
+    private func playerLayoutPicker() -> some View {
+        Picker("Player layout", selection: $playerLayout) {
+            Text("Custom").tag(PlayerLayout.custom)
+            Text("System").tag(PlayerLayout.system)
         }
     }
 
@@ -96,6 +96,18 @@ struct SettingsView: View {
             Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
             Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
             Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
+        }
+    }
+
+    @ViewBuilder
+    private func debuggingSection() -> some View {
+        Section {
+            Button("Simulate memory warning", action: simulateMemoryWarning)
+            Button("Clear URL cache", action: clearUrlCache)
+        } header: {
+            Text("Debugging")
+        } footer: {
+            debuggingFooter()
         }
     }
 

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -13,8 +13,8 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaults.bodyCountersEnabledKey)
     private var areBodyCountersEnabled = false
-    
-    @AppStorage(UserDefaults.playerLayoutKey)
+
+    @available(tvOS, unavailable) @AppStorage(UserDefaults.playerLayoutKey)
     private var playerLayout: PlayerLayout = .custom
 
     @AppStorage(UserDefaults.allowsExternalPlaybackKey)
@@ -63,7 +63,9 @@ struct SettingsView: View {
     @ViewBuilder
     private func playerSection() -> some View {
         Section("Player") {
+#if os(iOS)
             playerLayoutPicker()
+#endif
             Toggle("Allows external playback", isOn: $allowsExternalPlayback)
             Toggle(isOn: $isSmartNavigationEnabled) {
                 Text("Smart navigation")
@@ -74,7 +76,7 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
+    @available(tvOS, unavailable) @ViewBuilder
     private func playerLayoutPicker() -> some View {
         Picker("Player layout", selection: $playerLayout) {
             Text("Custom").tag(PlayerLayout.custom)

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaults.bodyCountersEnabledKey)
     private var areBodyCountersEnabled = false
-
+    
     @AppStorage(UserDefaults.playerLayoutKey)
     private var playerLayout: PlayerLayout = .custom
 

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -21,11 +21,12 @@ enum SeekBehaviorSetting: Int {
 extension UserDefaults {
     static let presenterModeEnabledKey = "presenterModeEnabled"
     static let bodyCountersEnabledKey = "bodyCountersEnabled"
-    static let seekBehaviorSettingKey = "seekBehaviorSetting"
+    static let playerLayoutKey = "playerLayout"
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
+    static let seekBehaviorSettingKey = "seekBehaviorSetting"
     static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
-    static let serviceUrlKey = "serviceUrlKey"
+    static let serviceUrlKey = "serviceUrl"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -33,6 +34,18 @@ extension UserDefaults {
 
     @objc dynamic var bodyCountersEnabled: Bool {
         bool(forKey: Self.bodyCountersEnabledKey)
+    }
+
+    @objc dynamic var playerLayout: PlayerLayout {
+        .init(rawValue: integer(forKey: Self.playerLayoutKey)) ?? .custom
+    }
+
+    @objc dynamic var allowsExternalPlaybackEnabled: Bool {
+        bool(forKey: Self.allowsExternalPlaybackKey)
+    }
+
+    @objc dynamic var smartNavigationEnabled: Bool {
+        bool(forKey: Self.smartNavigationEnabledKey)
     }
 
     var seekBehavior: SeekBehavior {
@@ -46,14 +59,6 @@ extension UserDefaults {
 
     @objc dynamic var seekBehaviorSetting: SeekBehaviorSetting {
         .init(rawValue: integer(forKey: Self.seekBehaviorSettingKey)) ?? .immediate
-    }
-
-    @objc dynamic var allowsExternalPlaybackEnabled: Bool {
-        bool(forKey: Self.allowsExternalPlaybackKey)
-    }
-
-    @objc dynamic var smartNavigationEnabled: Bool {
-        bool(forKey: Self.smartNavigationEnabledKey)
     }
 
     @objc dynamic var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -21,7 +21,10 @@ enum SeekBehaviorSetting: Int {
 extension UserDefaults {
     static let presenterModeEnabledKey = "presenterModeEnabled"
     static let bodyCountersEnabledKey = "bodyCountersEnabled"
+
+    @available(tvOS, unavailable)
     static let playerLayoutKey = "playerLayout"
+
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
@@ -36,6 +39,7 @@ extension UserDefaults {
         bool(forKey: Self.bodyCountersEnabledKey)
     }
 
+    @available(tvOS, unavailable)
     @objc dynamic var playerLayout: PlayerLayout {
         .init(rawValue: integer(forKey: Self.playerLayoutKey)) ?? .custom
     }


### PR DESCRIPTION
# Pull request

## Description

This PR adds a player layout selection setting to the iOS demo. The user can choose between the custom layout implemented in the demo or the system player. This choice is then applied widely throughout demos and makes it possible for us to compare behaviors between our custom layout and Apple default one.

## Changes made

- Add player selection user default key.
- Add corresponding setting.
- Make sure the setting is not available on tvOS.
- Reorder settings to more closely match their order on screen.
- Rename existing `serviceUrlKey ` setting key for consistency.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
