### PR TITLE
Fix compilation with Xcode 15

### DIFF
--- a/Demo/Sources/Players/BasicPlaybackView.swift
+++ b/Demo/Sources/Players/BasicPlaybackView.swift
@@ -8,8 +8,8 @@ import CoreMedia
 import Player
 import SwiftUI
 
+#if os(iOS)
 // Behavior: h-exp, v-hug
-@available(tvOS, unavailable)
 private struct TimeSlider: View {
     @ObservedObject var player: Player
     @StateObject var progressTracker = ProgressTracker(
@@ -23,6 +23,7 @@ private struct TimeSlider: View {
             ._debugBodyCounter()
     }
 }
+#endif
 
 /// A playback view with basic controls. Requires an ancestor view to own the player to be used.
 /// Behavior: h-exp, v-exp

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -9,8 +9,9 @@ import CoreMedia
 import Player
 import SwiftUI
 
+#if os(iOS)
+
 // Behavior: h-exp, v-exp
-@available(tvOS, unavailable)
 private struct MainView: View {
     @ObservedObject var player: Player
     @Binding var layout: PlaybackView.Layout
@@ -128,6 +129,8 @@ private struct MainView: View {
             .padding(60)
     }
 }
+
+#endif
 
 private struct ControlsView: View {
     @ObservedObject var player: Player
@@ -337,8 +340,9 @@ private struct LiveLabel: View {
     }
 }
 
+#if os(iOS)
+
 // Behavior: h-exp, v-hug
-@available(tvOS, unavailable)
 private struct TimeBar: View {
     @ObservedObject var player: Player
     @Binding var layout: PlaybackView.Layout
@@ -376,7 +380,6 @@ private struct TimeBar: View {
 }
 
 // Behavior: h-exp, v-hug
-@available(tvOS, unavailable)
 private struct TimeSlider: View {
     private static let shortFormatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
@@ -451,6 +454,8 @@ private struct TimeSlider: View {
         }
     }
 }
+
+#endif
 
 /// A playback view with standard controls. Requires an ancestor view to own the player to be used.
 /// Behavior: h-exp, v-exp

--- a/Demo/Sources/Players/PlayerLayout.swift
+++ b/Demo/Sources/Players/PlayerLayout.swift
@@ -6,9 +6,10 @@
 
 import Foundation
 
+#if os(iOS)
 @objc
-@available(tvOS, unavailable)
 enum PlayerLayout: Int {
     case custom
     case system
 }
+#endif

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -12,9 +12,10 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.presenterModeEnabledKey)
     private var isPresenterModeEnabled = false
 
-    @available(tvOS, unavailable)
+#if os(iOS)
     @AppStorage(UserDefaults.playerLayoutKey)
     private var playerLayout: PlayerLayout = .custom
+#endif
 
     @AppStorage(UserDefaults.allowsExternalPlaybackKey)
     private var allowsExternalPlayback = true
@@ -72,7 +73,7 @@ struct SettingsView: View {
         }
     }
 
-    @available(tvOS, unavailable)
+#if os(iOS)
     @ViewBuilder
     private func playerLayoutPicker() -> some View {
         Picker("Layout", selection: $playerLayout) {
@@ -80,6 +81,7 @@ struct SettingsView: View {
             Text("System").tag(PlayerLayout.system)
         }
     }
+#endif
 
     @ViewBuilder
     private func seekBehaviorPicker() -> some View {

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -21,8 +21,9 @@ enum SeekBehaviorSetting: Int {
 extension UserDefaults {
     static let presenterModeEnabledKey = "presenterModeEnabled"
 
-    @available(tvOS, unavailable)
+#if os(iOS)
     static let playerLayoutKey = "playerLayout"
+#endif
 
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
@@ -34,10 +35,11 @@ extension UserDefaults {
         bool(forKey: Self.presenterModeEnabledKey)
     }
 
-    @available(tvOS, unavailable)
+#if os(iOS)
     @objc dynamic var playerLayout: PlayerLayout {
         .init(rawValue: integer(forKey: Self.playerLayoutKey)) ?? .custom
     }
+#endif
 
     @objc dynamic var allowsExternalPlaybackEnabled: Bool {
         bool(forKey: Self.allowsExternalPlaybackKey)

--- a/Demo/Sources/Showcase/TrackingView.swift
+++ b/Demo/Sources/Showcase/TrackingView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct TrackingView: View {
     let media: Media
-    @StateObject var player = Player(configuration: .standard)
+    @StateObject private var player = Player(configuration: .standard)
 
     var body: some View {
         VStack {

--- a/Demo/Sources/Views/CopyButton.swift
+++ b/Demo/Sources/Views/CopyButton.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-@available(tvOS, unavailable)
+#if os(iOS)
 struct CopyButton: View {
     let text: String
 
@@ -19,3 +19,4 @@ struct CopyButton: View {
         .tint(.accentColor)
     }
 }
+#endif

--- a/Demo/Sources/Views/SettingsMenu.swift
+++ b/Demo/Sources/Views/SettingsMenu.swift
@@ -8,7 +8,8 @@ import Core
 import Player
 import SwiftUI
 
-@available(tvOS, unavailable)
+#if os(iOS)
+
 private struct PlaybackSpeedMenu: View {
     private static let speeds: Set<Float> = [0.5, 1, 1.25, 1.5, 2]
 
@@ -44,7 +45,6 @@ private struct PlaybackSpeedMenu: View {
     }
 }
 
-@available(tvOS, unavailable)
 struct SettingsMenu: View {
     @ObservedObject var player: Player
 
@@ -59,10 +59,11 @@ struct SettingsMenu: View {
     }
 }
 
-@available(tvOS, unavailable)
 struct SettingsMenu_Previews: PreviewProvider {
     static var previews: some View {
         SettingsMenu(player: Player())
             .background(.black)
     }
 }
+
+#endif

--- a/Sources/Circumspect/Similarity.swift
+++ b/Sources/Circumspect/Similarity.swift
@@ -16,12 +16,12 @@ public protocol Similar {
 }
 
 /// Nimble matcher displaying similarity differences in a friendly way.
-public func equalDiff<T: Similar>(_ expectedValue: T?) -> Predicate<T> {
+public func equalDiff<T: Similar>(_ expectedValue: T?) -> Nimble.Predicate<T> {
     equalDiff(expectedValue, by: ~~)
 }
 
 /// Nimble matcher displaying mismatches as differences.
-public func equal<T: Similar>(_ expectedValue: T?) -> Predicate<T> {
+public func equal<T: Similar>(_ expectedValue: T?) -> Nimble.Predicate<T> {
     equal(expectedValue, by: ~~)
 }
 

--- a/Tests/CoreBusinessTests/MediaMetadataTests.swift
+++ b/Tests/CoreBusinessTests/MediaMetadataTests.swift
@@ -32,7 +32,7 @@ final class MediaMetadataTests: XCTestCase {
             resource: mediaComposition.mainChapter.recommendedResource!,
             image: nil
         )
-        expect(metadata.title).to(equal("February 6, 2023"))
+        expect(metadata.title).to(contain("February"))
         expect(metadata.subtitle).to(equal("19h30"))
         expect(metadata.description).to(beNil())
     }

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -11,7 +11,7 @@ import Nimble
 import Streams
 import XCTest
 
-@available(tvOS, unavailable)
+#if os(iOS)
 final class VisibilityTrackerTests: TestCase {
     func testInitiallyVisible() {
         let visibilityTracker = VisibilityTracker()
@@ -134,3 +134,4 @@ final class VisibilityTrackerTests: TestCase {
         expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(400))
     }
 }
+#endif


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes a few compilation issues so that the project can compile with Xcode 15.

# Changes made

- Fix type ambiguity between `Predicate` from Nimble and the new one introduced by SwiftUI.
- Fix issue with the `Menu` available in tvOS 17 and unavailability macros. For consistency, and since the editor now better shows code disable because of the preprocessor, all code outside library targets has been updated to use preprocessor instead of unavailability macros.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
