### PR TITLE
Support iPad applications run on Silicon Macs

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -661,6 +661,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					MediaPlayer,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -684,6 +688,10 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					MediaPlayer,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
@@ -762,6 +770,10 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					MediaPlayer,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -701,6 +701,7 @@ extension Player {
     }
 
     private func configureControlCenterPublishers() {
+        guard NSClassFromString("MediaPlayer") != nil else { return }
         configureControlCenterPublisher()
         configureControlCenterCommandAvailabilityPublisher()
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -701,7 +701,7 @@ extension Player {
     }
 
     private func configureControlCenterPublishers() {
-        guard NSClassFromString("MediaPlayer") != nil else { return }
+        guard !ProcessInfo.processInfo.isiOSAppOnMac else { return }
         configureControlCenterPublisher()
         configureControlCenterCommandAvailabilityPublisher()
     }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -69,3 +69,11 @@ The media type can be `.unknown` if an AirPlay session was established before pl
 ### Workaround
 
 No workaround is available yet.
+
+## Audio duration is zero in Mac applications "Designed for iPad"
+
+Pillarbox can be used in iPad applications run on Silicon Macs (_Designed for iPad_ destination) but audios played will have a reported duration of zero. As a result progress reported by `ProgressTracker` also remains stuck at zero.
+
+### Workaround
+
+No workaround is available yet.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,10 @@ If you want to contribute to the project have a look at our [contributing guide]
 
 The library can be integrated using [Swift Package Manager](https://swift.org/package-manager) directly [within Xcode](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). You can also declare the library as a dependency of another one directly in the associated `Package.swift` manifest.
 
-When building a project integrating Pillarbox for the first time, Xcode might ask you to trust our plugins. You should accept.
+A few remarks:
+
+- When building a project integrating Pillarbox for the first time, Xcode might ask you to trust our plugins. You should accept.
+- If you want your application to run on Mac Catalyst you must add `-weak_framework MediaPlayer` to your target _Other Linker Flags_ setting.
 
 # Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ The library can be integrated using [Swift Package Manager](https://swift.org/pa
 A few remarks:
 
 - When building a project integrating Pillarbox for the first time, Xcode might ask you to trust our plugins. You should accept.
-- If you want your application to run on Mac Catalyst you must add `-weak_framework MediaPlayer` to your target _Other Linker Flags_ setting.
+- If you want your application to run on Silicon Macs as an iPad application you must add `-weak_framework MediaPlayer` to your target _Other Linker Flags_ setting.
 
 # Getting started
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR restores Mac Silicon compatibility for Pillarbox.

# Changes made

- Update integration documentation.
- Weak link `MediaPlayer.framework` in the demo.
- Avoid control center API usage when run on Mac Silicon as iPad application.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
