### PR TITLE
Support multiple player instances

### DIFF
--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -141,6 +141,10 @@ enum URNTemplate {
         title: "Vertical video",
         type: .urn("urn:rts:video:13444390")
     )
+    static let onDemandVideo = Template(
+        title: "A bon entendeur",
+        type: .urn("urn:rts:video:14080915")
+    )
     static let liveVideo = Template(
         title: "RSI 1",
         description: "Live video",

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -485,7 +485,10 @@ struct PlaybackView: View {
             }
         }
         .background(.black)
-        .onAppear(perform: player.play)
+        .onAppear {
+            player.becomeActiveIfPossible()
+            player.play()
+        }
     }
 
     init(player: Player, layout: Binding<Layout> = .constant(.inline)) {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -466,8 +466,8 @@ struct PlaybackView: View {
         case maximized
     }
 
-    @ObservedObject var player: Player
-    @Binding var layout: Layout
+    @ObservedObject private var player: Player
+    @Binding private var layout: Layout
 
     var body: some View {
         ZStack {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -486,7 +486,7 @@ struct PlaybackView: View {
         }
         .background(.black)
         .onAppear {
-            player.becomeActiveIfPossible()
+            player.becomeActive()
             player.play()
         }
     }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -20,16 +20,19 @@ private struct SingleView: View {
 
     var body: some View {
         ZStack {
-            VideoView(player: player)
-                .accessibilityAddTraits(.isButton)
-                .onTapGesture(perform: action)
+            videoView(player: player)
             playbackButton(player: player)
             routePickerView(player: player)
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
             ProgressView()
                 .opacity(player.isBusy ? 1 : 0)
         }
+    }
+
+    @ViewBuilder
+    private func videoView(player: Player) -> some View {
+        VideoView(player: player)
+            .accessibilityAddTraits(.isButton)
+            .onTapGesture(perform: action)
     }
 
     @ViewBuilder
@@ -50,6 +53,8 @@ private struct SingleView: View {
             RoutePickerView()
                 .tint(.white)
                 .frame(width: 45, height: 45)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
     }
 }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -8,6 +8,11 @@ import Analytics
 import Player
 import SwiftUI
 
+private enum ActivePlayer {
+    case top
+    case bottom
+}
+
 // Behavior: h-exp, v-exp
 struct MultiView: View {
     let media1: Media
@@ -15,12 +20,23 @@ struct MultiView: View {
 
     @StateObject private var topPlayer = Player(configuration: .externalPlaybackDisabled)
     @StateObject private var bottomPlayer = Player(configuration: .externalPlaybackDisabled)
+    @State private var activePlayer = ActivePlayer.top
 
     var body: some View {
         VStack(spacing: 10) {
             Group {
                 BasicPlaybackView(player: topPlayer)
+                    .accessibilityAddTraits(.isButton)
+                    .onTapGesture {
+                        activePlayer = .top
+                    }
+                    .saturation(activePlayer == .top ? 1 : 0)
                 BasicPlaybackView(player: bottomPlayer)
+                    .accessibilityAddTraits(.isButton)
+                    .onTapGesture {
+                        activePlayer = .bottom
+                    }
+                    .saturation(activePlayer == .bottom ? 1 : 0)
             }
             .background(.black)
         }
@@ -40,8 +56,8 @@ struct MultiView: View {
 struct MultiView_Previews: PreviewProvider {
     static var previews: some View {
         MultiView(
-            media1: Media(from: URLTemplate.appleBasic_16_9_TS_HLS),
-            media2: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS)
+            media1: Media(from: URNTemplate.onDemandHorizontalVideo),
+            media2: Media(from: URNTemplate.onDemandVerticalVideo)
         )
     }
 }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -61,9 +61,11 @@ struct MultiView: View {
         case .top:
             topPlayer.isMuted = false
             bottomPlayer.isMuted = true
+            topPlayer.becomeActiveIfPossible()
         case .bottom:
             topPlayer.isMuted = true
             bottomPlayer.isMuted = false
+            bottomPlayer.becomeActiveIfPossible()
         }
     }
 }
@@ -72,7 +74,7 @@ struct MultiView_Previews: PreviewProvider {
     static var previews: some View {
         MultiView(
             media1: Media(from: URNTemplate.onDemandHorizontalVideo),
-            media2: Media(from: URNTemplate.onDemandVerticalVideo)
+            media2: Media(from: URNTemplate.onDemandVideo)
         )
     }
 }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -44,6 +44,7 @@ private struct SingleView: View {
                 .frame(width: 50)
                 .tint(.white)
                 .shadow(radius: 5)
+                .opacity(player.isBusy ? 0 : 1)
         }
     }
 

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -87,6 +87,14 @@ struct MultiView: View {
         player.play()
     }
 
+    private static func make(activePlayer: Player, inactivePlayer: Player) {
+        activePlayer.becomeActiveIfPossible()
+        activePlayer.isTrackingEnabled = true
+        activePlayer.isMuted = false
+        inactivePlayer.isMuted = true
+        inactivePlayer.isTrackingEnabled = false
+    }
+
     @ViewBuilder
     private func playerView(player: Player, position: PlayerPosition) -> some View {
         SingleView(player: player) { activePosition = position }
@@ -97,13 +105,9 @@ struct MultiView: View {
     private func setActive(position: PlayerPosition) {
         switch position {
         case .top:
-            topPlayer.isMuted = false
-            bottomPlayer.isMuted = true
-            topPlayer.becomeActiveIfPossible()
+            Self.make(activePlayer: topPlayer, inactivePlayer: bottomPlayer)
         case .bottom:
-            topPlayer.isMuted = true
-            bottomPlayer.isMuted = false
-            bottomPlayer.becomeActiveIfPossible()
+            Self.make(activePlayer: bottomPlayer, inactivePlayer: topPlayer)
         }
     }
 }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -23,11 +23,24 @@ private struct SingleView: View {
             VideoView(player: player)
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture(perform: action)
+            playbackButton(player: player)
             routePickerView(player: player)
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
             ProgressView()
                 .opacity(player.isBusy ? 1 : 0)
+        }
+    }
+
+    @ViewBuilder
+    private func playbackButton(player: Player) -> some View {
+        Button(action: player.togglePlayPause) {
+            Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 50)
+                .tint(.white)
+                .shadow(radius: 5)
         }
     }
 

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -13,13 +13,41 @@ private enum PlayerPosition {
     case bottom
 }
 
+/// Behavior: h-exp, v-exp
+private struct SingleView: View {
+    @ObservedObject var player: Player
+    let action: () -> Void
+
+    var body: some View {
+        ZStack {
+            VideoView(player: player)
+                .accessibilityAddTraits(.isButton)
+                .onTapGesture(perform: action)
+            routePickerView(player: player)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            ProgressView()
+                .opacity(player.isBusy ? 1 : 0)
+        }
+    }
+
+    @ViewBuilder
+    private func routePickerView(player: Player) -> some View {
+        if player.configuration.allowsExternalPlayback {
+            RoutePickerView()
+                .tint(.white)
+                .frame(width: 45, height: 45)
+        }
+    }
+}
+
 // Behavior: h-exp, v-exp
 struct MultiView: View {
     let media1: Media
     let media2: Media
 
-    @StateObject private var topPlayer = Player(configuration: .externalPlaybackDisabled)
-    @StateObject private var bottomPlayer = Player(configuration: .externalPlaybackDisabled)
+    @StateObject private var topPlayer = Player()
+    @StateObject private var bottomPlayer = Player()
     @State private var activePosition: PlayerPosition = .top
 
     var body: some View {
@@ -48,11 +76,8 @@ struct MultiView: View {
 
     @ViewBuilder
     private func playerView(player: Player, position: PlayerPosition) -> some View {
-        BasicPlaybackView(player: player)
+        SingleView(player: player) { activePosition = position }
             .accessibilityAddTraits(.isButton)
-            .onTapGesture {
-                activePosition = position
-            }
             .saturation(activePosition == position ? 1 : 0)
     }
 

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -8,7 +8,7 @@ import Analytics
 import Player
 import SwiftUI
 
-private enum ActivePlayer {
+private enum PlayerPosition {
     case top
     case bottom
 }
@@ -20,23 +20,13 @@ struct MultiView: View {
 
     @StateObject private var topPlayer = Player(configuration: .externalPlaybackDisabled)
     @StateObject private var bottomPlayer = Player(configuration: .externalPlaybackDisabled)
-    @State private var activePlayer = ActivePlayer.top
+    @State private var activePosition: PlayerPosition = .top
 
     var body: some View {
         VStack(spacing: 10) {
             Group {
-                BasicPlaybackView(player: topPlayer)
-                    .accessibilityAddTraits(.isButton)
-                    .onTapGesture {
-                        activePlayer = .top
-                    }
-                    .saturation(activePlayer == .top ? 1 : 0)
-                BasicPlaybackView(player: bottomPlayer)
-                    .accessibilityAddTraits(.isButton)
-                    .onTapGesture {
-                        activePlayer = .bottom
-                    }
-                    .saturation(activePlayer == .bottom ? 1 : 0)
+                playerView(player: topPlayer, position: .top)
+                playerView(player: bottomPlayer, position: .bottom)
             }
             .background(.black)
         }
@@ -50,6 +40,16 @@ struct MultiView: View {
     private static func play(media: Media, in player: Player) {
         player.append(media.playerItem())
         player.play()
+    }
+
+    @ViewBuilder
+    private func playerView(player: Player, position: PlayerPosition) -> some View {
+        BasicPlaybackView(player: player)
+            .accessibilityAddTraits(.isButton)
+            .onTapGesture {
+                activePosition = position
+            }
+            .saturation(activePosition == position ? 1 : 0)
     }
 }
 

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -97,8 +97,9 @@ struct MultiView: View {
         activePlayer.becomeActive()
         activePlayer.isTrackingEnabled = true
         activePlayer.isMuted = false
-        inactivePlayer.isMuted = true
+
         inactivePlayer.isTrackingEnabled = false
+        inactivePlayer.isMuted = true
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -88,7 +88,7 @@ struct MultiView: View {
     }
 
     private static func make(activePlayer: Player, inactivePlayer: Player) {
-        activePlayer.becomeActiveIfPossible()
+        activePlayer.becomeActive()
         activePlayer.isTrackingEnabled = true
         activePlayer.isMuted = false
         inactivePlayer.isMuted = true

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -30,9 +30,13 @@ struct MultiView: View {
             }
             .background(.black)
         }
+        .onChange(of: activePosition) { position in
+            setActive(position: position)
+        }
         .onAppear {
             Self.play(media: media1, in: topPlayer)
             Self.play(media: media2, in: bottomPlayer)
+            setActive(position: activePosition)
         }
         .tracked(title: "multi")
     }
@@ -50,6 +54,17 @@ struct MultiView: View {
                 activePosition = position
             }
             .saturation(activePosition == position ? 1 : 0)
+    }
+
+    private func setActive(position: PlayerPosition) {
+        switch position {
+        case .top:
+            topPlayer.isMuted = false
+            bottomPlayer.isMuted = true
+        case .bottom:
+            topPlayer.isMuted = true
+            bottomPlayer.isMuted = false
+        }
     }
 }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -99,8 +99,8 @@ struct ShowcaseView: View {
             }
             Cell(title: "Multi") {
                 MultiView(
-                    media1: Media(from: URLTemplate.appleBasic_16_9_TS_HLS),
-                    media2: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS)
+                    media1: Media(from: URNTemplate.onDemandHorizontalVideo),
+                    media2: Media(from: URNTemplate.onDemandVerticalVideo)
                 )
             }
             Cell(title: "Link") {

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -100,7 +100,7 @@ struct ShowcaseView: View {
             Cell(title: "Multi") {
                 MultiView(
                     media1: Media(from: URNTemplate.onDemandHorizontalVideo),
-                    media2: Media(from: URNTemplate.onDemandVerticalVideo)
+                    media2: Media(from: URNTemplate.onDemandVideo)
                 )
             }
             Cell(title: "Link") {

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -7,6 +7,13 @@
 import Combine
 import MediaPlayer
 
+public extension Player {
+    /// Make the player the current active one.
+    func becomeActiveIfPossible() {
+        nowPlayingSession.becomeActiveIfPossible()
+    }
+}
+
 extension Player {
     func updateControlCenter(nowPlayingInfo: NowPlaying.Info) {
         if !nowPlayingInfo.isEmpty {

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -8,9 +8,15 @@ import Combine
 import MediaPlayer
 
 public extension Player {
+    private static weak var currentPlayer: Player?
+
     /// Make the player the current active one.
     func becomeActiveIfPossible() {
         nowPlayingSession.becomeActiveIfPossible()
+
+        Self.currentPlayer?.queuePlayer.allowsExternalPlayback = false
+        queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
+        Self.currentPlayer = self
     }
 }
 

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -7,19 +7,6 @@
 import Combine
 import MediaPlayer
 
-public extension Player {
-    private static weak var currentPlayer: Player?
-
-    /// Make the player the current active one.
-    func becomeActiveIfPossible() {
-        nowPlayingSession.becomeActiveIfPossible()
-
-        Self.currentPlayer?.queuePlayer.allowsExternalPlayback = false
-        queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
-        Self.currentPlayer = self
-    }
-}
-
 extension Player {
     func updateControlCenter(nowPlayingInfo: NowPlaying.Info) {
         if !nowPlayingInfo.isEmpty {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -145,7 +145,7 @@ public final class Player: ObservableObject, Equatable {
 
     /// Enable AirPlay and Control Center integration for the receiver, making the player the current active one. At most
     /// one player can be active at any time.
-    public func becomeActiveIfPossible() {
+    public func becomeActive() {
         Self.currentPlayer?.isActive = false
         isActive = true
         Self.currentPlayer = self

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -143,7 +143,8 @@ public final class Player: ObservableObject, Equatable {
         lhs === rhs
     }
 
-    /// Make the player the current active one.
+    /// Enable AirPlay and Control Center integration for the receiver, making the player the current active one. At most
+    /// one player can be active at any time.
     public func becomeActiveIfPossible() {
         Self.currentPlayer?.isActive = false
         isActive = true

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -107,11 +107,11 @@ public final class Player: ObservableObject, Equatable {
         storedItems = Deque(items)
 
         nowPlayingSession = MPNowPlayingSession(players: [queuePlayer])
-        nowPlayingSession.becomeActiveIfPossible()
 
         self.configuration = configuration
 
         configurePlayer()
+        becomeActiveIfPossible()
 
         configureControlCenterPublishers()
         configureQueuePlayerUpdatePublishers()
@@ -131,7 +131,7 @@ public final class Player: ObservableObject, Equatable {
     }
 
     private func configurePlayer() {
-        queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
+        queuePlayer.allowsExternalPlayback = false
         queuePlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring
         queuePlayer.preventsDisplaySleepDuringVideoPlayback = configuration.preventsDisplaySleepDuringVideoPlayback
         queuePlayer.audiovisualBackgroundPlaybackPolicy = configuration.audiovisualBackgroundPlaybackPolicy

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -13,6 +13,8 @@ import TimelaneCombine
 
 /// An audio / video player maintaining its items as a double-ended queue (deque).
 public final class Player: ObservableObject, Equatable {
+    private static weak var currentPlayer: Player?
+
     /// Current playback state.
     @Published public private(set) var playbackState: PlaybackState = .idle
 
@@ -48,6 +50,16 @@ public final class Player: ObservableObject, Equatable {
     @Published var currentItem: CurrentItem = .good(nil)
     @Published var storedItems: Deque<PlayerItem>
 
+    @Published private(set) var isActive = false {
+        didSet {
+            if isActive {
+                nowPlayingSession.becomeActiveIfPossible()
+                queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
+            } else {
+                queuePlayer.allowsExternalPlayback = false
+            }
+        }
+    }
     @Published private var currentTracker: CurrentTracker?
 
     /// The player configuration
@@ -111,7 +123,6 @@ public final class Player: ObservableObject, Equatable {
         self.configuration = configuration
 
         configurePlayer()
-        becomeActiveIfPossible()
 
         configureControlCenterPublishers()
         configureQueuePlayerUpdatePublishers()
@@ -128,6 +139,13 @@ public final class Player: ObservableObject, Equatable {
 
     public nonisolated static func == (lhs: Player, rhs: Player) -> Bool {
         lhs === rhs
+    }
+
+    /// Make the player the current active one.
+    public func becomeActiveIfPossible() {
+        Self.currentPlayer?.isActive = false
+        isActive = true
+        Self.currentPlayer = self
     }
 
     private func configurePlayer() {
@@ -281,16 +299,23 @@ private extension Player {
 
 private extension Player {
     func configureControlCenterMetadataUpdatePublisher() {
-        Publishers.CombineLatest(
+        Publishers.CombineLatest3(
             nowPlayingInfoMetadataPublisher(),
-            queuePlayer.nowPlayingInfoPlaybackPublisher()
+            queuePlayer.nowPlayingInfoPlaybackPublisher(),
+            $isActive
         )
         .receiveOnMainThread()
         .lane("control_center_update")
-        .sink { [weak self] nowPlayingInfoMetadata, nowPlayingInfoPlayback in
-            self?.updateControlCenter(
-                nowPlayingInfo: nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new }
-            )
+        .sink { [weak self] nowPlayingInfoMetadata, nowPlayingInfoPlayback, isActive in
+            guard let self else { return }
+            if isActive {
+                self.updateControlCenter(
+                    nowPlayingInfo: nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new }
+                )
+            }
+            else {
+                self.updateControlCenter(nowPlayingInfo: [:])
+            }
         }
         .store(in: &cancellables)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -311,14 +311,8 @@ private extension Player {
         .lane("control_center_update")
         .sink { [weak self] nowPlayingInfoMetadata, nowPlayingInfoPlayback, isActive in
             guard let self else { return }
-            if isActive {
-                self.updateControlCenter(
-                    nowPlayingInfo: nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new }
-                )
-            }
-            else {
-                self.updateControlCenter(nowPlayingInfo: [:])
-            }
+            let nowPlayingInfo = isActive ? nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new } : [:]
+            self.updateControlCenter(nowPlayingInfo: nowPlayingInfo)
         }
         .store(in: &cancellables)
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -50,16 +50,18 @@ public final class Player: ObservableObject, Equatable {
     @Published var currentItem: CurrentItem = .good(nil)
     @Published var storedItems: Deque<PlayerItem>
 
-    @Published private(set) var isActive = false {
+    @Published private var isActive = false {
         didSet {
             if isActive {
                 nowPlayingSession.becomeActiveIfPossible()
                 queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
-            } else {
+            }
+            else {
                 queuePlayer.allowsExternalPlayback = false
             }
         }
     }
+
     @Published private var currentTracker: CurrentTracker?
 
     /// The player configuration

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -243,7 +243,7 @@ A player can be loaded with several items to create a playlist. The playlist can
 The player supports AirPlay and can be integrated with the Control Center:
 
 - For AirPlay support please ensure that your application audio session and background modes are configured appropriately.
-- Call `becomeActiveIfPossible()` on a player instance to enable AirPlay and Control Center support for it.
+- Call `becomeActive()` on a player instance to enable AirPlay and Control Center support for it.
 
 ## Custom player items
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -238,12 +238,12 @@ You can also use a layout reader to check whether the view covers the full scree
 
 A player can be loaded with several items to create a playlist. The playlist can be mutated at any time by inserting, deleting or moving items. Please refer to our extended playlist demo to discover what can be readily achieved with our current playlist API.
 
-## AirPlay and control center integration (iOS)
+## AirPlay and Control Center integration (iOS)
 
-The player supports AirPlay and can be integrated with the control center:
+The player supports AirPlay and can be integrated with the Control Center:
 
 - For AirPlay support please ensure that your application audio session and background modes are configured appropriately.
-- Call `becomeActiveIfPossible()` on a player instance to enable AirPlay and control center support for it.
+- Call `becomeActiveIfPossible()` on a player instance to enable AirPlay and Control Center support for it.
 
 ## Custom player items
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -238,13 +238,12 @@ You can also use a layout reader to check whether the view covers the full scree
 
 A player can be loaded with several items to create a playlist. The playlist can be mutated at any time by inserting, deleting or moving items. Please refer to our extended playlist demo to discover what can be readily achieved with our current playlist API.
 
-## AirPlay (iOS)
+## AirPlay and control center integration (iOS)
 
-The player supports AirPlay. Please ensure that your application audio session and background modes are configured appropriately.
+The player supports AirPlay and can be integrated with the control center:
 
-## Control center integration (iOS)
-
-The player is automatically integrated with the control center. Currently only the most recent player instance is registered with the control center. This behavior will be further improved in the future, though.
+- For AirPlay support please ensure that your application audio session and background modes are configured appropriately.
+- Call `becomeActiveIfPossible()` on a player instance to enable AirPlay and control center support for it.
 
 ## Custom player items
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -85,3 +85,11 @@ When chaining an on-demand stream played at a speed > 1 to a livestream (without
 ### Workaround
 
 No workaround is available yet.
+
+## Sound of a player casting to AirPlay incorrectly overlaps with sound of local player instances
+
+When casting a player to AirPlay while other players are playing other content locally (even muted), sound of these other instances overlaps with the sound of the main instance played on the AirPlay receiver.
+
+### Workaround
+
+Pause players playing content locally.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -4,7 +4,7 @@ The following document lists known Pillarbox issues. Entries with a feedback num
 
 ## Video view leak (FB11934227)
 
-A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button.
+A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback button on iOS 16. The issue has been fixed on iOS 17.
 
 ### Workaround
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to choose which player instance is active.

# Changes made

- A `becomeActive()` method has been introduce to choose the player which have the hand on the Control Center and AirPlay
- The Multi showcase in the demo app has been improved.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
