### PR TITLE
Update Swiftlint to version 0.52.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,9 +31,11 @@ disabled_rules:
   - no_magic_numbers
   - nslocalizedstring_require_bundle
   - required_deinit
+  - sorted_enum_cases
   - statement_position
   - strict_fileprivate
   - strong_iboutlet
+  - superfluous_else
   - todo
   - vertical_whitespace_between_cases
   - yoda_condition
@@ -55,6 +57,7 @@ opt_in_rules:
   - contains_over_first_not_nil
   - contains_over_range_nil_comparison
   - convenience_type
+  - direct_return
   - discarded_notification_center_observer
   - discouraged_assert
   - discouraged_object_literal
@@ -122,6 +125,7 @@ opt_in_rules:
   - raw_value_for_camel_cased_codable_enum
   - reduce_into
   - redundant_nil_coalescing
+  - redundant_self_in_closure
   - redundant_type_annotation
   - required_enum_case
   - return_value_from_void_function
@@ -139,6 +143,7 @@ opt_in_rules:
   - type_body_length
   - type_contents_order
   - unavailable_function
+  - unhandled_throwing_task
   - unneeded_parentheses_in_closure_argument
   - unowned_variable_capture
   - untyped_error_in_catch
@@ -153,6 +158,9 @@ analyzer_rules:
   - typesafe_array_init
   - unused_declaration
   - unused_import
+
+attributes:
+  always_on_same_line: ["@Environment"]
 
 cyclomatic_complexity:
   warning: 5

--- a/Demo/Sources/Examples/ExamplesViewModel.swift
+++ b/Demo/Sources/Examples/ExamplesViewModel.swift
@@ -119,7 +119,7 @@ final class ExamplesViewModel: ObservableObject {
 
     func refresh() async {
         Task {
-            try await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .seconds(1))
             trigger.activate(for: TriggerId.reload)
         }
     }

--- a/Demo/Sources/Lists/ContentListViewModel.swift
+++ b/Demo/Sources/Lists/ContentListViewModel.swift
@@ -257,7 +257,7 @@ final class ContentListViewModel: ObservableObject, Refreshable {
 
     func refresh() async {
         Task {
-            try await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .seconds(1))
             trigger.activate(for: TriggerId.reload)
         }
     }

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -201,7 +201,7 @@ struct Template: Hashable {
         self.type = type
     }
 
-    static func medias(from templates: [Template]) -> [Media] {
+    static func medias(from templates: [Self]) -> [Media] {
         templates.map { Media(from: $0) }
     }
 }

--- a/Demo/Sources/Search/SearchViewModel.swift
+++ b/Demo/Sources/Search/SearchViewModel.swift
@@ -86,7 +86,7 @@ final class SearchViewModel: ObservableObject, Refreshable {
 
     func refresh() async {
         Task {
-            try await Task.sleep(for: .seconds(1))
+            try? await Task.sleep(for: .seconds(1))
             trigger.activate(for: TriggerId.reload)
         }
     }

--- a/Sources/CoreBusiness/Model/StreamingMethod.swift
+++ b/Sources/CoreBusiness/Model/StreamingMethod.swift
@@ -36,7 +36,7 @@ public enum StreamingMethod: String, Decodable {
     case unknown = "UNKNOWN"
 
     /// Supported streaming methods on Apple platforms.
-    public static var supportedMethods: [StreamingMethod] {
+    public static var supportedMethods: [Self] {
         [.progressive, .m3uPlaylist, .hls, .http, .https]
     }
 }

--- a/Sources/Player/CurrentTracker.swift
+++ b/Sources/Player/CurrentTracker.swift
@@ -20,13 +20,13 @@ final class CurrentTracker {
     private func configureTrackingPublisher(player: Player) {
         player.$isTrackingEnabled
             .sink { [weak self, weak player] enabled in
-                guard let self, let player, self.isEnabled != enabled else { return }
-                self.isEnabled = enabled
+                guard let self, let player, isEnabled != enabled else { return }
+                isEnabled = enabled
                 if enabled {
-                    self.enableAsset(for: player)
+                    enableAsset(for: player)
                 }
                 else {
-                    self.disableAsset()
+                    disableAsset()
                 }
             }
             .store(in: &cancellables)

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -79,7 +79,7 @@ class QueuePlayer: AVQueuePlayer {
 
         enqueue(seek: seek) { [weak self] in
             guard let self else { return }
-            self.notifySeekEnd()
+            notifySeekEnd()
         }
     }
 

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -22,7 +22,7 @@ struct Seek: Equatable {
 
     private let id = UUID()
 
-    static func == (lhs: Seek, rhs: Seek) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
 }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -742,10 +742,10 @@ extension Player {
             .sink { [weak self] items, index, streamType in
                 guard let self else { return }
                 let areSkipsEnabled = items.count <= 1 && streamType != .live
-                self.nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled
-                self.nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled
-                self.nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = self.canReturn(before: index, in: items, streamType: streamType)
-                self.nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = Self.canAdvanceToItem(after: index, in: items)
+                nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled
+                nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled
+                nowPlayingSession.remoteCommandCenter.previousTrackCommand.isEnabled = canReturn(before: index, in: items, streamType: streamType)
+                nowPlayingSession.remoteCommandCenter.nextTrackCommand.isEnabled = Self.canAdvanceToItem(after: index, in: items)
             }
             .store(in: &cancellables)
     }

--- a/Sources/Player/Types/ItemState.swift
+++ b/Sources/Player/Types/ItemState.swift
@@ -42,7 +42,7 @@ enum ItemState: Equatable {
         }
     }
 
-    static func == (lhs: ItemState, rhs: ItemState) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.unknown, .unknown), (.readyToPlay, .readyToPlay), (.ended, .ended):
             return true

--- a/Sources/Player/Types/PlaybackState.swift
+++ b/Sources/Player/Types/PlaybackState.swift
@@ -19,7 +19,7 @@ public enum PlaybackState: Equatable {
     /// The player encountered an error.
     case failed(error: Error)
 
-    static func state(for itemState: ItemState, rate: Float) -> PlaybackState {
+    static func state(for itemState: ItemState, rate: Float) -> Self {
         switch itemState {
         case .readyToPlay:
             return (rate == 0) ? .paused : .playing
@@ -32,7 +32,7 @@ public enum PlaybackState: Equatable {
         }
     }
 
-    public static func == (lhs: PlaybackState, rhs: PlaybackState) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.idle, .idle), (.playing, .playing), (.paused, .paused), (.ended, .ended):
             return true

--- a/Tests/AnalyticsTests/ComScore/ComScoreEventExpectation.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreEventExpectation.swift
@@ -12,7 +12,7 @@ struct ComScoreEventExpectation {
     private let name: ComScoreEvent.Name
     private let evaluate: (ComScoreLabels) -> Void
 
-    static func match(event: ComScoreEvent, with expectation: ComScoreEventExpectation) -> Bool {
+    static func match(event: ComScoreEvent, with expectation: Self) -> Bool {
         guard event.name == expectation.name else { return false }
         expectation.evaluate(event.labels)
         return true

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventExpectation.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventExpectation.swift
@@ -12,7 +12,7 @@ struct CommandersActEventExpectation {
     private let name: CommandersActEvent.Name
     private let evaluate: (CommandersActLabels) -> Void
 
-    static func match(event: CommandersActEvent, with expectation: CommandersActEventExpectation) -> Bool {
+    static func match(event: CommandersActEvent, with expectation: Self) -> Bool {
         guard event.name == expectation.name else { return false }
         expectation.evaluate(event.labels)
         return true

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -22,7 +22,6 @@ class TestCase: XCTestCase {
     }
 
     override func setUp() {
-        super.setUp()
         waitUntil { done in
             AnalyticsListener.start(completion: done)
         }

--- a/Tests/CircumspectTests/Tools.swift
+++ b/Tests/CircumspectTests/Tools.swift
@@ -12,7 +12,7 @@ struct StructError: Error {}
 struct NamedPerson: Similar {
     let name: String
 
-    static func ~~ (lhs: NamedPerson, rhs: NamedPerson) -> Bool {
+    static func ~~ (lhs: Self, rhs: Self) -> Bool {
         lhs.name.localizedCaseInsensitiveContains(rhs.name)
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR updates Swiftlint to version 0.52.0. This version most notably introduces syntax improvements introduced in Swift 5.8 like implicit self in closures.

To merge this PR it is likely that CI servers must be updated first. Other existing PRs should likely be merged first for simplicity.

# Changes made

- Update linter rules.
- Update code.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
