### PR TITLE
Add blurred layout example

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		6F9DDB44288FE90E0069B687 /* Player in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9DDB43288FE90E0069B687 /* Player */; };
 		6FBEFCEB289132DB004BE625 /* UserInterface in Frameworks */ = {isa = PBXBuildFile; productRef = 6FBEFCEA289132DB004BE625 /* UserInterface */; };
 		6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6FCA4746292CBEC7008C2812 /* ShowTime */; };
+		6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCB9DDD29E024E900961B69 /* BlurredView.swift */; };
 		6FE324B329E4657D007501CF /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE324B229E4657D007501CF /* View.swift */; };
 /* End PBXBuildFile section */
 
@@ -120,6 +121,7 @@
 		6F917C082887EA8E004113BA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6F917C0D2887EA8E004113BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6F9DDB40288FE8F80069B687 /* pillarbox-apple */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "pillarbox-apple"; path = ..; sourceTree = "<group>"; };
+		6FCB9DDD29E024E900961B69 /* BlurredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredView.swift; sourceTree = "<group>"; };
 		6FE324B229E4657D007501CF /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -256,6 +258,7 @@
 				6F59E85629CF31E10093E6FB /* Playlist */,
 				6F59E85B29CF31E10093E6FB /* Stories */,
 				6F59E85F29CF31E10093E6FB /* Wrapped */,
+				6FCB9DDD29E024E900961B69 /* BlurredView.swift */,
 				6F59E86229CF31E10093E6FB /* LinkView.swift */,
 				6F59E85529CF31E10093E6FB /* MultiView.swift */,
 				6F59E85A29CF31E10093E6FB /* ShowcaseView.swift */,
@@ -517,6 +520,7 @@
 				6F59E89829CF31E20093E6FB /* PlayerConfiguration.swift in Sources */,
 				6F59E88B29CF31E20093E6FB /* PlaylistViewModel.swift in Sources */,
 				6F59E87F29CF31E10093E6FB /* Template.swift in Sources */,
+				6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */,
 				6F59E89129CF31E20093E6FB /* WrappedView.swift in Sources */,
 				6F59E88629CF31E20093E6FB /* ContentListView.swift in Sources */,
 				6F59E89B29CF31E20093E6FB /* SystemPlayerView.swift in Sources */,

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Player
+import SwiftUI
+
+// Behavior: h-exp, v-exp
+struct BlurredView: View {
+    let media: Media
+
+    @StateObject private var player = Player(configuration: .externalPlaybackDisabled)
+
+    var body: some View {
+        ZStack {
+            VideoView(player: player, gravity: .resizeAspectFill)
+                .blur(radius: 20)
+            VideoView(player: player)
+                .ignoresSafeArea()
+            ProgressView()
+                .opacity(player.isBusy ? 1 : 0)
+        }
+        .background(.black)
+        .onAppear(perform: play)
+    }
+
+    private func play() {
+        player.append(media.playerItem())
+        player.play()
+    }
+}
+
+struct BlurredView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlurredView(media: Media(from: URLTemplate.onDemandVideoLocalHLS))
+    }
+}

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -26,6 +26,9 @@ struct ShowcaseView: View {
             Cell(title: "Simple") {
                 SimplePlayerView(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
             }
+            Cell(title: "Blurred") {
+                BlurredView(media: Media(from: URLTemplate.dvrVideoHLS))
+            }
             Cell(title: "Stories") {
                 StoriesView()
             }


### PR DESCRIPTION
# Pull request

## Description

This PR adds a simple layout with a player displayed a second time blurred in the background.

## Changes made

- Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
