### PR TITLE
Rename a `LayoutInfo` property

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -36,11 +36,11 @@ private struct MainView: View {
     }
 
     private var gravity: AVLayerVideoGravity {
-        layoutInfo.isMaximized ? selectedGravity : .resizeAspect
+        layoutInfo.isOverCurrentContext ? selectedGravity : .resizeAspect
     }
 
     private var magnificationGestureMask: GestureMask {
-        layoutInfo.isMaximized ? .all : .subviews
+        layoutInfo.isOverCurrentContext ? .all : .subviews
     }
 
     private var isUserInterfaceHidden: Bool {

--- a/Sources/Player/UserInterface/LayoutReader.swift
+++ b/Sources/Player/UserInterface/LayoutReader.swift
@@ -10,16 +10,17 @@ import SwiftUI
 public struct LayoutInfo {
     /// A placeholder for unfilled layout information.
     public static var none: Self {
-        .init(isMaximized: false, isFullScreen: false)
+        .init(isOverCurrentContext: false, isFullScreen: false)
     }
 
-    /// Return whether the view is maximized in its parent context.
-    public let isMaximized: Bool
+    /// Return whether the view is in its parent context.
+    public let isOverCurrentContext: Bool
+
     /// Return whether the view covers the whole screen
     public let isFullScreen: Bool
 }
 
-/// A view which is able to determine whether it is maximized in its parent context or full screen. The view lays out
+/// A view which is able to determine whether it is over its parent context or full screen. The view lays out
 /// its children like a `ZStack`.
 @available(tvOS, unavailable)
 public struct LayoutReader<Content: View>: View {
@@ -58,7 +59,7 @@ struct LayoutReader_Previews: PreviewProvider {
                         .ignoresSafeArea()
                     Color.blue
                     VStack {
-                        Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                        Text(layoutInfo.isOverCurrentContext ? "✅ Over current context" : "❌ Not over current context")
                         Text(layoutInfo.isFullScreen ? "✅ Full screen" : "❌ Not full screen")
                     }
                 }
@@ -84,7 +85,7 @@ struct LayoutReader_Previews: PreviewProvider {
                 Color.red
                 Color.blue
                 VStack {
-                    Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                    Text(layoutInfo.isOverCurrentContext ? "✅ Over current context" : "❌ Not over current context")
                     Text(layoutInfo.isFullScreen ? "✅ Full screen" : "❌ Not full screen")
                 }
             }
@@ -100,14 +101,14 @@ struct LayoutReader_Previews: PreviewProvider {
         }
     }
 
-    private struct NonMaximizedLayoutReader: View {
+    private struct NotOverCurrentContextLayoutReader: View {
         @State private var layoutInfo: LayoutInfo = .none
 
         var body: some View {
             LayoutReader(layoutInfo: $layoutInfo) {
                 Color.blue
                 VStack {
-                    Text(layoutInfo.isMaximized ? "❌ Maximized" : "✅ Not maximized")
+                    Text(layoutInfo.isOverCurrentContext ? "❌ Over current context" : "✅ Not over current context")
                     Text(layoutInfo.isFullScreen ? "❌ Full screen" : "✅ Not full screen")
                 }
             }
@@ -124,7 +125,7 @@ struct LayoutReader_Previews: PreviewProvider {
                     LayoutReader(layoutInfo: $layoutInfo) {
                         Color.blue
                         VStack {
-                            Text(layoutInfo.isMaximized ? "✅ Maximized" : "❌ Not maximized")
+                            Text(layoutInfo.isOverCurrentContext ? "✅ Over current context" : "❌ Not over current context")
                             Text(layoutInfo.isFullScreen ? "❌ Full screen" : "✅ Not full screen")
                         }
                     }
@@ -142,8 +143,8 @@ struct LayoutReader_Previews: PreviewProvider {
             .previewDisplayName("Safe area in LayoutReader")
         SafeAreaInZStack()
             .previewDisplayName("Safe area in ZStack")
-        NonMaximizedLayoutReader()
-            .previewDisplayName("Non-maximized LayoutReader")
+        NotOverCurrentContextLayoutReader()
+            .previewDisplayName("Not over current context LayoutReader")
         NonFullScreenLayoutReader()
             .previewDisplayName("Non full-screen LayoutReader")
     }

--- a/Sources/Player/UserInterface/LayoutReaderHost.swift
+++ b/Sources/Player/UserInterface/LayoutReaderHost.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-/// An internal host controller which can determine whether it is maximized in its parent context or full screen.
+/// An internal host controller which can determine whether it is over its parent context or full screen.
 @available(tvOS, unavailable)
 final class LayoutReaderHostingController<Content: View>: UIHostingController<Content>, UIGestureRecognizerDelegate {
     var layoutInfo: Binding<LayoutInfo> = .constant(.none)
@@ -48,7 +48,7 @@ final class LayoutReaderHostingController<Content: View>: UIHostingController<Co
         let screenFrame = view.window?.windowScene?.screen.bounds ?? .zero
 
         layoutInfo.wrappedValue = .init(
-            isMaximized: frame == parentFrame,
+            isOverCurrentContext: frame == parentFrame,
             isFullScreen: frame == screenFrame
         )
     }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -192,13 +192,13 @@ By having the `ProgressTracker` stored in a nested view you ensure that only thi
 
 To make it easier to spot where user interface updates can be optimized our `Core` package provides a `_debugBodyCounter(color:)` modifier which surrounds any view you want to observe with a counter, showing how many times its body has been evaluated. This way you can observe how your layout behaves and visually detects where parts of your user interface could benefit from local progress tracking.
 
-## Maximized layout management (iOS)
+## Over current context layout management (iOS)
 
 Sometimes you want to enable behaviors only when a player view fills its parent context, for example zoom gestures which control the `VideoView` gravity.
 
 Pillarbox does not implement such behaviors natively but instead provides a `LayoutReader` wrapper returning its layout information through a binding.
 
-Here is for example how you could implement a pinch gesture only available when the player view is maximized in its parent context:
+Here is for example how you could implement a pinch gesture only available when the player view is over its parent context:
 
 ```swift
 struct PlayerView: View {
@@ -220,7 +220,7 @@ struct PlayerView: View {
     }
 
     private var magnificationGestureMask: GestureMask {
-        layoutInfo.isMaximized ? .all : .subviews
+        layoutInfo.isOverCurrentContext ? .all : .subviews
     }
 
     private func magnificationGesture() -> some Gesture {


### PR DESCRIPTION
# Pull request

## Description

Self-explanatory.

## Changes made

- `isMaximized` has been renamed to `isOverCurrentContext`

## Checklist

- [X] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
