### PR TITLE
Update swiftlint to version 0.51.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -104,6 +104,7 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - period_spacing
   - prefer_nimble
   - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self

--- a/Demo/Sources/Application/DemoApp.swift
+++ b/Demo/Sources/Application/DemoApp.swift
@@ -63,7 +63,8 @@ private struct ShowcaseTab: View {
 
 @main
 struct DemoApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @UIApplicationDelegateAdaptor(AppDelegate.self)
+    private var appDelegate
 
     var body: some Scene {
         WindowGroup {

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -14,7 +14,8 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.bodyCountersEnabledKey)
     private var areBodyCountersEnabled = false
 
-    @available(tvOS, unavailable) @AppStorage(UserDefaults.playerLayoutKey)
+    @available(tvOS, unavailable)
+    @AppStorage(UserDefaults.playerLayoutKey)
     private var playerLayout: PlayerLayout = .custom
 
     @AppStorage(UserDefaults.allowsExternalPlaybackKey)
@@ -76,7 +77,8 @@ struct SettingsView: View {
         }
     }
 
-    @available(tvOS, unavailable) @ViewBuilder
+    @available(tvOS, unavailable)
+    @ViewBuilder
     private func playerLayoutPicker() -> some View {
         Picker("Layout", selection: $playerLayout) {
             Text("Custom").tag(PlayerLayout.custom)

--- a/Tests/CircumspectTests/ExpectationsTests.swift
+++ b/Tests/CircumspectTests/ExpectationsTests.swift
@@ -19,7 +19,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectAtLeastEqualPublishedValuesWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectAtLeastEqualPublished(
             values: [4, 7],
@@ -39,7 +38,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectAtLeastEqualPublishedNextValuesWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectAtLeastEqualPublishedNext(
             values: [7, 8],
@@ -62,7 +60,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectEqualPublishedValuesDuringIntervalWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectEqualPublished(
             values: [4, 7, 8],
@@ -85,7 +82,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectEqualPublishedNextValuesDuringIntervalWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectEqualPublishedNext(
             values: [7, 8],
@@ -99,13 +95,11 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectNothingPublished() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectNothingPublished(from: subject, during: .seconds(1))
     }
 
     func testExpectNothingPublishedNext() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectNothingPublishedNext(from: subject, during: .seconds(1)) {
             subject.send(4)
@@ -155,7 +149,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectOnlyEqualPublishedValuesWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectOnlyEqualPublished(
             values: [4, 7],
@@ -175,7 +168,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectOnlyEqualPublishedNextValuesWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         expectOnlyEqualPublishedNext(
             values: [7, 8],
@@ -189,7 +181,6 @@ final class ExpectationTests: XCTestCase {
     }
 
     func testExpectAtLeastEqualFollowingExpectEqual() {
-        // swiftlint:disable:next private_subject
         let publisher = PassthroughSubject<Int, Never>()
         expectEqualPublished(values: [1, 2], from: publisher, during: .milliseconds(100)) {
             publisher.send(1)

--- a/Tests/CircumspectTests/PublishersTests.swift
+++ b/Tests/CircumspectTests/PublishersTests.swift
@@ -17,7 +17,6 @@ final class PublisherTests: XCTestCase {
     }
 
     func testWaitForSuccessResultWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         let values = try? waitForResult(from: subject) {
             subject.send(4)
@@ -38,7 +37,6 @@ final class PublisherTests: XCTestCase {
     }
 
     func testWaitForOutputWhileExecuting() throws {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         let values = try waitForOutput(from: subject) {
             subject.send(4)
@@ -54,7 +52,6 @@ final class PublisherTests: XCTestCase {
     }
 
     func testWaitForSingleOutputWhileExecuting() throws {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         let value = try waitForSingleOutput(from: subject) {
             subject.send(4)
@@ -69,7 +66,6 @@ final class PublisherTests: XCTestCase {
     }
 
     func testWaitForFailureWhileExecuting() throws {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Error>()
         let error = try waitForFailure(from: Fail<Int, Error>(error: StructError())) {
             subject.send(4)
@@ -86,7 +82,6 @@ final class PublisherTests: XCTestCase {
     }
 
     func testCollectOutputWhileExecuting() {
-        // swiftlint:disable:next private_subject
         let subject = PassthroughSubject<Int, Never>()
         let values = collectOutput(from: subject, during: .milliseconds(500)) {
             subject.send(4)


### PR DESCRIPTION
# Pull request

## Description

This PR updates swiftlint to version 0.51.0.

## Changes made

- Checked the rule list and enabled new available rules.
- Fix new linting issues appeared with version 0.51.0.
- Updated swiftlint on all CI agents.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
