### PR TITLE
Add muted playback support

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -127,12 +127,16 @@ private struct ControlsView: View {
     var body: some View {
         ZStack {
             Color(white: 0, opacity: 0.3)
+
             HStack(spacing: 30) {
                 SkipBackwardButton(player: player, progressTracker: progressTracker)
                 PlaybackButton(player: player)
                 SkipForwardButton(player: player, progressTracker: progressTracker)
             }
             .debugBodyCounter(color: .green)
+
+            VolumeButton(player: player)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
         .animation(.defaultLinear, value: player.playbackState)
         .bind(progressTracker, to: player)
@@ -272,6 +276,27 @@ private struct FullScreenButton: View {
         default:
             break
         }
+    }
+}
+
+// Behavior: h-hug, v-hug
+private struct VolumeButton: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        Button(action: toggleMuted) {
+            Image(systemName: imageName)
+                .tint(.white)
+        }
+        .frame(width: 45, height: 45)
+    }
+
+    private var imageName: String {
+        player.isMuted ? "speaker.slash.fill" : "speaker.wave.3.fill"
+    }
+
+    private func toggleMuted() {
+        player.isMuted.toggle()
     }
 }
 

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -102,32 +102,32 @@ public struct CommandersActLabels: Decodable {
 
     /// Value of `media_volume`.
     public var media_volume: Int? {
-        guard let _media_volume else { return nil }
-        return Int(_media_volume)
+        extract(\._media_volume)
     }
 
     /// Value of `media_position`.
     public var media_position: Int? {
-        guard let _media_position else { return nil }
-        return Int(_media_position)
+        extract(\._media_position)
     }
 
     /// Value of `media_timeshift`.
     public var media_timeshift: Int? {
-        guard let _media_timeshift else { return nil }
-        return Int(_media_timeshift)
+        extract(\._media_timeshift)
     }
 
     /// Value of `media_playback_rate`.
     public var media_playback_rate: Float? {
-        guard let _media_playback_rate else { return nil }
-        return Float(_media_playback_rate)
+        extract(\._media_playback_rate)
     }
 
     /// Value of `media_bandwidth`.
     public var media_bandwidth: Double? {
-        guard let _media_bandwidth else { return nil }
-        return Double(_media_bandwidth)
+        extract(\._media_bandwidth)
+    }
+
+    private func extract<T: LosslessStringConvertible>(_ keyPath: KeyPath<Self, String?>) -> T? {
+        guard let value = self[keyPath: keyPath] else { return nil }
+        return .init(value)
     }
 }
 

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -8,10 +8,11 @@ import Foundation
 
 /// Labels associated with a Commanders Act event.
 public struct CommandersActLabels: Decodable {
+    private let _media_bandwidth: String?
+    private let _media_playback_rate: String?
     private let _media_position: String?
     private let _media_timeshift: String?
-    private let _media_playback_rate: String?
-    private let _media_bandwidth: String?
+    private let _media_volume: String?
 
     let event_name: String?
     let listener_session_id: String?
@@ -100,7 +101,10 @@ public struct CommandersActLabels: Decodable {
     public let media_player_version: String?
 
     /// Value of `media_volume`.
-    public let media_volume: String?
+    public var media_volume: Int? {
+        guard let _media_volume else { return nil }
+        return Int(_media_volume)
+    }
 
     /// Value of `media_position`.
     public var media_position: Int? {
@@ -159,10 +163,10 @@ private extension CommandersActLabels {
         case event_value_5
         case media_player_display
         case media_player_version
-        case media_volume
+        case _media_bandwidth = "media_bandwidth"
         case _media_playback_rate = "media_playback_rate"
         case _media_position = "media_position"
         case _media_timeshift = "media_timeshift"
-        case _media_bandwidth = "media_bandwidth"
+        case _media_volume = "media_volume"
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -100,9 +100,14 @@ public struct CommandersActLabels: Decodable {
     /// Value of `media_player_version`.
     public let media_player_version: String?
 
-    /// Value of `media_volume`.
-    public var media_volume: Int? {
-        extract(\._media_volume)
+    /// Value of `media_bandwidth`.
+    public var media_bandwidth: Double? {
+        extract(\._media_bandwidth)
+    }
+
+    /// Value of `media_playback_rate`.
+    public var media_playback_rate: Float? {
+        extract(\._media_playback_rate)
     }
 
     /// Value of `media_position`.
@@ -115,14 +120,9 @@ public struct CommandersActLabels: Decodable {
         extract(\._media_timeshift)
     }
 
-    /// Value of `media_playback_rate`.
-    public var media_playback_rate: Float? {
-        extract(\._media_playback_rate)
-    }
-
-    /// Value of `media_bandwidth`.
-    public var media_bandwidth: Double? {
-        extract(\._media_bandwidth)
+    /// Value of `media_volume`.
+    public var media_volume: Int? {
+        extract(\._media_volume)
     }
 
     private func extract<T: LosslessStringConvertible>(_ keyPath: KeyPath<Self, String?>) -> T? {

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -74,8 +74,8 @@ public final class CommandersActTracker: PlayerItemTracker {
 }
 
 private extension CommandersActTracker {
-    private var volume: Float {
-        AVAudioSession.sharedInstance().outputVolume * 100
+    private var volume: Int {
+        Int(AVAudioSession.sharedInstance().outputVolume * 100)
     }
 
     private func bitrate(for player: Player) -> Int {

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -74,8 +74,9 @@ public final class CommandersActTracker: PlayerItemTracker {
 }
 
 private extension CommandersActTracker {
-    private var volume: Int {
-        Int(AVAudioSession.sharedInstance().outputVolume * 100)
+    private func volume(for player: Player) -> Int {
+        guard !player.isMuted else { return 0 }
+        return Int(AVAudioSession.sharedInstance().outputVolume * 100)
     }
 
     private func bitrate(for player: Player) -> Int {
@@ -87,7 +88,7 @@ private extension CommandersActTracker {
         metadata.labels.merging([
             "media_player_display": "Pillarbox",
             "media_player_version": PackageInfo.version,
-            "media_volume": "\(volume)",
+            "media_volume": "\(volume(for: player))",
             "media_playback_rate": "1",
             "media_bandwidth": "\(bitrate(for: player))"
         ]) { _, new in new }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -37,6 +37,13 @@ public final class Player: ObservableObject, Equatable {
     /// Set whether trackers are enabled or not.
     @Published public var isTrackingEnabled = true
 
+    /// Set whether the audio output of the player is muted.
+    @Published public var isMuted = true {
+        didSet {
+            queuePlayer.isMuted = isMuted
+        }
+    }
+
     @Published private var currentTracker: CurrentTracker?
     @Published private var currentItem: CurrentItem = .good(nil)
     @Published private var storedItems: Deque<PlayerItem>
@@ -65,16 +72,6 @@ public final class Player: ObservableObject, Equatable {
     /// Returns whether the player is currently busy (buffering or seeking).
     public var isBusy: Bool {
         isBuffering || isSeeking
-    }
-
-    /// A Boolean value that indicates whether the audio output of the player is muted.
-    public var isMuted: Bool {
-        get {
-            queuePlayer.isMuted
-        }
-        set {
-            queuePlayer.isMuted = newValue
-        }
     }
 
     /// The low-level system player. Exposed for specific read-only needs like interfacing with `AVPlayer`-based
@@ -126,6 +123,7 @@ public final class Player: ObservableObject, Equatable {
         configureQueueUpdatePublisher()
         configureExternalPlaybackPublisher()
         configurePresentationSizePublisher()
+        configureMutedPublisher()
 
         configurePlayer()
     }
@@ -789,6 +787,12 @@ extension Player {
         queuePlayer.presentationSizePublisher()
             .receiveOnMainThread()
             .assign(to: &$presentationSize)
+    }
+
+    private func configureMutedPublisher() {
+        queuePlayer.publisher(for: \.isMuted)
+            .receiveOnMainThread()
+            .assign(to: &$isMuted)
     }
 
     private func itemUpdatePublisher() -> AnyPublisher<ItemUpdate, Never> {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -67,6 +67,16 @@ public final class Player: ObservableObject, Equatable {
         isBuffering || isSeeking
     }
 
+    /// A Boolean value that indicates whether the audio output of the player is muted.
+    public var isMuted: Bool {
+        get {
+            queuePlayer.isMuted
+        }
+        set {
+            queuePlayer.isMuted = newValue
+        }
+    }
+
     /// The low-level system player. Exposed for specific read-only needs like interfacing with `AVPlayer`-based
     /// 3rd party APIs. Mutating the state of this player directly is not supported and leads to undefined behavior.
     public var systemPlayer: AVPlayer {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -833,29 +833,29 @@ extension Player {
     }
 }
 
-extension Player {
-    private func playRegistration() -> some RemoteCommandRegistrable {
+private extension Player {
+    func playRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.playCommand) { [weak self] _ in
             self?.play()
             return .success
         }
     }
 
-    private func pauseRegistration() -> some RemoteCommandRegistrable {
+    func pauseRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.pauseCommand) { [weak self] _ in
             self?.pause()
             return .success
         }
     }
 
-    private func togglePlayPauseRegistration() -> some RemoteCommandRegistrable {
+    func togglePlayPauseRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.togglePlayPauseCommand) { [weak self] _ in
             self?.togglePlayPause()
             return .success
         }
     }
 
-    private func previousTrackRegistration() -> some RemoteCommandRegistrable {
+    func previousTrackRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = false
         return nowPlayingSession.remoteCommandCenter.register(command: \.previousTrackCommand) { [weak self] _ in
             self?.returnToPrevious()
@@ -863,7 +863,7 @@ extension Player {
         }
     }
 
-    private func nextTrackRegistration() -> some RemoteCommandRegistrable {
+    func nextTrackRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = false
         return nowPlayingSession.remoteCommandCenter.register(command: \.nextTrackCommand) { [weak self] _ in
             self?.advanceToNext()
@@ -871,7 +871,7 @@ extension Player {
         }
     }
 
-    private func changePlaybackPositionRegistration() -> some RemoteCommandRegistrable {
+    func changePlaybackPositionRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.changePlaybackPositionCommand) { [weak self] event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
             self?.seek(near(.init(seconds: positionEvent.positionTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC))))
@@ -879,7 +879,7 @@ extension Player {
         }
     }
 
-    private func skipBackwardRegistration() -> some RemoteCommandRegistrable {
+    func skipBackwardRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = false
         nowPlayingSession.remoteCommandCenter.skipBackwardCommand.preferredIntervals = [.init(value: configuration.backwardSkipInterval)]
         return nowPlayingSession.remoteCommandCenter.register(command: \.skipBackwardCommand) { [weak self] _ in
@@ -888,7 +888,7 @@ extension Player {
         }
     }
 
-    private func skipForwardRegistration() -> some RemoteCommandRegistrable {
+    func skipForwardRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = false
         nowPlayingSession.remoteCommandCenter.skipForwardCommand.preferredIntervals = [.init(value: configuration.forwardSkipInterval)]
         return nowPlayingSession.remoteCommandCenter.register(command: \.skipForwardCommand) { [weak self] _ in
@@ -897,7 +897,7 @@ extension Player {
         }
     }
 
-    private func installRemoteCommands() {
+    func installRemoteCommands() {
         commandRegistrations = [
             playRegistration(),
             pauseRegistration(),
@@ -910,14 +910,14 @@ extension Player {
         ]
     }
 
-    private func uninstallRemoteCommands() {
+    func uninstallRemoteCommands() {
         commandRegistrations.forEach { registration in
             nowPlayingSession.remoteCommandCenter.unregister(registration)
         }
         commandRegistrations = []
     }
 
-    private func updateControlCenter(nowPlayingInfo: NowPlaying.Info) {
+    func updateControlCenter(nowPlayingInfo: NowPlaying.Info) {
         if !nowPlayingInfo.isEmpty {
             if nowPlayingSession.nowPlayingInfoCenter.nowPlayingInfo == nil {
                 uninstallRemoteCommands()

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -65,4 +65,25 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             player = nil
         }
     }
+
+    func testMuted() {
+        var player: Player?
+        expectAtLeastEvents(
+            .play { labels in
+                expect(labels.media_volume).to(equal(0))
+            }
+        ) {
+             player = Player(item: .simple(
+                url: Stream.shortOnDemand.url,
+                metadata: AssetMetadataMock(),
+                trackerAdapters: [
+                    CommandersActTracker.adapter { _ in
+                        .test(streamType: .onDemand)
+                    }
+                ]
+            ))
+            player?.isMuted = true
+            player?.play()
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -19,7 +19,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             .play { labels in
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
-                expect(labels.media_volume).notTo(beEmpty())
+                expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_playback_rate).to(equal(1))
                 expect(labels.media_bandwidth).to(equal(0))
                 expect(labels.media_title).to(equal("title"))
@@ -56,7 +56,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             .stop { labels in
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
-                expect(labels.media_volume).notTo(beEmpty())
+                expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_playback_rate).to(equal(1))
                 expect(labels.media_bandwidth).to(equal(0))
                 expect(labels.media_title).to(equal("title"))

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -13,22 +13,10 @@ import Streams
 private struct AssetMetadataMock: AssetMetadata {}
 
 final class CommandersActTrackerMetadataTests: CommandersActTestCase {
-    func testPause() {
-        let player = Player(item: .simple(
-            url: Stream.shortOnDemand.url,
-            metadata: AssetMetadataMock(),
-            trackerAdapters: [
-                CommandersActTracker.adapter { _ in
-                    .test(streamType: .onDemand)
-                }
-            ]
-        ))
-
-        player.play()
-        expect(player.playbackState).toEventually(equal(.playing))
-
+    func testWhenInitialized() {
+        var player: Player?
         expectAtLeastEvents(
-            .pause { labels in
+            .play { labels in
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beEmpty())
@@ -37,11 +25,20 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_title).to(equal("title"))
             }
         ) {
-            player.pause()
+             player = Player(item: .simple(
+                url: Stream.shortOnDemand.url,
+                metadata: AssetMetadataMock(),
+                trackerAdapters: [
+                    CommandersActTracker.adapter { _ in
+                        .test(streamType: .onDemand)
+                    }
+                ]
+            ))
+            player?.play()
         }
     }
 
-    func testStopWhenDestroyed() {
+    func testWhenDestroyed() {
         var player: Player? = Player(item: .simple(
             url: Stream.shortOnDemand.url,
             metadata: AssetMetadataMock(),


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds a property to mute the player.

# Changes made

- Add `isMuted` published property.
- Update analytics.
- Update demo custom player.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
