### PR TITLE
Handle interruptions

### DIFF
--- a/Demo/Sources/PlayerConfiguration.swift
+++ b/Demo/Sources/PlayerConfiguration.swift
@@ -13,6 +13,7 @@ extension PlayerConfiguration {
         return .init(
             allowsExternalPlayback: userDefaults.allowsExternalPlaybackEnabled,
             usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
+            autoResumeAfterAnInterruption: userDefaults.autoResumeAfterAnInterruptionEnabled,
             audiovisualBackgroundPlaybackPolicy: userDefaults.audiovisualBackgroundPlaybackPolicy,
             smartNavigationEnabled: userDefaults.smartNavigationEnabled
         )
@@ -22,6 +23,7 @@ extension PlayerConfiguration {
         let userDefaults = UserDefaults.standard
         return .init(
             allowsExternalPlayback: false,
+            autoResumeAfterAnInterruption: userDefaults.autoResumeAfterAnInterruptionEnabled,
             audiovisualBackgroundPlaybackPolicy: userDefaults.audiovisualBackgroundPlaybackPolicy,
             smartNavigationEnabled: userDefaults.smartNavigationEnabled
         )

--- a/Demo/Sources/SettingsView.swift
+++ b/Demo/Sources/SettingsView.swift
@@ -29,6 +29,9 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicyKey)
     private var audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
 
+    @AppStorage(UserDefaults.autoResumeAfterAnInterruptionKey)
+    private var autoResumeAfterAnInterruption = false
+
     private var version: String {
         Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
     }
@@ -73,6 +76,7 @@ struct SettingsView: View {
             }
             seekBehaviorPicker()
             audiovisualBackgroundPlaybackPolicyPicker()
+            Toggle("Auto resume after an interruption", isOn: $autoResumeAfterAnInterruption)
         }
     }
 

--- a/Demo/Sources/UserDefaults.swift
+++ b/Demo/Sources/UserDefaults.swift
@@ -30,6 +30,7 @@ extension UserDefaults {
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
     static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
     static let serviceUrlKey = "serviceUrl"
+    static let autoResumeAfterAnInterruptionKey = "autoResumeAfterAnInterruption"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -73,6 +74,10 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.serviceUrlKey)) ?? .production
     }
 
+    @objc dynamic var autoResumeAfterAnInterruptionEnabled: Bool {
+        bool(forKey: Self.autoResumeAfterAnInterruptionKey)
+    }
+
     func registerDefaults() {
         register(defaults: [
             Self.presenterModeEnabledKey: false,
@@ -81,7 +86,8 @@ extension UserDefaults {
             Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
             Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue,
-            Self.serviceUrlKey: ServiceUrl.production.rawValue
+            Self.serviceUrlKey: ServiceUrl.production.rawValue,
+            Self.autoResumeAfterAnInterruptionKey: false
         ])
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -887,6 +887,7 @@ private extension Player {
         NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)
             .sink { [weak self] notification in
                 guard let self,
+                      UIApplication.shared.applicationState == .active,
                       self.configuration.autoResumeAfterAnInterruption,
                       let userInfo = notification.userInfo,
                       let interruptionTypeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -95,6 +95,7 @@ public final class Player: ObservableObject, Equatable {
         configureControlCenterPublishers()
         configureQueueUpdatePublisher()
         configureExternalPlaybackPublisher()
+        configureInterruptionPublisher()
 
         configurePlayer()
     }
@@ -878,5 +879,20 @@ extension Player {
             uninstallRemoteCommands()
             nowPlayingSession.nowPlayingInfoCenter.nowPlayingInfo = nil
         }
+    }
+}
+
+private extension Player {
+    private func configureInterruptionPublisher() {
+        NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)
+            .sink { [weak self] notification in
+                guard let userInfo = notification.userInfo,
+                      let interruptionTypeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+                      let interruptionType = AVAudioSession.InterruptionType(rawValue: interruptionTypeValue) else { return }
+                if interruptionType == .ended {
+                    self?.play()
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -886,12 +886,13 @@ private extension Player {
     private func configureInterruptionPublisher() {
         NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)
             .sink { [weak self] notification in
-                guard let userInfo = notification.userInfo,
+                guard let self,
+                      self.configuration.autoResumeAfterAnInterruption,
+                      let userInfo = notification.userInfo,
                       let interruptionTypeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-                      let interruptionType = AVAudioSession.InterruptionType(rawValue: interruptionTypeValue) else { return }
-                if interruptionType == .ended {
-                    self?.play()
-                }
+                      let interruptionType = AVAudioSession.InterruptionType(rawValue: interruptionTypeValue),
+                      interruptionType == .ended else { return }
+                self.play()
             }
             .store(in: &cancellables)
     }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -19,6 +19,9 @@ public struct PlayerConfiguration {
     /// Indicates whether video playback prevents display and device sleep.
     public let preventsDisplaySleepDuringVideoPlayback: Bool
 
+    /// A Boolean value that indicates whether the player should automatically resume playback after an interruption ends.
+    public let autoResumeAfterAnInterruption: Bool
+
     /// A policy that determines how playback of audiovisual media continues when the app transitions
     /// to the background.
     public let audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy
@@ -38,6 +41,8 @@ public struct PlayerConfiguration {
     ///   - allowsExternalPlayback: Allows switching to external playback mode.
     ///   - usesExternalPlaybackWhileMirroring: Allows switching to external playback when mirroring.
     ///   - preventsDisplaySleepDuringVideoPlayback: Indicates whether video playback prevents display and device sleep.
+    ///   - autoResumeAfterAnInterruption: A Boolean value that indicates whether the player should automatically resume playback
+    ///     after an interruption ends.
     ///   - audiovisualBackgroundPlaybackPolicy: Policy that determines how playback of audiovisual media continues
     ///     when the app transitions to the background.
     ///   - smartNavigationEnabled: Enables smart playlist navigation (see `isSmartNavigationEnabled`).
@@ -47,6 +52,7 @@ public struct PlayerConfiguration {
         allowsExternalPlayback: Bool = true,
         usesExternalPlaybackWhileMirroring: Bool = false,
         preventsDisplaySleepDuringVideoPlayback: Bool = true,
+        autoResumeAfterAnInterruption: Bool = false,
         audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic,
         smartNavigationEnabled: Bool = true,
         backwardSkipInterval: TimeInterval = 10,
@@ -57,6 +63,7 @@ public struct PlayerConfiguration {
         self.allowsExternalPlayback = allowsExternalPlayback
         self.usesExternalPlaybackWhileMirroring = usesExternalPlaybackWhileMirroring
         self.preventsDisplaySleepDuringVideoPlayback = preventsDisplaySleepDuringVideoPlayback
+        self.autoResumeAfterAnInterruption = autoResumeAfterAnInterruption
         self.audiovisualBackgroundPlaybackPolicy = audiovisualBackgroundPlaybackPolicy
         self.isSmartNavigationEnabled = smartNavigationEnabled
         self.backwardSkipInterval = backwardSkipInterval

--- a/Tests/PlayerTests/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/PlayerConfigurationTests.swift
@@ -16,6 +16,7 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.allowsExternalPlayback).to(beTrue())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
         expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beTrue())
+        expect(player.configuration.autoResumeAfterAnInterruption).to(beFalse())
         expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.automatic))
         expect(player.configuration.isSmartNavigationEnabled).to(beTrue())
         expect(player.configuration.backwardSkipInterval).to(equal(10))
@@ -27,6 +28,7 @@ final class PlayerConfigurationTests: TestCase {
             allowsExternalPlayback: false,
             usesExternalPlaybackWhileMirroring: true,
             preventsDisplaySleepDuringVideoPlayback: false,
+            autoResumeAfterAnInterruption: true,
             audiovisualBackgroundPlaybackPolicy: .pauses,
             smartNavigationEnabled: false,
             backwardSkipInterval: 42,
@@ -36,6 +38,7 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
         expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beFalse())
+        expect(player.configuration.autoResumeAfterAnInterruption).to(beTrue())
         expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.pauses))
         expect(player.configuration.isSmartNavigationEnabled).to(beFalse())
         expect(player.configuration.backwardSkipInterval).to(equal(42))


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to handle interruptions when a call is received or a alarm is fired.

## Changes made

- A new configuration method (`configureInterruptionPublisher`) has been added.
- A new setting has been added to enable/disable the auto resume after an interruption.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
