### PR TITLE
Support page view and event tracking

### DIFF
--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -56,6 +56,43 @@ public class Analytics {
         trackPageView(title: title, levels: levels, labels: nil)
     }
 
+    /// Record an event.
+    /// - Parameters:
+    ///   - name: The event name.
+    ///   - type: The event type.
+    ///   - value: The event value.
+    ///   - source: The event source.
+    ///   - extra1: The event extra1.
+    ///   - extra2: The event extra2.
+    ///   - extra3: The event extra3.
+    ///   - extra4: The event extra4.
+    ///   - extra5: The event extra5.
+    public func trackEvent(
+        name: String = "",
+        type: String = "",
+        value: String = "",
+        source: String = "",
+        extra1: String = "",
+        extra2: String = "",
+        extra3: String = "",
+        extra4: String = "",
+        extra5: String = ""
+    ) {
+        services.forEach { service in
+            service.trackEvent(
+                name: name,
+                type: type,
+                value: value,
+                source: source,
+                extra1: extra1,
+                extra2: extra2,
+                extra3: extra3,
+                extra4: extra4,
+                extra5: extra5
+            )
+        }
+    }
+
     func trackPageView(title: String, levels: [String], labels: Labels?) {
         services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
     }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -78,6 +78,10 @@ public class Analytics {
         extra4: String = "",
         extra5: String = ""
     ) {
+        // TODO: -
+        // Should we avoid to send an event with an empty name?
+        // Should we have some mandatory fields?
+
         sendEvent(
             name: name,
             type: type,

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -68,7 +68,7 @@ public class Analytics {
     ///   - extra4: The event extra4.
     ///   - extra5: The event extra5.
     public func sendEvent(
-        name: String = "",
+        name: String,
         type: String = "",
         value: String = "",
         source: String = "",
@@ -78,10 +78,6 @@ public class Analytics {
         extra4: String = "",
         extra5: String = ""
     ) {
-        // TODO: -
-        // Should we avoid to send an event with an empty name?
-        // Should we have some mandatory fields?
-
         sendEvent(
             name: name,
             type: type,
@@ -97,21 +93,24 @@ public class Analytics {
     }
 
     func sendPageView(title: String, levels: [String], labels: Labels?) {
+        assert(!title.isEmpty, "The title is required!")
         services.forEach { $0.sendPageView(title: title, levels: levels, labels: labels) }
     }
 
+    // swiftlint:disable:next function_parameter_count
     func sendEvent(
-        name: String = "",
-        type: String = "",
-        value: String = "",
-        source: String = "",
-        extra1: String = "",
-        extra2: String = "",
-        extra3: String = "",
-        extra4: String = "",
-        extra5: String = "",
+        name: String,
+        type: String,
+        value: String,
+        source: String,
+        extra1: String,
+        extra2: String,
+        extra3: String,
+        extra4: String,
+        extra5: String,
         labels: Labels?
     ) {
+        assert(!name.isEmpty, "The name is required!")
         services.forEach { service in
             service.sendEvent(
                 name: name,

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -28,25 +28,6 @@ public class Analytics {
         }
     }
 
-    /// Information sent with analytics events.
-    struct Labels {
-        /// comScore-specific information.
-        let comScore: [String: String]
-
-        /// Commanders Act-specific information.
-        let commandersAct: [String: String]
-
-        /// Merge labels together.
-        /// - Parameter other: The other labels which must be merged into the receiver.
-        /// - Returns: The merged labels.
-        func merging(_ other: Self) -> Self {
-            .init(
-                comScore: comScore.merging(other.comScore) { _, new in new },
-                commandersAct: commandersAct.merging(other.commandersAct) { _, new in new }
-            )
-        }
-    }
-
     /// The singleton instance.
     public static var shared = Analytics()
 

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -52,8 +52,8 @@ public class Analytics {
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
-    public func trackPageView(title: String, levels: [String] = []) {
-        trackPageView(title: title, levels: levels, labels: nil)
+    public func sendPageView(title: String, levels: [String] = []) {
+        sendPageView(title: title, levels: levels, labels: nil)
     }
 
     /// Record an event.
@@ -92,8 +92,8 @@ public class Analytics {
         )
     }
 
-    func trackPageView(title: String, levels: [String], labels: Labels?) {
-        services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
+    func sendPageView(title: String, levels: [String], labels: Labels?) {
+        services.forEach { $0.sendPageView(title: title, levels: levels, labels: labels) }
     }
 
     func sendEvent(

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -62,11 +62,11 @@ public class Analytics {
     ///   - type: The event type.
     ///   - value: The event value.
     ///   - source: The event source.
-    ///   - extra1: The event extra1.
-    ///   - extra2: The event extra2.
-    ///   - extra3: The event extra3.
-    ///   - extra4: The event extra4.
-    ///   - extra5: The event extra5.
+    ///   - extra1: Extra information associated with the event.
+    ///   - extra2: Extra information associated with the event.
+    ///   - extra3: Extra information associated with the event.
+    ///   - extra4: Extra information associated with the event.
+    ///   - extra5: Extra information associated with the event.
     public func sendEvent(
         name: String,
         type: String = "",

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -78,6 +78,36 @@ public class Analytics {
         extra4: String = "",
         extra5: String = ""
     ) {
+        trackEvent(
+            name: name,
+            type: type,
+            value: value,
+            source: source,
+            extra1: extra1,
+            extra2: extra2,
+            extra3: extra3,
+            extra4: extra4,
+            extra5: extra5,
+            labels: nil
+        )
+    }
+
+    func trackPageView(title: String, levels: [String], labels: Labels?) {
+        services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
+    }
+
+    func trackEvent(
+        name: String = "",
+        type: String = "",
+        value: String = "",
+        source: String = "",
+        extra1: String = "",
+        extra2: String = "",
+        extra3: String = "",
+        extra4: String = "",
+        extra5: String = "",
+        labels: Labels?
+    ) {
         services.forEach { service in
             service.trackEvent(
                 name: name,
@@ -88,12 +118,9 @@ public class Analytics {
                 extra2: extra2,
                 extra3: extra3,
                 extra4: extra4,
-                extra5: extra5
+                extra5: extra5,
+                labels: labels
             )
         }
-    }
-
-    func trackPageView(title: String, levels: [String], labels: Labels?) {
-        services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
     }
 }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -67,7 +67,7 @@ public class Analytics {
     ///   - extra3: The event extra3.
     ///   - extra4: The event extra4.
     ///   - extra5: The event extra5.
-    public func trackEvent(
+    public func sendEvent(
         name: String = "",
         type: String = "",
         value: String = "",
@@ -78,7 +78,7 @@ public class Analytics {
         extra4: String = "",
         extra5: String = ""
     ) {
-        trackEvent(
+        sendEvent(
             name: name,
             type: type,
             value: value,
@@ -96,7 +96,7 @@ public class Analytics {
         services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
     }
 
-    func trackEvent(
+    func sendEvent(
         name: String = "",
         type: String = "",
         value: String = "",
@@ -109,7 +109,7 @@ public class Analytics {
         labels: Labels?
     ) {
         services.forEach { service in
-            service.trackEvent(
+            service.sendEvent(
                 name: name,
                 type: type,
                 value: value,

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -29,26 +29,17 @@ public class Analytics {
     }
 
     /// Information sent with analytics events.
-    public struct Labels {
+    struct Labels {
         /// comScore-specific information.
-        public let comScore: [String: String]
+        let comScore: [String: String]
 
         /// Commanders Act-specific information.
-        public let commandersAct: [String: String]
-
-        /// Create labels.
-        /// - Parameters:
-        ///   - comScore: comScore-specific information.
-        ///   - commandersAct: Commanders Act-specific information.
-        public init(comScore: [String: String], commandersAct: [String: String]) {
-            self.comScore = comScore
-            self.commandersAct = commandersAct
-        }
+        let commandersAct: [String: String]
 
         /// Merge labels together.
         /// - Parameter other: The other labels which must be merged into the receiver.
         /// - Returns: The merged labels.
-        public func merging(_ other: Self) -> Self {
+        func merging(_ other: Self) -> Self {
             .init(
                 comScore: comScore.merging(other.comScore) { _, new in new },
                 commandersAct: commandersAct.merging(other.commandersAct) { _, new in new }
@@ -80,8 +71,11 @@ public class Analytics {
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
-    ///   - labels: Labels associated with the event.
-    public func trackPageView(title: String, levels: [String] = [], labels: Labels? = nil) {
+    public func trackPageView(title: String, levels: [String] = []) {
+        trackPageView(title: title, levels: levels, labels: nil)
+    }
+
+    func trackPageView(title: String, levels: [String], labels: Labels?) {
         services.forEach { $0.trackPageView(title: title, levels: levels, labels: labels) }
     }
 }

--- a/Sources/Analytics/AnalyticsService.swift
+++ b/Sources/Analytics/AnalyticsService.swift
@@ -10,7 +10,7 @@ protocol AnalyticsService {
     func start(with configuration: Analytics.Configuration)
     func trackPageView(title: String, levels: [String], labels: Labels?)
     // swiftlint:disable:next function_parameter_count
-    func trackEvent(
+    func sendEvent(
         name: String,
         type: String,
         value: String,

--- a/Sources/Analytics/AnalyticsService.swift
+++ b/Sources/Analytics/AnalyticsService.swift
@@ -8,5 +8,5 @@ import Foundation
 
 protocol AnalyticsService {
     func start(with configuration: Analytics.Configuration)
-    func trackPageView(title: String, levels: [String], labels: Analytics.Labels?)
+    func trackPageView(title: String, levels: [String], labels: Labels?)
 }

--- a/Sources/Analytics/AnalyticsService.swift
+++ b/Sources/Analytics/AnalyticsService.swift
@@ -19,6 +19,7 @@ protocol AnalyticsService {
         extra2: String,
         extra3: String,
         extra4: String,
-        extra5: String
+        extra5: String,
+        labels: Labels?
     )
 }

--- a/Sources/Analytics/AnalyticsService.swift
+++ b/Sources/Analytics/AnalyticsService.swift
@@ -9,4 +9,16 @@ import Foundation
 protocol AnalyticsService {
     func start(with configuration: Analytics.Configuration)
     func trackPageView(title: String, levels: [String], labels: Labels?)
+    // swiftlint:disable:next function_parameter_count
+    func trackEvent(
+        name: String,
+        type: String,
+        value: String,
+        source: String,
+        extra1: String,
+        extra2: String,
+        extra3: String,
+        extra4: String,
+        extra5: String
+    )
 }

--- a/Sources/Analytics/AnalyticsService.swift
+++ b/Sources/Analytics/AnalyticsService.swift
@@ -8,7 +8,7 @@ import Foundation
 
 protocol AnalyticsService {
     func start(with configuration: Analytics.Configuration)
-    func trackPageView(title: String, levels: [String], labels: Labels?)
+    func sendPageView(title: String, levels: [String], labels: Labels?)
     // swiftlint:disable:next function_parameter_count
     func sendEvent(
         name: String,

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -14,12 +14,13 @@ struct ComScoreService: AnalyticsService {
 
     func start(with configuration: Analytics.Configuration) {
         let publisherConfiguration = SCORPublisherConfiguration { builder in
-            builder!.publisherId = "6036016"
-            builder!.secureTransmissionEnabled = true
+            guard let builder else { return }
+            builder.publisherId = "6036016"
+            builder.secureTransmissionEnabled = true
 
             // See https://confluence.srg.beecollaboration.com/pages/viewpage.action?pageId=13188565
             // Coding Document for Video Players, section 4.4
-            builder!.httpRedirectCachingEnabled = false
+            builder.httpRedirectCachingEnabled = false
         }
         let comScoreConfiguration = SCORAnalytics.configuration()!
         comScoreConfiguration.addClient(with: publisherConfiguration)
@@ -52,6 +53,5 @@ struct ComScoreService: AnalyticsService {
         extra4: String,
         extra5: String,
         labels: Labels?
-    ) {
-    }
+    ) {}
 }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -35,7 +35,7 @@ struct ComScoreService: AnalyticsService {
         SCORAnalytics.start()
     }
 
-    func trackPageView(title: String, levels: [String], labels: Labels?) {
+    func sendPageView(title: String, levels: [String], labels: Labels?) {
         let allLabels = ["ns_category": title].merging(labels?.comScore ?? [:]) { _, new in new }
         SCORAnalytics.notifyViewEvent(withLabels: allLabels)
     }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -17,8 +17,8 @@ struct ComScoreService: AnalyticsService {
             builder!.publisherId = "6036016"
             builder!.secureTransmissionEnabled = true
 
-            // See https://confluence.srg.beecollaboration.com/display/INTFORSCHUNG/ComScore+-+Media+Metrix+Report
-            // Coding Document for Video Players, page 16
+            // See https://confluence.srg.beecollaboration.com/pages/viewpage.action?pageId=13188565
+            // Coding Document for Video Players, section 4.4
             builder!.httpRedirectCachingEnabled = false
         }
         let comScoreConfiguration = SCORAnalytics.configuration()!

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -50,7 +50,8 @@ struct ComScoreService: AnalyticsService {
         extra2: String,
         extra3: String,
         extra4: String,
-        extra5: String
+        extra5: String,
+        labels: Labels?
     ) {
     }
 }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -39,4 +39,18 @@ struct ComScoreService: AnalyticsService {
         let allLabels = ["ns_category": title].merging(labels?.comScore ?? [:]) { _, new in new }
         SCORAnalytics.notifyViewEvent(withLabels: allLabels)
     }
+
+    // swiftlint:disable:next function_parameter_count
+    func trackEvent(
+        name: String,
+        type: String,
+        value: String,
+        source: String,
+        extra1: String,
+        extra2: String,
+        extra3: String,
+        extra4: String,
+        extra5: String
+    ) {
+    }
 }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -32,7 +32,7 @@ struct ComScoreService: AnalyticsService {
     }
 
     func trackPageView(title: String, levels: [String], labels: Analytics.Labels?) {
-        let allLabels = ["name": title].merging(labels?.comScore ?? [:]) { _, new in new }
+        let allLabels = ["ns_category": title].merging(labels?.comScore ?? [:]) { _, new in new }
         SCORAnalytics.notifyViewEvent(withLabels: allLabels)
     }
 }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -27,7 +27,10 @@ struct ComScoreService: AnalyticsService {
         comScoreConfiguration.applicationVersion = applicationVersion
         comScoreConfiguration.usagePropertiesAutoUpdateMode = .foregroundAndBackground
         comScoreConfiguration.preventAdSupportUsage = true
-        comScoreConfiguration.addPersistentLabels(["mp_brand": configuration.vendor.rawValue])
+        comScoreConfiguration.addPersistentLabels([
+            "mp_brand": configuration.vendor.rawValue,
+            "mp_v": applicationVersion
+        ])
 
         SCORAnalytics.start()
     }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -27,6 +27,7 @@ struct ComScoreService: AnalyticsService {
         comScoreConfiguration.applicationVersion = applicationVersion
         comScoreConfiguration.usagePropertiesAutoUpdateMode = .foregroundAndBackground
         comScoreConfiguration.preventAdSupportUsage = true
+        comScoreConfiguration.addPersistentLabels(["mp_brand": configuration.vendor.rawValue])
 
         SCORAnalytics.start()
     }

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -41,7 +41,7 @@ struct ComScoreService: AnalyticsService {
     }
 
     // swiftlint:disable:next function_parameter_count
-    func trackEvent(
+    func sendEvent(
         name: String,
         type: String,
         value: String,

--- a/Sources/Analytics/ComScoreService.swift
+++ b/Sources/Analytics/ComScoreService.swift
@@ -35,7 +35,7 @@ struct ComScoreService: AnalyticsService {
         SCORAnalytics.start()
     }
 
-    func trackPageView(title: String, levels: [String], labels: Analytics.Labels?) {
+    func trackPageView(title: String, levels: [String], labels: Labels?) {
         let allLabels = ["ns_category": title].merging(labels?.comScore ?? [:]) { _, new in new }
         SCORAnalytics.notifyViewEvent(withLabels: allLabels)
     }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -37,7 +37,7 @@ final class CommandersActService: AnalyticsService {
     }
 
     // swiftlint:disable:next function_parameter_count
-    func trackEvent(
+    func sendEvent(
         name: String,
         type: String,
         value: String,

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -26,27 +26,27 @@ final class CommandersActService: AnalyticsService {
 
     func start(with configuration: Analytics.Configuration) {
         vendor = configuration.vendor
-        serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey)
-        serverSide?.addPermanentData("app_library_version", withValue: PackageInfo.version)
-        serverSide?.addPermanentData("navigation_app_site_name", withValue: configuration.site)
-        serverSide?.addPermanentData("navigation_device", withValue: UIDevice.current.model)
-        serverSide?.enableRunningInBackground()
+        guard let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) else { return }
+        serverSide.addPermanentData("app_library_version", withValue: PackageInfo.version)
+        serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.site)
+        serverSide.addPermanentData("navigation_device", withValue: UIDevice.current.model)
+        serverSide.enableRunningInBackground()
     }
 
     func sendPageView(title: String, levels: [String], labels: Labels?) {
-        let event = TCPageViewEvent(type: title)
+        guard let serverSide, let event = TCPageViewEvent(type: title) else { return }
 
-        event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
-        event?.addAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
+        event.addAdditionalProperty("navigation_property_type", withStringValue: "app")
+        event.addAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
         levels.enumerated().forEach { index, level in
             guard index < 8 else { return }
-            event?.addAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)
+            event.addAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)
         }
 
         labels?.commandersAct.forEach { label in
-            event?.addAdditionalProperty(label.key, withStringValue: label.value)
+            event.addAdditionalProperty(label.key, withStringValue: label.value)
         }
-        serverSide?.execute(event)
+        serverSide.execute(event)
     }
 
     // swiftlint:disable:next function_parameter_count
@@ -62,20 +62,20 @@ final class CommandersActService: AnalyticsService {
         extra5: String,
         labels: Labels?
     ) {
-        let event = TCCustomEvent(name: name)
-        event?.addAdditionalProperty("event_type", withStringValue: type)
-        event?.addAdditionalProperty("event_value", withStringValue: value)
-        event?.addAdditionalProperty("event_source", withStringValue: source)
-        event?.addAdditionalProperty("event_value_1", withStringValue: extra1)
-        event?.addAdditionalProperty("event_value_2", withStringValue: extra2)
-        event?.addAdditionalProperty("event_value_3", withStringValue: extra3)
-        event?.addAdditionalProperty("event_value_4", withStringValue: extra4)
-        event?.addAdditionalProperty("event_value_5", withStringValue: extra5)
+        guard let serverSide, let event = TCCustomEvent(name: name) else { return }
+        event.addAdditionalProperty("event_type", withStringValue: type)
+        event.addAdditionalProperty("event_value", withStringValue: value)
+        event.addAdditionalProperty("event_source", withStringValue: source)
+        event.addAdditionalProperty("event_value_1", withStringValue: extra1)
+        event.addAdditionalProperty("event_value_2", withStringValue: extra2)
+        event.addAdditionalProperty("event_value_3", withStringValue: extra3)
+        event.addAdditionalProperty("event_value_4", withStringValue: extra4)
+        event.addAdditionalProperty("event_value_5", withStringValue: extra5)
 
         labels?.commandersAct.forEach { label in
-            event?.addAdditionalProperty(label.key, withStringValue: label.value)
+            event.addAdditionalProperty(label.key, withStringValue: label.value)
         }
 
-        serverSide?.execute(event)
+        serverSide.execute(event)
     }
 }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -20,6 +20,9 @@ final class CommandersActService: AnalyticsService {
 
     func trackPageView(title: String, levels: [String], labels: Analytics.Labels?) {
         let event = TCPageViewEvent(type: title)
+
+        event?.addAdditionalProperty("event_id", withStringValue: "screen")
+
         labels?.commandersAct.forEach { label in
             event?.addAdditionalProperty(label.key, withStringValue: label.value)
         }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -9,8 +9,10 @@ import TCServerSide_noIDFA
 
 final class CommandersActService: AnalyticsService {
     private var serverSide: ServerSide?
+    private var vendor: Vendor?
 
     func start(with configuration: Analytics.Configuration) {
+        vendor = configuration.vendor
         serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey)
         serverSide?.addPermanentData("app_library_version", withValue: PackageInfo.version)
         serverSide?.addPermanentData("navigation_app_site_name", withValue: configuration.site)
@@ -24,6 +26,7 @@ final class CommandersActService: AnalyticsService {
         event?.addAdditionalProperty("event_id", withStringValue: "screen")
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
         event?.addAdditionalProperty("content_title", withStringValue: title)
+        event?.addAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
 
         labels?.commandersAct.forEach { label in
             event?.addAdditionalProperty(label.key, withStringValue: label.value)

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -46,7 +46,23 @@ final class CommandersActService: AnalyticsService {
         extra2: String,
         extra3: String,
         extra4: String,
-        extra5: String
+        extra5: String,
+        labels: Labels?
     ) {
+        let event = TCCustomEvent(name: name)
+        event?.addAdditionalProperty("event_type", withStringValue: type)
+        event?.addAdditionalProperty("event_value", withStringValue: value)
+        event?.addAdditionalProperty("event_source", withStringValue: source)
+        event?.addAdditionalProperty("event_value_1", withStringValue: extra1)
+        event?.addAdditionalProperty("event_value_2", withStringValue: extra2)
+        event?.addAdditionalProperty("event_value_3", withStringValue: extra3)
+        event?.addAdditionalProperty("event_value_4", withStringValue: extra4)
+        event?.addAdditionalProperty("event_value_5", withStringValue: extra5)
+
+        labels?.commandersAct.forEach { label in
+            event?.addAdditionalProperty(label.key, withStringValue: label.value)
+        }
+
+        serverSide?.execute(event)
     }
 }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -22,6 +22,7 @@ final class CommandersActService: AnalyticsService {
         let event = TCPageViewEvent(type: title)
 
         event?.addAdditionalProperty("event_id", withStringValue: "screen")
+        event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
 
         labels?.commandersAct.forEach { label in
             event?.addAdditionalProperty(label.key, withStringValue: label.value)

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -27,6 +27,10 @@ final class CommandersActService: AnalyticsService {
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
         event?.addAdditionalProperty("content_title", withStringValue: title)
         event?.addAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
+        levels.enumerated().forEach { index, level in
+            guard index < 8 else { return }
+            event?.addAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)
+        }
 
         labels?.commandersAct.forEach { label in
             event?.addAdditionalProperty(label.key, withStringValue: label.value)

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -14,6 +14,7 @@ final class CommandersActService: AnalyticsService {
         serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey)
         serverSide?.addPermanentData("app_library_version", withValue: PackageInfo.version)
         serverSide?.addPermanentData("navigation_app_site_name", withValue: configuration.site)
+        serverSide?.addPermanentData("navigation_device", withValue: UIDevice.current.model)
         serverSide?.enableRunningInBackground()
     }
 

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -23,6 +23,7 @@ final class CommandersActService: AnalyticsService {
 
         event?.addAdditionalProperty("event_id", withStringValue: "screen")
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
+        event?.addAdditionalProperty("content_title", withStringValue: title)
 
         labels?.commandersAct.forEach { label in
             event?.addAdditionalProperty(label.key, withStringValue: label.value)

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -20,7 +20,7 @@ final class CommandersActService: AnalyticsService {
         serverSide?.enableRunningInBackground()
     }
 
-    func trackPageView(title: String, levels: [String], labels: Analytics.Labels?) {
+    func trackPageView(title: String, levels: [String], labels: Labels?) {
         let event = TCPageViewEvent(type: title)
 
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -20,7 +20,7 @@ final class CommandersActService: AnalyticsService {
         serverSide?.enableRunningInBackground()
     }
 
-    func trackPageView(title: String, levels: [String], labels: Labels?) {
+    func sendPageView(title: String, levels: [String], labels: Labels?) {
         let event = TCPageViewEvent(type: title)
 
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -13,6 +13,7 @@ final class CommandersActService: AnalyticsService {
     func start(with configuration: Analytics.Configuration) {
         serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey)
         serverSide?.addPermanentData("app_library_version", withValue: PackageInfo.version)
+        serverSide?.addPermanentData("navigation_app_site_name", withValue: configuration.site)
         serverSide?.enableRunningInBackground()
     }
 

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -23,9 +23,7 @@ final class CommandersActService: AnalyticsService {
     func trackPageView(title: String, levels: [String], labels: Analytics.Labels?) {
         let event = TCPageViewEvent(type: title)
 
-        event?.addAdditionalProperty("event_id", withStringValue: "screen")
         event?.addAdditionalProperty("navigation_property_type", withStringValue: "app")
-        event?.addAdditionalProperty("content_title", withStringValue: title)
         event?.addAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
         levels.enumerated().forEach { index, level in
             guard index < 8 else { return }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -35,4 +35,18 @@ final class CommandersActService: AnalyticsService {
         }
         serverSide?.execute(event)
     }
+
+    // swiftlint:disable:next function_parameter_count
+    func trackEvent(
+        name: String,
+        type: String,
+        value: String,
+        source: String,
+        extra1: String,
+        extra2: String,
+        extra3: String,
+        extra4: String,
+        extra5: String
+    ) {
+    }
 }

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -11,7 +11,7 @@ final class CommandersActService: AnalyticsService {
     private var serverSide: ServerSide?
     private var vendor: Vendor?
 
-    static func device() -> String {
+    private static func device() -> String {
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:
             return "phone"

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -29,8 +29,9 @@ final class CommandersActService: AnalyticsService {
         guard let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) else { return }
         serverSide.addPermanentData("app_library_version", withValue: PackageInfo.version)
         serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.site)
-        serverSide.addPermanentData("navigation_device", withValue: UIDevice.current.model)
+        serverSide.addPermanentData("navigation_device", withValue: Self.device())
         serverSide.enableRunningInBackground()
+        self.serverSide = serverSide
     }
 
     func sendPageView(title: String, levels: [String], labels: Labels?) {

--- a/Sources/Analytics/CommandersActService.swift
+++ b/Sources/Analytics/CommandersActService.swift
@@ -11,6 +11,19 @@ final class CommandersActService: AnalyticsService {
     private var serverSide: ServerSide?
     private var vendor: Vendor?
 
+    static func device() -> String {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .phone:
+            return "phone"
+        case .pad:
+            return "tablet"
+        case .tv:
+            return "tvbox"
+        default:
+            return "phone"
+        }
+    }
+
     func start(with configuration: Analytics.Configuration) {
         vendor = configuration.vendor
         serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey)

--- a/Sources/Analytics/Labels.swift
+++ b/Sources/Analytics/Labels.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// Information sent with analytics events.
+struct Labels {
+    /// comScore-specific information.
+    let comScore: [String: String]
+
+    /// Commanders Act-specific information.
+    let commandersAct: [String: String]
+
+    /// Merge labels together.
+    /// - Parameter other: The other labels which must be merged into the receiver.
+    /// - Returns: The merged labels.
+    func merging(_ other: Self) -> Self {
+        .init(
+            comScore: comScore.merging(other.comScore) { _, new in new },
+            commandersAct: commandersAct.merging(other.commandersAct) { _, new in new }
+        )
+    }
+}

--- a/Sources/Analytics/Vendor.swift
+++ b/Sources/Analytics/Vendor.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// The vendor for which analytics are collected.
-public enum Vendor {
+public enum Vendor: String {
     /// SRF.
     case SRF
     /// RTS.

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -25,4 +25,40 @@ public struct AnalyticsTest {
     public func trackPageView(title: String, levels: [String] = []) {
         Analytics.shared.trackPageView(title: title, levels: levels, labels: .init(comScore: additionalLabels, commandersAct: additionalLabels))
     }
+
+    /// Record an event.
+    /// - Parameters:
+    ///   - name: The event name.
+    ///   - type: The event type.
+    ///   - value: The event value.
+    ///   - source: The event source.
+    ///   - extra1: The event extra1.
+    ///   - extra2: The event extra2.
+    ///   - extra3: The event extra3.
+    ///   - extra4: The event extra4.
+    ///   - extra5: The event extra5.
+    public func trackEvent(
+        name: String = "",
+        type: String = "",
+        value: String = "",
+        source: String = "",
+        extra1: String = "",
+        extra2: String = "",
+        extra3: String = "",
+        extra4: String = "",
+        extra5: String = ""
+    ) {
+        Analytics.shared.trackEvent(
+            name: name,
+            type: type,
+            value: value,
+            source: source,
+            extra1: extra1,
+            extra2: extra2,
+            extra3: extra3,
+            extra4: extra4,
+            extra5: extra5,
+            labels: .init(comScore: additionalLabels, commandersAct: additionalLabels)
+        )
+    }
 }

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -38,7 +38,7 @@ public struct AnalyticsTest {
     ///   - extra4: The event extra4.
     ///   - extra5: The event extra5.
     public func sendEvent(
-        name: String = "name-test", // TODO: Should be removed!
+        name: String,
         type: String = "",
         value: String = "",
         source: String = "",

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -38,7 +38,7 @@ public struct AnalyticsTest {
     ///   - extra4: The event extra4.
     ///   - extra5: The event extra5.
     public func sendEvent(
-        name: String = "",
+        name: String = "name-test", // TODO: Should be removed!
         type: String = "",
         value: String = "",
         source: String = "",

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -4,14 +4,14 @@
 //  License information is available from the LICENSE file.
 //
 
-import Analytics
+@testable import Analytics
 import Foundation
 
 /// Analytics test context.
 public struct AnalyticsTest {
-    let additionalLabels: Analytics.Labels
+    let additionalLabels: [String: String]
 
-    init(additionalLabels: Analytics.Labels) {
+    init(additionalLabels: [String: String]) {
         self.additionalLabels = additionalLabels
         try? Analytics.shared.start(with: .init(vendor: .RTS, sourceKey: "source", site: "site"))
         URLSession.enableInterceptor()
@@ -22,8 +22,7 @@ public struct AnalyticsTest {
     ///   - title: The page title.
     ///   - levels: The page levels.
     ///   - labels: Labels associated with the event.
-    public func trackPageView(title: String, levels: [String] = [], labels: Analytics.Labels? = nil) {
-        let allLabels = labels?.merging(additionalLabels) ?? additionalLabels
-        Analytics.shared.trackPageView(title: title, levels: levels, labels: allLabels)
+    public func trackPageView(title: String, levels: [String] = []) {
+        Analytics.shared.trackPageView(title: title, levels: levels, labels: .init(comScore: additionalLabels, commandersAct: additionalLabels))
     }
 }

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -22,8 +22,8 @@ public struct AnalyticsTest {
     ///   - title: The page title.
     ///   - levels: The page levels.
     ///   - labels: Labels associated with the event.
-    public func trackPageView(title: String, levels: [String] = []) {
-        Analytics.shared.trackPageView(title: title, levels: levels, labels: .init(comScore: additionalLabels, commandersAct: additionalLabels))
+    public func sendPageView(title: String, levels: [String] = []) {
+        Analytics.shared.sendPageView(title: title, levels: levels, labels: .init(comScore: additionalLabels, commandersAct: additionalLabels))
     }
 
     /// Record an event.

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -37,7 +37,7 @@ public struct AnalyticsTest {
     ///   - extra3: The event extra3.
     ///   - extra4: The event extra4.
     ///   - extra5: The event extra5.
-    public func trackEvent(
+    public func sendEvent(
         name: String = "",
         type: String = "",
         value: String = "",
@@ -48,7 +48,7 @@ public struct AnalyticsTest {
         extra4: String = "",
         extra5: String = ""
     ) {
-        Analytics.shared.trackEvent(
+        Analytics.shared.sendEvent(
             name: name,
             type: type,
             value: value,

--- a/Sources/AnalyticsTestBridge/AnalyticsTest.swift
+++ b/Sources/AnalyticsTestBridge/AnalyticsTest.swift
@@ -32,11 +32,11 @@ public struct AnalyticsTest {
     ///   - type: The event type.
     ///   - value: The event value.
     ///   - source: The event source.
-    ///   - extra1: The event extra1.
-    ///   - extra2: The event extra2.
-    ///   - extra3: The event extra3.
-    ///   - extra4: The event extra4.
-    ///   - extra5: The event extra5.
+    ///   - extra1: Extra information associated with the event.
+    ///   - extra2: Extra information associated with the event.
+    ///   - extra3: Extra information associated with the event.
+    ///   - extra4: Extra information associated with the event.
+    ///   - extra5: Extra information associated with the event.
     public func sendEvent(
         name: String,
         type: String = "",

--- a/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
+++ b/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
@@ -66,7 +66,7 @@ public extension ComScoreTestCase {
         }
     }
 
-    /// Wait until the `didReceiveComScoreRequest` has been received.
+    /// Wait until a `didReceiveComScoreRequest` notification has been received as a result of executing some code.
     func wait(
         timeout: DispatchTimeInterval = .seconds(20),
         function: String = #function,
@@ -75,10 +75,8 @@ public extension ComScoreTestCase {
     ) {
         let id = Self.identifier(for: function)
         expectation(forNotification: .didReceiveComScoreRequest, object: nil) { notification in
-            guard let labels = notification.userInfo?[ComScoreRequestInfoKey.queryItems] as? [String: String] else {
-                return false
-            }
-            guard labels[Self.identifierKey] == id else {
+            guard let labels = notification.userInfo?[ComScoreRequestInfoKey.queryItems] as? [String: String],
+                       labels[Self.identifierKey] == id else {
                 return false
             }
             received(labels)

--- a/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
+++ b/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
@@ -17,8 +17,8 @@ open class ComScoreTestCase: XCTestCase {
         "\(self).\(function)-\(UUID().uuidString)"
     }
 
-    private static func additionalLabels(for id: String) -> Analytics.Labels {
-        .init(comScore: [identifierKey: id], commandersAct: [:])
+    private static func additionalLabels(for id: String) -> [String: String] {
+        [identifierKey: id]
     }
 
     private static func publisher(for id: String, key: String) -> AnyPublisher<String, Never> {

--- a/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
+++ b/Sources/AnalyticsTestBridge/ComScoreTestCase.swift
@@ -65,4 +65,26 @@ public extension ComScoreTestCase {
             executing?(AnalyticsTest(additionalLabels: Self.additionalLabels(for: id)))
         }
     }
+
+    /// Wait until the `didReceiveComScoreRequest` has been received.
+    func wait(
+        timeout: DispatchTimeInterval = .seconds(20),
+        function: String = #function,
+        while executing: (AnalyticsTest) -> Void,
+        received: @escaping ([String: String]) -> Void
+    ) {
+        let id = Self.identifier(for: function)
+        expectation(forNotification: .didReceiveComScoreRequest, object: nil) { notification in
+            guard let labels = notification.userInfo?[ComScoreRequestInfoKey.queryItems] as? [String: String] else {
+                return false
+            }
+            guard labels[Self.identifierKey] == id else {
+                return false
+            }
+            received(labels)
+            return true
+        }
+        executing(AnalyticsTest(additionalLabels: Self.additionalLabels(for: id)))
+        waitForExpectations(timeout: timeout.double())
+    }
 }

--- a/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
+++ b/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
@@ -74,7 +74,6 @@ public extension CommandersActTestCase {
 
     /// Ensure a publisher does not emit any value during some time interval.
     func expectNothingPublished(
-        values: [String],
         for key: String,
         during interval: DispatchTimeInterval = .seconds(20),
         file: StaticString = #file,

--- a/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
+++ b/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
@@ -18,8 +18,8 @@ open class CommandersActTestCase: XCTestCase {
         "\(self).\(function)-\(UUID().uuidString)"
     }
 
-    private static func additionalLabels(for id: String) -> Analytics.Labels {
-        .init(comScore: [:], commandersAct: [identifierKey: id])
+    private static func additionalLabels(for id: String) -> [String: String] {
+        [identifierKey: id]
     }
 
     private static func publisher(for id: String, key: String) -> AnyPublisher<String, Never> {

--- a/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
+++ b/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
@@ -71,4 +71,21 @@ public extension CommandersActTestCase {
             executing?(AnalyticsTest(additionalLabels: Self.additionalLabels(for: id)))
         }
     }
+
+    /// Ensure a publisher does not emit any value during some time interval.
+    func expectNothingPublished(
+        values: [String],
+        for key: String,
+        during interval: DispatchTimeInterval = .seconds(20),
+        file: StaticString = #file,
+        line: UInt = #line,
+        function: String = #function,
+        while executing: ((AnalyticsTest) -> Void)? = nil
+    ) {
+        let id = Self.identifier(for: function)
+        let publisher = Self.publisher(for: id, key: key)
+        expectNothingPublished(from: publisher, during: interval, file: file, line: line) {
+            executing?(AnalyticsTest(additionalLabels: Self.additionalLabels(for: id)))
+        }
+    }
 }

--- a/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
+++ b/Sources/AnalyticsTestBridge/CommandersActTestCase.swift
@@ -94,7 +94,7 @@ public extension CommandersActTestCase {
         }
     }
 
-    /// Wait until the `kTCNotification_HTTPRequest` has been received.
+    /// Wait until a `kTCNotification_HTTPRequest ` notification has been received as a result of executing some code.
     func wait(
         timeout: DispatchTimeInterval = .seconds(20),
         function: String = #function,

--- a/Sources/Circumspect/TimeInterval.swift
+++ b/Sources/Circumspect/TimeInterval.swift
@@ -6,7 +6,8 @@
 
 import Dispatch
 
-extension DispatchTimeInterval {
+public extension DispatchTimeInterval {
+    /// Transform the receiver into a double.
     func double() -> Double {
         switch self {
         case let .seconds(value):

--- a/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
+++ b/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
@@ -13,9 +13,9 @@ import Player
 /// Stream tracker for comScore.
 public final class ComScoreTracker: PlayerItemTracker {
     public struct Configuration {
-        let labels: Analytics.Labels?
+        let labels: [String: String]
 
-        public init(labels: Analytics.Labels? = nil) {
+        public init(labels: [String: String] = [:]) {
             self.labels = labels
         }
     }
@@ -33,12 +33,11 @@ public final class ComScoreTracker: PlayerItemTracker {
         streamingAnalytics.setMediaPlayerName("Pillarbox")
         streamingAnalytics.setMediaPlayerVersion(PackageInfo.version)
 
-        if let labels = configuration.labels?.comScore {
-            let metadata = SCORStreamingContentMetadata { builder in
-                builder!.setCustomLabels(labels)
-            }
-            streamingAnalytics.setMetadata(metadata)
+        let metadata = SCORStreamingContentMetadata { [weak self] builder in
+            guard let self else { return }
+            builder!.setCustomLabels(self.configuration.labels)
         }
+        streamingAnalytics.setMetadata(metadata)
         streamingAnalytics.notifyPlay()
     }
 

--- a/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
+++ b/Sources/CoreBusiness/Analytics/ComScoreTracker.swift
@@ -34,8 +34,8 @@ public final class ComScoreTracker: PlayerItemTracker {
         streamingAnalytics.setMediaPlayerVersion(PackageInfo.version)
 
         let metadata = SCORStreamingContentMetadata { [weak self] builder in
-            guard let self else { return }
-            builder!.setCustomLabels(self.configuration.labels)
+            guard let self, let builder else { return }
+            builder.setCustomLabels(self.configuration.labels)
         }
         streamingAnalytics.setMetadata(metadata)
         streamingAnalytics.notifyPlay()

--- a/Tests/AnalyticsTests/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScorePageViewTests.swift
@@ -12,13 +12,13 @@ import XCTest
 final class ComScorePageViewTests: ComScoreTestCase {
     func testTitle() {
         expectAtLeastEqual(values: ["title"], for: "ns_category") { test in
-            test.trackPageView(title: "title")
+            test.sendPageView(title: "title")
         }
     }
 
     func testBrand() {
         expectAtLeastEqual(values: ["RTS"], for: "mp_brand") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 }

--- a/Tests/AnalyticsTests/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScorePageViewTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class ComScorePageViewTests: ComScoreTestCase {
     func testTitle() {
-        expectAtLeastEqual(values: ["title"], for: "name") { test in
+        expectAtLeastEqual(values: ["title"], for: "ns_category") { test in
             test.trackPageView(title: "title")
         }
     }

--- a/Tests/AnalyticsTests/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScorePageViewTests.swift
@@ -15,4 +15,10 @@ final class ComScorePageViewTests: ComScoreTestCase {
             test.trackPageView(title: "title")
         }
     }
+
+    func testBrand() {
+        expectAtLeastEqual(values: ["RTS"], for: "mp_brand") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScorePageViewTests.swift
@@ -7,18 +7,20 @@
 @testable import Analytics
 
 import AnalyticsTestBridge
+import Nimble
 import XCTest
 
 final class ComScorePageViewTests: ComScoreTestCase {
-    func testTitle() {
-        expectAtLeastEqual(values: ["title"], for: "ns_category") { test in
+    func testLabels() {
+        wait { test in
             test.sendPageView(title: "title")
-        }
-    }
-
-    func testBrand() {
-        expectAtLeastEqual(values: ["RTS"], for: "mp_brand") { test in
-            test.sendPageView(title: "\(#function)")
+        } received: { labels in
+            expect(labels["c2"]).to(equal("6036016"))
+            expect(labels["ns_ap_an"]).to(equal("xctest"))
+            expect(labels["ns_category"]).to(equal("title"))
+            expect(labels["ns_st_mp"]).to(beNil())
+            expect(labels["mp_brand"]).to(equal("RTS"))
+            expect(labels["mp_v"]).notTo(beNil())
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -15,4 +15,10 @@ final class CommandersActEventTests: CommandersActTestCase {
             test.trackEvent(name: "my-event")
         }
     }
+
+    func testType() {
+        expectAtLeastEqual(values: ["my-event-type"], for: "event_type") { test in
+            test.trackEvent(type: "my-event-type")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -21,4 +21,10 @@ final class CommandersActEventTests: CommandersActTestCase {
             test.trackEvent(type: "my-event-type")
         }
     }
+
+    func testSource() {
+        expectAtLeastEqual(values: ["my-event-source"], for: "event_source") { test in
+            test.trackEvent(source: "my-event-source")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -12,49 +12,49 @@ import XCTest
 final class CommandersActEventTests: CommandersActTestCase {
     func testName() {
         expectAtLeastEqual(values: ["my-event"], for: "event_name") { test in
-            test.trackEvent(name: "my-event")
+            test.sendEvent(name: "my-event")
         }
     }
 
     func testType() {
         expectAtLeastEqual(values: ["my-event-type"], for: "event_type") { test in
-            test.trackEvent(type: "my-event-type")
+            test.sendEvent(type: "my-event-type")
         }
     }
 
     func testSource() {
         expectAtLeastEqual(values: ["my-event-source"], for: "event_source") { test in
-            test.trackEvent(source: "my-event-source")
+            test.sendEvent(source: "my-event-source")
         }
     }
 
     func testExtra1() {
         expectAtLeastEqual(values: ["my-event-extra1"], for: "event_value_1") { test in
-            test.trackEvent(extra1: "my-event-extra1")
+            test.sendEvent(extra1: "my-event-extra1")
         }
     }
 
     func testExtra2() {
         expectAtLeastEqual(values: ["my-event-extra2"], for: "event_value_2") { test in
-            test.trackEvent(extra2: "my-event-extra2")
+            test.sendEvent(extra2: "my-event-extra2")
         }
     }
 
     func testExtra3() {
         expectAtLeastEqual(values: ["my-event-extra3"], for: "event_value_3") { test in
-            test.trackEvent(extra3: "my-event-extra3")
+            test.sendEvent(extra3: "my-event-extra3")
         }
     }
 
     func testExtra4() {
         expectAtLeastEqual(values: ["my-event-extra4"], for: "event_value_4") { test in
-            test.trackEvent(extra4: "my-event-extra4")
+            test.sendEvent(extra4: "my-event-extra4")
         }
     }
 
     func testExtra5() {
         expectAtLeastEqual(values: ["my-event-extra5"], for: "event_value_5") { test in
-            test.trackEvent(extra5: "my-event-extra5")
+            test.sendEvent(extra5: "my-event-extra5")
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Analytics
+
+import AnalyticsTestBridge
+import XCTest
+
+final class CommandersActEventTests: CommandersActTestCase {
+    func testName() {
+        expectAtLeastEqual(values: ["my-event"], for: "event_name") { test in
+            test.trackEvent(name: "my-event")
+        }
+    }
+}

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -7,54 +7,33 @@
 @testable import Analytics
 
 import AnalyticsTestBridge
+import Nimble
 import XCTest
 
 final class CommandersActEventTests: CommandersActTestCase {
-    func testName() {
-        expectAtLeastEqual(values: ["my-event"], for: "event_name") { test in
-            test.sendEvent(name: "my-event")
-        }
-    }
-
-    func testType() {
-        expectAtLeastEqual(values: ["my-event-type"], for: "event_type") { test in
-            test.sendEvent(type: "my-event-type")
-        }
-    }
-
-    func testSource() {
-        expectAtLeastEqual(values: ["my-event-source"], for: "event_source") { test in
-            test.sendEvent(source: "my-event-source")
-        }
-    }
-
-    func testExtra1() {
-        expectAtLeastEqual(values: ["my-event-extra1"], for: "event_value_1") { test in
-            test.sendEvent(extra1: "my-event-extra1")
-        }
-    }
-
-    func testExtra2() {
-        expectAtLeastEqual(values: ["my-event-extra2"], for: "event_value_2") { test in
-            test.sendEvent(extra2: "my-event-extra2")
-        }
-    }
-
-    func testExtra3() {
-        expectAtLeastEqual(values: ["my-event-extra3"], for: "event_value_3") { test in
-            test.sendEvent(extra3: "my-event-extra3")
-        }
-    }
-
-    func testExtra4() {
-        expectAtLeastEqual(values: ["my-event-extra4"], for: "event_value_4") { test in
-            test.sendEvent(extra4: "my-event-extra4")
-        }
-    }
-
-    func testExtra5() {
-        expectAtLeastEqual(values: ["my-event-extra5"], for: "event_value_5") { test in
-            test.sendEvent(extra5: "my-event-extra5")
+    func testLabels() {
+        wait { test in
+            test.sendEvent(
+                name: "name",
+                type: "type",
+                value: "value",
+                source: "source",
+                extra1: "extra1",
+                extra2: "extra2",
+                extra3: "extra3",
+                extra4: "extra4",
+                extra5: "extra5"
+            )
+        } received: { labels in
+            expect(labels["event_name"] as? String).to(equal("name"))
+            expect(labels["event_type"] as? String).to(equal("type"))
+            expect(labels["event_value"] as? String).to(equal("value"))
+            expect(labels["event_source"] as? String).to(equal("source"))
+            expect(labels["event_value_1"] as? String).to(equal("extra1"))
+            expect(labels["event_value_2"] as? String).to(equal("extra2"))
+            expect(labels["event_value_3"] as? String).to(equal("extra3"))
+            expect(labels["event_value_4"] as? String).to(equal("extra4"))
+            expect(labels["event_value_5"] as? String).to(equal("extra5"))
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersActEventTests.swift
@@ -27,4 +27,34 @@ final class CommandersActEventTests: CommandersActTestCase {
             test.trackEvent(source: "my-event-source")
         }
     }
+
+    func testExtra1() {
+        expectAtLeastEqual(values: ["my-event-extra1"], for: "event_value_1") { test in
+            test.trackEvent(extra1: "my-event-extra1")
+        }
+    }
+
+    func testExtra2() {
+        expectAtLeastEqual(values: ["my-event-extra2"], for: "event_value_2") { test in
+            test.trackEvent(extra2: "my-event-extra2")
+        }
+    }
+
+    func testExtra3() {
+        expectAtLeastEqual(values: ["my-event-extra3"], for: "event_value_3") { test in
+            test.trackEvent(extra3: "my-event-extra3")
+        }
+    }
+
+    func testExtra4() {
+        expectAtLeastEqual(values: ["my-event-extra4"], for: "event_value_4") { test in
+            test.trackEvent(extra4: "my-event-extra4")
+        }
+    }
+
+    func testExtra5() {
+        expectAtLeastEqual(values: ["my-event-extra5"], for: "event_value_5") { test in
+            test.trackEvent(extra5: "my-event-extra5")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -47,26 +47,26 @@ final class CommandersActPageViewTests: CommandersActTestCase {
     }
 
     func testLevel0() {
-        expectNothingPublished(values: ["nothing"], for: "navigation_level_0") { test in
-            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        expectNothingPublished(for: "navigation_level_0", during: .seconds(3)) { test in
+            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel1() {
         expectAtLeastEqual(values: ["something_1"], for: "navigation_level_1") { test in
-            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel8() {
         expectAtLeastEqual(values: ["something_8"], for: "navigation_level_8") { test in
-            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel9() {
-        expectNothingPublished(values: ["nothing"], for: "navigation_level_9") { test in
-            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        expectNothingPublished(for: "navigation_level_9", during: .seconds(3)) { test in
+            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -33,4 +33,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testEventId() {
+        expectAtLeastEqual(values: ["screen"], for: "event_id") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -51,4 +51,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testVendor() {
+        expectAtLeastEqual(values: ["RTS"], for: "navigation_bu_distributer") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -7,66 +7,39 @@
 @testable import Analytics
 
 import AnalyticsTestBridge
+import Nimble
 import XCTest
 
 final class CommandersActPageViewTests: CommandersActTestCase {
-    func testTitle() {
-        expectAtLeastEqual(values: ["title"], for: "page_type") { test in
-            test.sendPageView(title: "title")
-        }
-    }
-
-    func testAppVersion() {
-        expectAtLeastEqual(values: [PackageInfo.version], for: "app_library_version") { test in
-            test.sendPageView(title: "\(#function)")
-        }
-    }
-
-    func testSite() {
-        expectAtLeastEqual(values: ["site"], for: "navigation_app_site_name") { test in
-            test.sendPageView(title: "\(#function)")
-        }
-    }
-
-    func testDevice() {
-        expectAtLeastEqual(values: [UIDevice.current.model], for: "navigation_device") { test in
-            test.sendPageView(title: "\(#function)")
-        }
-    }
-
-    func testNavigationPropertyType() {
-        expectAtLeastEqual(values: ["app"], for: "navigation_property_type") { test in
-            test.sendPageView(title: "\(#function)")
-        }
-    }
-
-    func testVendor() {
-        expectAtLeastEqual(values: ["RTS"], for: "navigation_bu_distributer") { test in
-            test.sendPageView(title: "\(#function)")
-        }
-    }
-
-    func testLevel0() {
-        expectNothingPublished(for: "navigation_level_0", during: .seconds(3)) { test in
-            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
-        }
-    }
-
-    func testLevel1() {
-        expectAtLeastEqual(values: ["something_1"], for: "navigation_level_1") { test in
-            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
-        }
-    }
-
-    func testLevel8() {
-        expectAtLeastEqual(values: ["something_8"], for: "navigation_level_8") { test in
-            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
-        }
-    }
-
-    func testLevel9() {
-        expectNothingPublished(for: "navigation_level_9", during: .seconds(3)) { test in
-            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
+    func testLabels() {
+        wait { test in
+            test.sendPageView(title: "title", levels: [
+                "level_1",
+                "level_2",
+                "level_3",
+                "level_4",
+                "level_5",
+                "level_6",
+                "level_7",
+                "level_8"
+            ])
+        } received: { labels in
+            expect(labels["page_type"] as? String).to(equal("title"))
+            expect(labels["navigation_level_0"]).to(beNil())
+            expect(labels["navigation_level_1"] as? String).to(equal("level_1"))
+            expect(labels["navigation_level_2"] as? String).to(equal("level_2"))
+            expect(labels["navigation_level_3"] as? String).to(equal("level_3"))
+            expect(labels["navigation_level_4"] as? String).to(equal("level_4"))
+            expect(labels["navigation_level_5"] as? String).to(equal("level_5"))
+            expect(labels["navigation_level_6"] as? String).to(equal("level_6"))
+            expect(labels["navigation_level_7"] as? String).to(equal("level_7"))
+            expect(labels["navigation_level_8"] as? String).to(equal("level_8"))
+            expect(labels["navigation_level_9"]).to(beNil())
+            expect(labels["navigation_device"]).notTo(beNil())
+            expect(labels["app_library_version"] as? String).to(equal(PackageInfo.version))
+            expect(labels["navigation_app_site_name"] as? String).to(equal("site"))
+            expect(labels["navigation_property_type"] as? String).to(equal("app"))
+            expect(labels["navigation_bu_distributer"] as? String).to(equal("RTS"))
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -27,4 +27,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testDevice() {
+        expectAtLeastEqual(values: [UIDevice.current.model], for: "navigation_device") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -35,7 +35,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             expect(labels["navigation_level_7"] as? String).to(equal("level_7"))
             expect(labels["navigation_level_8"] as? String).to(equal("level_8"))
             expect(labels["navigation_level_9"]).to(beNil())
-            expect(labels["navigation_device"]).notTo(beNil())
+            expect(["phone", "tablet", "tvbox", "phone"]).to(contain([labels["navigation_device"] as? String]))
             expect(labels["app_library_version"] as? String).to(equal(PackageInfo.version))
             expect(labels["navigation_app_site_name"] as? String).to(equal("site"))
             expect(labels["navigation_property_type"] as? String).to(equal("app"))

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -15,4 +15,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "title")
         }
     }
+
+    func testAppVersion() {
+        expectAtLeastEqual(values: [PackageInfo.version], for: "app_library_version") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -39,4 +39,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testNavigationPropertyType() {
+        expectAtLeastEqual(values: ["app"], for: "navigation_property_type") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -57,4 +57,28 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testLevel0() {
+        expectNothingPublished(values: ["nothing"], for: "navigation_level_0") { test in
+            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        }
+    }
+
+    func testLevel1() {
+        expectAtLeastEqual(values: ["something_1"], for: "navigation_level_1") { test in
+            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        }
+    }
+
+    func testLevel8() {
+        expectAtLeastEqual(values: ["something_8"], for: "navigation_level_8") { test in
+            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        }
+    }
+
+    func testLevel9() {
+        expectNothingPublished(values: ["nothing"], for: "navigation_level_9") { test in
+            test.trackPageView(title: "\(#function)", levels: [1, 2, 3, 4, 5, 6, 6, 8, 9, 10].map { "something_\($0)" })
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -45,4 +45,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testContentTitle() {
+        expectAtLeastEqual(values: ["\(#function)"], for: "content_title") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -12,61 +12,61 @@ import XCTest
 final class CommandersActPageViewTests: CommandersActTestCase {
     func testTitle() {
         expectAtLeastEqual(values: ["title"], for: "page_type") { test in
-            test.trackPageView(title: "title")
+            test.sendPageView(title: "title")
         }
     }
 
     func testAppVersion() {
         expectAtLeastEqual(values: [PackageInfo.version], for: "app_library_version") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 
     func testSite() {
         expectAtLeastEqual(values: ["site"], for: "navigation_app_site_name") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 
     func testDevice() {
         expectAtLeastEqual(values: [UIDevice.current.model], for: "navigation_device") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 
     func testNavigationPropertyType() {
         expectAtLeastEqual(values: ["app"], for: "navigation_property_type") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 
     func testVendor() {
         expectAtLeastEqual(values: ["RTS"], for: "navigation_bu_distributer") { test in
-            test.trackPageView(title: "\(#function)")
+            test.sendPageView(title: "\(#function)")
         }
     }
 
     func testLevel0() {
         expectNothingPublished(for: "navigation_level_0", during: .seconds(3)) { test in
-            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
+            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel1() {
         expectAtLeastEqual(values: ["something_1"], for: "navigation_level_1") { test in
-            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
+            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel8() {
         expectAtLeastEqual(values: ["something_8"], for: "navigation_level_8") { test in
-            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
+            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 
     func testLevel9() {
         expectNothingPublished(for: "navigation_level_9", during: .seconds(3)) { test in
-            test.trackPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
+            test.sendPageView(title: "\(#function)", levels: (1...10).map { "something_\($0)" })
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -21,4 +21,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             test.trackPageView(title: "\(#function)")
         }
     }
+
+    func testSite() {
+        expectAtLeastEqual(values: ["site"], for: "navigation_app_site_name") { test in
+            test.trackPageView(title: "\(#function)")
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersActPageViewTests.swift
@@ -34,20 +34,8 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         }
     }
 
-    func testEventId() {
-        expectAtLeastEqual(values: ["screen"], for: "event_id") { test in
-            test.trackPageView(title: "\(#function)")
-        }
-    }
-
     func testNavigationPropertyType() {
         expectAtLeastEqual(values: ["app"], for: "navigation_property_type") { test in
-            test.trackPageView(title: "\(#function)")
-        }
-    }
-
-    func testContentTitle() {
-        expectAtLeastEqual(values: ["\(#function)"], for: "content_title") { test in
             test.trackPageView(title: "\(#function)")
         }
     }


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to track page views and custom events.

## Changes made

- Tracking page view (`sendPageView(title: String, levels: [String] = [])`) and custom events (`sendEvent(name: String, type: String = "", value: String = "", source: String = "", extra1: String = "", extra2: String = "", extra3: String = "", extra4: String = "", extra5: String = "")`) is now possible.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
- [X] The playground has been updated (if relevant).
