### PR TITLE
Enable body counter debugging in Xcode previews

### DIFF
--- a/Sources/Core/BodyCounter.swift
+++ b/Sources/Core/BodyCounter.swift
@@ -67,9 +67,17 @@ private class _BodyCounterView: UIView {
 }
 
 public extension View {
+    private var isDebuggingEnabled: Bool {
+        ProcessInfo.processInfo.environment["PILLARBOX_DEBUG_BODY_COUNTER"] != nil
+    }
+
+    private var isRunningInXcodePreviews: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
+    }
+
     @ViewBuilder
     private func debugBodyCounterOverlay(color: UIColor) -> some View {
-        if ProcessInfo.processInfo.environment["PILLARBOX_DEBUG_BODY_COUNTER"] != nil {
+        if isDebuggingEnabled || isRunningInXcodePreviews {
             BodyCounterView(color: color)
                 .allowsHitTesting(false)
         }
@@ -79,7 +87,7 @@ public extension View {
     /// body has been evaluated.
     ///
     /// This feature is only available in debug builds and requires the application to be run with the
-    /// `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set.
+    /// `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set. It is also automatically enabled in Xcode previews.
     ///
     /// - Parameters:
     ///   - color: The frame and label color.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -190,7 +190,7 @@ struct PlayerView: View {
 
 By having the `ProgressTracker` stored in a nested view you ensure that only this part of the view hierarchy gets updated every 1/10th of a second. The main `PlayerView` itself is namely still only updated when the player state changes. This way you can avoid triggering frequent large view updates unnecessarily, which makes it possible to implement layouts in an energy-efficient way. Of course several progress trackers can be used should you want to have different parts of your user interface be updated at different rates.
 
-To make it easier to spot where user interface updates can be optimized our `Core` package provides a `_debugBodyCounter(color:)` modifier which surrounds any view you want to observe with a counter, showing how many times its body has been evaluated. This way you can observe how your layout behaves and visually detects where parts of your user interface could benefit from local progress tracking. This feature is only available in debug builds and requires the application to be run with the `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set.
+To make it easier to spot where user interface updates can be optimized our `Core` package provides a `_debugBodyCounter(color:)` modifier which surrounds any view you want to observe with a counter, showing how many times its body has been evaluated. This way you can observe how your layout behaves and visually detects where parts of your user interface could benefit from local progress tracking. This feature is only available in debug builds and requires the application to be run with the `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set. It is also automatically enabled in Xcode previews.
 
 ## Contextual layout management (iOS)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR enables body counter debugging in Xcode previews so that layouts can be optimized directly at design time.

# Changes made

- Check `XCODE_RUNNING_FOR_PREVIEWS` to enable body counter debugging.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
