### PR TITLE
Avoid ghost views

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -12,7 +12,7 @@ import ShowTime
 import SRGDataProvider
 import UIKit
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+final class AppDelegate: NSObject, UIApplicationDelegate {
     private var cancellables = Set<AnyCancellable>()
 
     // swiftlint:disable:next discouraged_optional_collection

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -28,6 +28,14 @@ public class Analytics {
         }
     }
 
+    /// Application states.
+    public enum ApplicationState {
+        /// Foreground and background.
+        case foregroundAndBackground
+        /// Foreground only.
+        case foreground
+    }
+
     /// The singleton instance.
     public static var shared = Analytics()
 
@@ -59,8 +67,12 @@ public class Analytics {
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
-    public func trackPageView(title: String, levels: [String] = []) {
+    ///   - state: The application states for which the page can be tracked. Defaults to `.foreground`. The
+    ///     `.foregroundAndBackground` option should only be used in the rare cases where page views must be recorded
+    ///     also while the application is in background, e.g. when tracking a CarPlay user interface.
+    public func trackPageView(title: String, levels: [String] = [], in state: ApplicationState = .foreground) {
         assert(!title.isBlank, "A title is required")
+        guard state == .foregroundAndBackground || UIApplication.shared.applicationState != .background else { return }
         comScoreService.trackPageView(title: title, levels: levels)
         commandersActService.trackPageView(title: title, levels: levels)
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR ensures page view analytics are never recorded when the application is in background, except in few cases where this might be required. To handle these exceptional cases an opt-in is provided. This opt-is is mostly useful for tracking view hierarchies displayed on an external screen, which is the case with CarPlay, most notably.

# Changes made

- Check application state before recording page views, prevented when the app is in background by default.
- Add opt-in to enable page views in background as well when needed.
- Update automatic tracking (note that automatic page views are reported before the application reaches the foreground so the opt-in has to be used in this case as well).

Meaningful tests are difficult to write in this case (since they would rely on the application state) and were therefore omitted.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
