### PR TITLE
Add full screen support to the demo player

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -148,15 +148,19 @@ private struct Toolbar: View {
 struct PlaylistView: View {
     @State var templates: [Template]
     @StateObject private var model = PlaylistViewModel()
+    @State private var layout: PlaybackView.Layout = .minimized
 
     var body: some View {
         VStack(spacing: 0) {
-            PlaybackView(player: model.player)
-            Toolbar(player: model.player, model: model)
-            List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
-                MediaCell(media: media, isPlaying: media == model.currentMedia)
+            PlaybackView(player: model.player, layout: $layout)
+            if layout != .maximized {
+                Toolbar(player: model.player, model: model)
+                List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
+                    MediaCell(media: media, isPlaying: media == model.currentMedia)
+                }
             }
         }
+        .animation(.linear, value: layout)
         .onAppear { model.templates = templates }
         .onChange(of: templates) { newValue in
             model.templates = newValue


### PR DESCRIPTION
# Pull request

## Description

This PR adds full screen support to the main demo player. Full-screen mode is currently only enabled for the playlist demo (in other settings the player fills the screen at all times).

## Changes made

- Add full screen button to `PlaybackView`.
- Add playback view layouts (with a special `.inline` layout for integrations without full screen button needs).
- Control layout with a binding.
- Add quasi-invisible background to bottom controls to avoid taps in transparent areas triggering the user interface toggle tap gesture.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
