### PR TITLE
Update analytics based on the current playback speed

### DIFF
--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -95,4 +95,9 @@ public extension ComScoreLabels {
         guard let value: Double = extract() else { return nil }
         return value / 1000
     }
+
+    /// Value of `ns_st_rt` (playback rate).
+    var ns_st_rt: Int? {
+        extract()
+    }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -89,7 +89,7 @@ private extension CommandersActTracker {
             "media_player_display": "Pillarbox",
             "media_player_version": PackageInfo.version,
             "media_volume": "\(volume(for: player))",
-            "media_playback_rate": "1",
+            "media_playback_rate": "\(player.effectivePlaybackSpeed)",
             "media_bandwidth": "\(bitrate(for: player))"
         ]) { _, new in new }
     }

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerDvrPropertiesTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerDvrPropertiesTests.swift
@@ -6,7 +6,6 @@
 
 @testable import Analytics
 
-import ComScore
 import CoreMedia
 import Nimble
 import Player

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerMetadataTests.swift
@@ -6,7 +6,6 @@
 
 @testable import Analytics
 
-import ComScore
 import CoreMedia
 import Nimble
 import Player

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerPlaybackSpeedTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerPlaybackSpeedTests.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Analytics
+
+import CoreMedia
+import Nimble
+import Player
+import Streams
+import XCTest
+
+private struct AssetMetadataMock: AssetMetadata {}
+
+final class ComScoreTrackerPlaybackSpeedTests: ComScoreTestCase {
+    func testRateAtStart() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+        player.setDesiredPlaybackSpeed(0.5)
+
+        expectAtLeastEvents(
+            .play { labels in
+                expect(labels.ns_st_rt).to(equal(50))
+            }
+        ) {
+            player.play()
+        }
+    }
+}

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerSeekTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerSeekTests.swift
@@ -6,7 +6,6 @@
 
 @testable import Analytics
 
-import ComScore
 import CoreMedia
 import Nimble
 import Player

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -6,7 +6,6 @@
 
 @testable import Analytics
 
-import ComScore
 import CoreMedia
 import Nimble
 import Player

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -20,7 +20,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
-                expect(labels.media_playback_rate).to(equal(1))
+                expect(labels.media_playback_rate).to(equal(0.5))
                 expect(labels.media_bandwidth).to(equal(0))
                 expect(labels.media_title).to(equal("title"))
             }
@@ -34,6 +34,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                     }
                 ]
             ))
+            player?.setDesiredPlaybackSpeed(0.5)
             player?.play()
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds playback speed information to standard analytics trackers.

# Changes made

- Add speed information to comScore events. Test coverage is partial as rate change events escape our event listeners.
- Add speed information to CommandersAct events.

# Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] The playground has been updated (if relevant).
