### PR TITLE
Deliver the tracker metadata from a publisher

### DIFF
--- a/Demo/Sources/Analytics/DemoTracker.swift
+++ b/Demo/Sources/Analytics/DemoTracker.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 import OSLog
 import Player
@@ -14,11 +15,16 @@ final class DemoTracker: PlayerItemTracker {
     }
 
     private static let logger = Logger(category: "DemoTracker")
-
+    private var cancellables = Set<AnyCancellable>()
     private let id = UUID()
 
-    init(configuration: Void) {
+    init(configuration: Void, metadataPublisher: AnyPublisher<Metadata, Never>) {
         Self.logger.debug("Init demo tracker \(self.id)")
+
+        metadataPublisher.sink { metadata in
+            Self.logger.debug("Update demo tracker metadata for \(self.id): \(metadata.title)")
+        }
+        .store(in: &cancellables)
     }
 
     func enable(for player: Player) {
@@ -27,10 +33,6 @@ final class DemoTracker: PlayerItemTracker {
 
     func disable() {
         Self.logger.debug("Disable demo tracker for \(self.id)")
-    }
-
-    func update(metadata: Metadata) {
-        Self.logger.debug("Update demo tracker metadata for \(self.id): \(metadata.title)")
     }
 
     deinit {

--- a/Demo/Sources/Analytics/DemoTracker.swift
+++ b/Demo/Sources/Analytics/DemoTracker.swift
@@ -21,8 +21,8 @@ final class DemoTracker: PlayerItemTracker {
     init(configuration: Void, metadataPublisher: AnyPublisher<Metadata, Never>) {
         Self.logger.debug("Init demo tracker \(self.id)")
 
-        metadataPublisher.sink { metadata in
-            Self.logger.debug("Update demo tracker metadata for \(self.id): \(metadata.title)")
+        metadataPublisher.sink { [id] metadata in
+            Self.logger.debug("Update demo tracker metadata for \(id): \(metadata.title)")
         }
         .store(in: &cancellables)
     }

--- a/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
+++ b/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 import Player
 
@@ -11,14 +12,10 @@ import Player
 public final class ComScoreTracker: PlayerItemTracker {
     private let id = UUID()
 
-    public init(configuration: Void) {}
+    public init(configuration: Void, metadataPublisher: AnyPublisher<[String: String], Never>) {}
 
     public func enable(for player: Player) {
         print("--> enable comScore \(id)")
-    }
-
-    public func update(metadata: [String: String]) {
-        print("--> update comScore metadata: \(metadata)")
     }
 
     public func disable() {

--- a/Sources/CoreBusiness/Analytics/CommandersActTracker.swift
+++ b/Sources/CoreBusiness/Analytics/CommandersActTracker.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 import Player
 
@@ -11,14 +12,10 @@ import Player
 public final class CommandersActTracker: PlayerItemTracker {
     private let id = UUID()
 
-    public init(configuration: Void) {}
+    public init(configuration: Void, metadataPublisher: AnyPublisher<[String: String], Never>) {}
 
     public func enable(for player: Player) {
         print("--> enable CommandersAct \(id)")
-    }
-
-    public func update(metadata: [String: String]) {
-        print("--> update CommandersAct metadata: \(metadata)")
     }
 
     public func disable() {

--- a/Sources/Player/Analytics/PlayerItemTracker.swift
+++ b/Sources/Player/Analytics/PlayerItemTracker.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 
 /// Common contract for player item tracker implementation. Initialization and deinitialization methods can be used
@@ -16,14 +17,14 @@ public protocol PlayerItemTracker: AnyObject {
     associatedtype Metadata
 
     /// Initialize the tracker.
-    init(configuration: Configuration)
+    /// - Parameters:
+    ///   - configuration: The tracker configuration.
+    ///   - metadataPublisher: The publisher that provides metadata updates.
+    init(configuration: Configuration, metadataPublisher: AnyPublisher<Metadata, Never>)
 
     /// Called when the tracker is enabled for a player.
     /// - Parameter player: The player for which the tracker must be enabled.
     func enable(for player: Player)
-
-    /// Called when the tracker metadata is updated.
-    func update(metadata: Metadata)
 
     /// Called when the tracker is disabled.
     func disable()

--- a/Tests/PlayerTests/Tools/MetadataFreeMock.swift
+++ b/Tests/PlayerTests/Tools/MetadataFreeMock.swift
@@ -18,15 +18,13 @@ final class MetadataFreeMock: ObservableObject, PlayerItemTracker {
 
     static var state = PassthroughSubject<State, Never>()
 
-    init(configuration: String) {
+    init(configuration: String, metadataPublisher: AnyPublisher<Void, Never>) {
         Self.state.send(.initialized(configuration))
     }
 
     func enable(for player: Player) {
         Self.state.send(.enabled)
     }
-
-    func update(metadata: Void) {}
 
     func disable() {
         Self.state.send(.disabled)

--- a/Tests/PlayerTests/Tools/NonConfigurableTrackerMock.swift
+++ b/Tests/PlayerTests/Tools/NonConfigurableTrackerMock.swift
@@ -18,9 +18,16 @@ final class NonConfigurableTrackerMock: ObservableObject, PlayerItemTracker {
     }
 
     static var state = PassthroughSubject<State, Never>()
+    private var cancellables = Set<AnyCancellable>()
 
-    init(configuration: Void) {
+    init(configuration: Void, metadataPublisher: AnyPublisher<String, Never>) {
         Self.state.send(.initialized)
+
+        metadataPublisher
+            .sink { metadata in
+                Self.state.send(.updated(metadata))
+            }
+        .store(in: &cancellables)
     }
 
     func enable(for player: Player) {
@@ -37,5 +44,6 @@ final class NonConfigurableTrackerMock: ObservableObject, PlayerItemTracker {
 
     deinit {
         Self.state.send(.deinitialized)
+        cancellables = []
     }
 }

--- a/Tests/PlayerTests/Tools/SimpleTrackerMock.swift
+++ b/Tests/PlayerTests/Tools/SimpleTrackerMock.swift
@@ -18,15 +18,13 @@ final class SimpleTrackerMock: ObservableObject, PlayerItemTracker {
 
     static var state = PassthroughSubject<State, Never>()
 
-    init(configuration: Void) {
+    init(configuration: Void, metadataPublisher: AnyPublisher<Void, Never>) {
         Self.state.send(.initialized)
     }
 
     func enable(for player: Player) {
         Self.state.send(.enabled)
     }
-
-    func update(metadata: Void) {}
 
     func disable() {
         Self.state.send(.disabled)

--- a/Tests/PlayerTests/Tools/TrackerMock.swift
+++ b/Tests/PlayerTests/Tools/TrackerMock.swift
@@ -18,9 +18,15 @@ final class TrackerMock: ObservableObject, PlayerItemTracker {
     }
 
     static var state = PassthroughSubject<State, Never>()
+    private var cancellables = Set<AnyCancellable>()
 
-    init(configuration: String) {
+    init(configuration: String, metadataPublisher: AnyPublisher<String, Never>) {
         Self.state.send(.initialized(configuration))
+
+        metadataPublisher.sink { metadata in
+            Self.state.send(.updated(metadata))
+        }
+        .store(in: &cancellables)
     }
 
     func enable(for player: Player) {
@@ -37,5 +43,6 @@ final class TrackerMock: ObservableObject, PlayerItemTracker {
 
     deinit {
         Self.state.send(.deinitialized)
+        cancellables = []
     }
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -265,14 +265,13 @@ The resulting player item can then be played in a Pillarbox `Player` instance. I
 Pillarbox makes it possible to easily integrate any kind of tracker, mostly for analytics or QoS needs. Proceed as follows to implement your own tracker:
 
 1. Create a new tracker class, say `CustomTracker`, and add conformance to the `PlayerItemTracker` protocol.
-2. The `PlayerItemTracker` protocol declares a `Configuration` associated type. If your tracker requires configuration just create a dedicated type which contains all required parameters. This type must be provided to the `init(configuration:)` method implemented in your tracker so that type inference correctly identifies it as configuration type. If no configuration is required just use `Void` instead.
-3. The `PlayerItemTracker` protocol declares a `Metadata` associated type. If your tracker requires metadata related to the item being tracked just create a dedicated type which contains all required information. This type must be provided to the `update(metadata:)` method implemented in your tracker so that type inference correctly identifies it as metadata type.
-4. Trackers are automatically instantiated and managed by a player. You therefore never instantiate a tracker directly but rather achieve the behavior you need by implementing `PlayerItemTracker` lifecycle methods instead:
-  - Configure your tracker early in `init(configuration:)` and / or store the configuration for later use. You can also start early data collection if needed.
+2. The `PlayerItemTracker` protocol declares `Configuration` and `Metadata` associated types. If your tracker requires a configuration or metadata related to the item being tracked just create dedicated types which contain all required parameters. Use `Void` for any type that is not required for your tracker.
+3. Trackers are automatically instantiated by the item they are associated with. You therefore never instantiate a tracker directly but rather achieve the behavior you need by implementing `PlayerItemTracker` lifecycle methods instead:
+  - When created `init(configuration:metadataPublisher:)` is called on your tracker with the configuration you provided as well as a publisher for the metadata type you chose. You can either use these values directly to setup your tracker or store them for later use.
   - Subscribe to player events which must be followed in `enable(for:)`. This method is called when the item to which the tracker is bound becomes the current one. Store the subscription tokens in your tracker and implement how the tracker should handle the events you subscribed to.
-  - Metadata updates are automatically received in `update(metadata:)`. You can for example store the metadata to use it at a later time in your tracker implementation.
+  - Metadata updates are automatically received from the `metadataPublisher`. You can combine this publisher with other publishers like `$playbackState` to achieve the behavior you need.
   - Cancel subscriptions in `disable()` by discarding the tokens you stored. This method is called when the item to which the tracker is bound stops being the current one.
-  - You can stop any remaining data collection in `deinit`.
+  - You can perform any necessary final cleanup in `deinit` which is called when the player item and its trackers are discarded.
 
 Once you have a tracker you can attach it to any item. The only requirement is that metadata supplied as part of the asset retrieval process is transformed into metadata required by the tracker. This transformation requires the use of a dedicated adapter, simply created from your custom tracker type with the `adapter(configuration:mapper:)` method. The adapter is also where you can supply any configuration required by your tracker:
 


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to decorrelate the method `update` from the `PlayerItemTracker` life cycle.

## Changes made

- The `update` method has been removed from the `PlayerItemTracker`.
- A new parameter `metadataPublisher` has been introduced in the tracker `init` method.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
