### PR TITLE
Fix incorrect volume button position in safe area

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -83,6 +83,7 @@ private struct MainView: View {
     private func volumeButton() -> some View {
         VolumeButton(player: player)
             .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
+            .preventsTouchPropagation()
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -28,6 +28,7 @@ private struct MainView: View {
             ZStack {
                 main()
                 timeBar()
+                volumeButton()
             }
             .animation(.defaultLinear, value: player.isBusy)
             .animation(.defaultLinear, value: isUserInterfaceHidden)
@@ -79,6 +80,13 @@ private struct MainView: View {
     }
 
     @ViewBuilder
+    private func volumeButton() -> some View {
+        VolumeButton(player: player)
+            .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+    }
+
+    @ViewBuilder
     private func video() -> some View {
         switch player.mediaType {
         case .audio:
@@ -127,16 +135,12 @@ private struct ControlsView: View {
     var body: some View {
         ZStack {
             Color(white: 0, opacity: 0.3)
-
             HStack(spacing: 30) {
                 SkipBackwardButton(player: player, progressTracker: progressTracker)
                 PlaybackButton(player: player)
                 SkipForwardButton(player: player, progressTracker: progressTracker)
             }
             ._debugBodyCounter(color: .green)
-
-            VolumeButton(player: player)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
         .animation(.defaultLinear, value: player.playbackState)
         .bind(progressTracker, to: player)

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -82,12 +82,12 @@ public extension View {
     /// - Parameters:
     ///   - visibilityTracker: The visibility tracker to bind.
     ///   - player: The player to observe.
-    func bind(_ visibility: VisibilityTracker, to player: Player?) -> some View {
+    func bind(_ visibilityTracker: VisibilityTracker, to player: Player?) -> some View {
         onAppear {
-            visibility.player = player
+            visibilityTracker.player = player
         }
         .onChange(of: player) { newValue in
-            visibility.player = newValue
+            visibilityTracker.player = newValue
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes volume button alignment in the safe area, easy to observe in nightly 267 as follows:

1. Open some content with the demo custom player on a modern iPhone (notch or dynamic island).
2. Rotate the device to landscape orientation.

# Changes made

- Fix button alignment.
- Make sure user interactions do not conflict with existing gesture recognizers.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
