### PR TITLE
Fix incorrectly inhibited taps on tracked views

### DIFF
--- a/Sources/Analytics/UserInterface/View.swift
+++ b/Sources/Analytics/UserInterface/View.swift
@@ -42,6 +42,7 @@ public extension View {
     func tracked(title: String, levels: [String] = []) -> some View {
         background {
             PageTrackingView(title: title, levels: levels)
+                .allowsHitTesting(false)
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes hit testing issues on tracked views, introduced with #358. This issue is easy to observe in the playlist demo, where previous and next buttons do not work well in recent nightlies.

# Changes made

- Disable hit testing on tracker views.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
