### PR TITLE
Add ability to disable AirPlay and Control Center integration

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0E6B995C29D43E4200D0276D /* TrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B995B29D43E4200D0276D /* TrackingView.swift */; };
+		0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B995B29D43E4200D0276D /* OptInView.swift */; };
 		0E84D6162A12753100EB48C5 /* SettingsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E84D6152A12753100EB48C5 /* SettingsMenu.swift */; };
 		0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */ = {isa = PBXBuildFile; productRef = 0EF42CB529AE513400553165 /* SRGDataProviderCombine */; };
 		6F36C62D28910538000DD160 /* CoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6F36C62C28910538000DD160 /* CoreBusiness */; };
@@ -65,7 +65,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0E6B995B29D43E4200D0276D /* TrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingView.swift; sourceTree = "<group>"; };
+		0E6B995B29D43E4200D0276D /* OptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInView.swift; sourceTree = "<group>"; };
 		0E84D6152A12753100EB48C5 /* SettingsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenu.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -262,7 +262,7 @@
 				6F59E86229CF31E10093E6FB /* LinkView.swift */,
 				6F59E85529CF31E10093E6FB /* MultiView.swift */,
 				6F59E85A29CF31E10093E6FB /* ShowcaseView.swift */,
-				0E6B995B29D43E4200D0276D /* TrackingView.swift */,
+				0E6B995B29D43E4200D0276D /* OptInView.swift */,
 				6F59E85929CF31E10093E6FB /* TwinsView.swift */,
 			);
 			path = Showcase;
@@ -488,7 +488,7 @@
 				6F59E88C29CF31E20093E6FB /* TwinsView.swift in Sources */,
 				6F59E88529CF31E20093E6FB /* ListsView.swift in Sources */,
 				6F59E8A329CF31E20093E6FB /* ExamplesView.swift in Sources */,
-				0E6B995C29D43E4200D0276D /* TrackingView.swift in Sources */,
+				0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */,
 				6F59E89C29CF31E20093E6FB /* BasicPlaybackView.swift in Sources */,
 				6F59E87A29CF31E10093E6FB /* SearchViewModel.swift in Sources */,
 				6F59E88829CF31E20093E6FB /* UserDefaults.swift in Sources */,

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -8,7 +8,7 @@ import Analytics
 import Player
 import SwiftUI
 
-struct TrackingView: View {
+struct OptInView: View {
     let media: Media
     @StateObject private var player = Player(configuration: .standard)
 
@@ -34,8 +34,8 @@ struct TrackingView: View {
     }
 }
 
-struct TrackingView_Previews: PreviewProvider {
+struct OptInView_Previews: PreviewProvider {
     static var previews: some View {
-        TrackingView(media: Media(from: URLTemplate.onDemandVideoLocalHLS))
+        OptInView(media: Media(from: URLTemplate.onDemandVideoLocalHLS))
     }
 }

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -12,10 +12,15 @@ struct OptInView: View {
     let media: Media
     @StateObject private var player = Player(configuration: .standard)
 
+    @State private var isActive = true
+
     var body: some View {
         VStack {
             PlaybackView(player: player)
             VStack(alignment: .leading) {
+                Toggle(isOn: $isActive) {
+                    Text("Active")
+                }
                 Toggle(isOn: $player.isTrackingEnabled) {
                     Text("Tracking")
                 }
@@ -25,6 +30,14 @@ struct OptInView: View {
             .padding()
         }
         .background(.black)
+        .onChange(of: isActive) { newValue in
+            if newValue {
+                player.becomeActive()
+            }
+            else {
+                player.resignActive()
+            }
+        }
         .onAppear(perform: load)
         .tracked(title: "tracking")
     }

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -114,12 +114,12 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func trackingSection() -> some View {
-        Section("Tracking") {
+        Section("Opt-in") {
             Cell(title: "Video URL") {
-                TrackingView(media: Media(from: URLTemplate.onDemandVideoMP4))
+                OptInView(media: Media(from: URLTemplate.onDemandVideoMP4))
             }
             Cell(title: "Video URN") {
-                TrackingView(media: Media(from: URNTemplate.onDemandVerticalVideo))
+                OptInView(media: Media(from: URNTemplate.onDemandVerticalVideo))
             }
         }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -151,6 +151,15 @@ public final class Player: ObservableObject, Equatable {
         Self.currentPlayer = self
     }
 
+    /// Disable AirPlay and Control Center integration for the receiver. Does nothing if the receiver is currently
+    /// inactive. Calling `resignActive()` is superfluous if `becomeActive` is called on a different player instance
+    /// or if the player gets destroyed.
+    public func resignActive() {
+        guard isActive, Self.currentPlayer == self else { return }
+        isActive = false
+        Self.currentPlayer = nil
+    }
+
     private func configurePlayer() {
         queuePlayer.allowsExternalPlayback = false
         queuePlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -146,6 +146,7 @@ public final class Player: ObservableObject, Equatable {
     /// Enable AirPlay and Control Center integration for the receiver, making the player the current active one. At most
     /// one player can be active at any time.
     public func becomeActive() {
+        guard Self.currentPlayer != self else { return }
         Self.currentPlayer?.isActive = false
         isActive = true
         Self.currentPlayer = self
@@ -155,7 +156,7 @@ public final class Player: ObservableObject, Equatable {
     /// inactive. Calling `resignActive()` is superfluous if `becomeActive` is called on a different player instance
     /// or if the player gets destroyed.
     public func resignActive() {
-        guard isActive, Self.currentPlayer == self else { return }
+        guard Self.currentPlayer == self else { return }
         isActive = false
         Self.currentPlayer = nil
     }

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -58,7 +58,7 @@ Once all status checks are successful and the pull request reviewed it can be ad
 
 To support our worflow GitHub `main` branch protection settings must be configured as follows:
 
-1. Enable _Require a pull request before merging_ and _Require approvals_ with 1 approval.
+1. Enable _Require a pull request before merging_, _Require approvals_ with 1 approval as well as _Require approval of the most recent reviewable push_.
 2. Enable _Require status checks to pass before merging_, _Require branches to be up to date before merging_ and the following required status checks:
   - Demo Archiving iOS (Apple)
   - Demo Archiving tvOS (Apple)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -244,6 +244,9 @@ The player supports AirPlay and can be integrated with the Control Center:
 
 - For AirPlay support please ensure that your application audio session and background modes are configured appropriately.
 - Call `becomeActive()` on a player instance to enable AirPlay and Control Center support for it.
+- Call `resignActive()` on a player to disable AirPlay and Control Center support for it (if currently active).
+
+You need to call `becomeActive()` when transitioning to an immersive player experience for which these integrations make sense. Calling `resignActive()` is most of the time superfluous, except when the same player instance is reused between an immersive playback user interface and a limited playback experience.
 
 ## Custom player items
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds an API to disable AirPlay and Control Center integration for the active player instance. This is mostly useful when a player is reused between a limited playback experience (e.g. inline playback in a video feed) and an immersive one (full screen player). In this case returning from the full screen player should disable these integrations, which was not possible without introducing a new API.

Note that this API is in general not required as these integrations are automatically disabled when a player gets deallocated.

# Changes made

- Add API and documentation.
- The tracking demo has been renamed to showcase opt-ins. A dedicated toggle has been added to enable or disable system integrations on the fly.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
