### PR TITLE
Add a way to use an adapter without any configuration or any mapper

### DIFF
--- a/Sources/Player/Analytics/PlayerItemTracker.swift
+++ b/Sources/Player/Analytics/PlayerItemTracker.swift
@@ -57,6 +57,12 @@ public extension PlayerItemTracker where Configuration == Void {
     static func adapter<M>(mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> where M: AssetMetadata {
         TrackerAdapter(trackerType: Self.self, configuration: (), mapper: mapper)
     }
+
+    /// Create an adapter for the receiver.
+    /// - Returns: The tracker adapter.
+    static func adapter() -> TrackerAdapter<Never> {
+        TrackerAdapter(trackerType: Self.self, configuration: (), mapper: nil)
+    }
 }
 
 public extension PlayerItemTracker where Metadata == Void, Configuration == Void {

--- a/Sources/Player/Analytics/TrackerAdapter.swift
+++ b/Sources/Player/Analytics/TrackerAdapter.swift
@@ -18,13 +18,15 @@ public struct TrackerAdapter<M: AssetMetadata> {
     ///   - trackerType: The type of the tracker to instantiate and manage.
     ///   - configuration: The tracker configuration.
     ///   - mapper: The metadata mapper.
-    public init<T>(trackerType: T.Type, configuration: T.Configuration, mapper: @escaping (M) -> T.Metadata) where T: PlayerItemTracker {
+    public init<T>(trackerType: T.Type, configuration: T.Configuration, mapper: ((M) -> T.Metadata)?) where T: PlayerItemTracker {
         // swiftlint:disable:next private_subject
         let metadataSubject = CurrentValueSubject<T.Metadata?, Never>(nil)
         let metadataPublisher = metadataSubject.compactMap { $0 }.eraseToAnyPublisher()
         let tracker = trackerType.init(configuration: configuration, metadataPublisher: metadataPublisher)
         update = { metadata in
-            metadataSubject.send(mapper(metadata))
+            if let mapper {
+                metadataSubject.send(mapper(metadata))
+            }
         }
         self.tracker = tracker
     }


### PR DESCRIPTION
# Pull request

## Description

Self-explanatory.

## Changes made

- The `TrackerAdapter` has been updated. The `mapper` parameter is not required anymore.
- A new syntactic sugar has been added to be allowed to do `MyAdapter.adapter()`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
