### PR TITLE
Avoid conflicts with SwiftUI environment attribute

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		6F59E87B29CF31E10093E6FB /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84329CF31E10093E6FB /* DemoApp.swift */; };
 		6F59E87C29CF31E10093E6FB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84429CF31E10093E6FB /* AppDelegate.swift */; };
 		6F59E87D29CF31E10093E6FB /* Vendor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84629CF31E10093E6FB /* Vendor.swift */; };
-		6F59E87E29CF31E10093E6FB /* ServiceUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84729CF31E10093E6FB /* ServiceUrl.swift */; };
+		6F59E87E29CF31E10093E6FB /* ServerSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84729CF31E10093E6FB /* ServerSetting.swift */; };
 		6F59E87F29CF31E10093E6FB /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84829CF31E10093E6FB /* Template.swift */; };
 		6F59E88029CF31E10093E6FB /* RadioChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84929CF31E10093E6FB /* RadioChannel.swift */; };
 		6F59E88129CF31E10093E6FB /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84A29CF31E10093E6FB /* Playlist.swift */; };
@@ -78,7 +78,7 @@
 		6F59E84329CF31E10093E6FB /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		6F59E84429CF31E10093E6FB /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6F59E84629CF31E10093E6FB /* Vendor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vendor.swift; sourceTree = "<group>"; };
-		6F59E84729CF31E10093E6FB /* ServiceUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceUrl.swift; sourceTree = "<group>"; };
+		6F59E84729CF31E10093E6FB /* ServerSetting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerSetting.swift; sourceTree = "<group>"; };
 		6F59E84829CF31E10093E6FB /* Template.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
 		6F59E84929CF31E10093E6FB /* RadioChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadioChannel.swift; sourceTree = "<group>"; };
 		6F59E84A29CF31E10093E6FB /* Playlist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
@@ -224,7 +224,7 @@
 				6F59E84C29CF31E10093E6FB /* MediaDescription.swift */,
 				6F59E84A29CF31E10093E6FB /* Playlist.swift */,
 				6F59E84929CF31E10093E6FB /* RadioChannel.swift */,
-				6F59E84729CF31E10093E6FB /* ServiceUrl.swift */,
+				6F59E84729CF31E10093E6FB /* ServerSetting.swift */,
 				6F59E84829CF31E10093E6FB /* Template.swift */,
 				6F59E84629CF31E10093E6FB /* Vendor.swift */,
 			);
@@ -497,7 +497,7 @@
 				6F59E88129CF31E10093E6FB /* Playlist.swift in Sources */,
 				6F59E87D29CF31E10093E6FB /* Vendor.swift in Sources */,
 				6F59E88229CF31E10093E6FB /* Media.swift in Sources */,
-				6F59E87E29CF31E10093E6FB /* ServiceUrl.swift in Sources */,
+				6F59E87E29CF31E10093E6FB /* ServerSetting.swift in Sources */,
 				6F59E89E29CF31E20093E6FB /* PlayerView.swift in Sources */,
 				6F59E87929CF31E10093E6FB /* SearchView.swift in Sources */,
 				6F59E88029CF31E10093E6FB /* RadioChannel.swift in Sources */,

--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -35,10 +35,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     private func configureDataProvider() {
-        UserDefaults.standard.publisher(for: \.serviceUrl)
+        UserDefaults.standard.publisher(for: \.serverSetting)
             .receiveOnMainThread()
-            .sink { serviceUrl in
-                SRGDataProvider.current = SRGDataProvider(serviceURL: serviceUrl.url)
+            .sink { serverSetting in
+                SRGDataProvider.current = SRGDataProvider(serviceURL: serverSetting.url)
             }
             .store(in: &cancellables)
     }

--- a/Demo/Sources/Lists/ListsView.swift
+++ b/Demo/Sources/Lists/ListsView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 
 // Behavior: h-exp, v-exp
 struct ListsView: View {
-    @AppStorage(UserDefaults.serviceUrlKey)
-    private var serviceUrl: ServiceUrl = .production
+    @AppStorage(UserDefaults.serverSettingKey)
+    private var selectedServerSetting: ServerSetting = .production
 
     var body: some View {
         List {
@@ -25,7 +25,7 @@ struct ListsView: View {
             Self.radioShows(image: "waveform")
             Self.latestAudiosSection(image: "music.note.list")
         }
-        .navigationTitle("Lists (\(serviceUrl.title))")
+        .navigationTitle("Lists (\(selectedServerSetting.title))")
         .tracked(title: "lists")
         .toolbarTitleMenu {
             titlesMenu()
@@ -102,13 +102,13 @@ struct ListsView: View {
 
     @ViewBuilder
     private func titlesMenu() -> some View {
-        ForEach(ServiceUrl.allCases, id: \.self) { service in
+        ForEach(ServerSetting.allCases, id: \.self) { service in
             Button {
-                serviceUrl = service
+                selectedServerSetting = service
             } label: {
                 HStack {
                     Text(service.title)
-                    if serviceUrl == service {
+                    if selectedServerSetting == service {
                         Image(systemName: "checkmark")
                     }
                 }

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -7,7 +7,7 @@
 import SRGDataProvider
 
 @objc
-enum ServiceUrl: Int, CaseIterable {
+enum ServerSetting: Int, CaseIterable {
     case production
     case staging
     case test

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -28,7 +28,7 @@ extension UserDefaults {
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
     static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
-    static let serviceUrlKey = "serviceUrl"
+    static let serverSettingKey = "serverSetting"
 
     @objc dynamic var presenterModeEnabled: Bool {
         bool(forKey: Self.presenterModeEnabledKey)
@@ -64,8 +64,8 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicyKey)) ?? .automatic
     }
 
-    @objc dynamic var serviceUrl: ServiceUrl {
-        .init(rawValue: integer(forKey: Self.serviceUrlKey)) ?? .production
+    @objc dynamic var serverSetting: ServerSetting {
+        .init(rawValue: integer(forKey: Self.serverSettingKey)) ?? .production
     }
 
     func registerDefaults() {
@@ -75,7 +75,7 @@ extension UserDefaults {
             Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
             Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue,
-            Self.serviceUrlKey: ServiceUrl.production.rawValue
+            Self.serverSettingKey: ServerSetting.production.rawValue
         ])
     }
 }

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -17,11 +17,11 @@ final class DataProvider {
         case width1920 = 1920
     }
 
-    let environment: Environment
+    let server: Server
     private let session: URLSession
 
-    init(environment: Environment = .production) {
-        self.environment = environment
+    init(server: Server = .production) {
+        self.server = server
         session = URLSession(configuration: .ephemeral)
     }
 
@@ -40,7 +40,7 @@ final class DataProvider {
     }
 
     func mediaCompositionUrl(for urn: String) -> URL {
-        let url = environment.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
+        let url = server.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
         components.queryItems = [
             URLQueryItem(name: "onlyChapters", value: "true")
@@ -72,7 +72,7 @@ final class DataProvider {
 
     private func scaledImageUrl(_ url: URL, width: ImageWidth) -> URL {
         guard var components = URLComponents(
-            url: environment.url.appending(path: "images/"),
+            url: server.url.appending(path: "images/"),
             resolvingAgainstBaseURL: false
         ) else {
             return url

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -6,8 +6,8 @@
 
 import Foundation
 
-/// Environment.
-public enum Environment {
+/// Server.
+public enum Server {
     /// Production.
     case production
     /// State.

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -11,16 +11,16 @@ import Player
 import UIKit
 
 public extension PlayerItem {
-    /// Create a player item from a URN played in the specified environment.
+    /// Create a player item from a URN.
     /// - Parameters:
     ///   - urn: The URN to play.
-    ///   - environment: The environment which the URN is played from.
+    ///   - server: The server which the URN is played from.
     static func urn(
         _ urn: String,
-        environment: Environment = .production,
+        server: Server = .production,
         trackerAdapters: [TrackerAdapter<MediaMetadata>] = []
     ) -> Self {
-        let dataProvider = DataProvider(environment: environment)
+        let dataProvider = DataProvider(server: server)
         let publisher = dataProvider.playableMediaCompositionPublisher(forUrn: urn)
             .tryMap { mediaComposition in
                 let mainChapter = mediaComposition.mainChapter

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -12,7 +12,7 @@ No workaround is available yet.
 
 ## DRM-protected streams do not play in the simulator
 
-DRM-protected streams do not play in the simulator. This is expected behavior as the required hardware features are not available in the simulator environment.
+DRM-protected streams do not play in the simulator. This is expected behavior as the required hardware features are not available in the simulator.
 
 ### Workaround
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes name conflicts with the SwiftUI `@Environment` attribute when both `CoreBusiness` as well as `SwiftUI` are included from the same file.

# Changes made

- Rename `Environment` as `Server`.
- Update the corresponding demo setting accordingly.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
