### PR TITLE
Polish documentation

### DIFF
--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -75,7 +75,7 @@ public class Analytics {
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
-    ///   - mode: The modes for which page views are recorded. Defaults to `.foreground`.
+    ///   - mode: The mode for which page views are recorded. Defaults to `.foreground`.
     public func trackPageView(title: String, levels: [String] = [], for mode: PageViewMode = .foreground) {
         assert(!title.isBlank, "A title is required")
         guard mode == .foregroundAndBackground || UIApplication.shared.applicationState != .background else { return }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -10,7 +10,6 @@ import UIKit
 /// A single entry-point for analytics conforming to the SRG SSR standards.
 ///
 /// SRG SSR applications must use this singleton to gather analytics. These include:
-///
 /// - Page views: Which views are presented to the user.
 /// - Events: Arbitrary events which need to be recorded (e.g. user interaction with a button).
 /// - Streaming: Streaming analytics collected with standard `PlayerItemTracker` implementations.

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -7,16 +7,26 @@
 import Foundation
 import UIKit
 
-/// Gathers analytics according to SRG SSR standards. The associated singleton instance must be started with `start(with:)`
-/// before use.
+/// A single entry-point for analytics conforming to the SRG SSR standards.
+///
+/// SRG SSR applications must use this singleton to gather analytics. These include:
+///
+/// - Page views: Which views are presented to the user.
+/// - Events: Arbitrary events which need to be recorded (e.g. user interaction with a button).
+/// - Streaming: Streaming analytics collected with standard `PlayerItemTracker` implementations.
+///
+/// Before analytics can be gathered the singleton must be started with a configuration suitable for your application.
 public class Analytics {
-    /// Analytics configuration.
+    /// A configuration for analytics.
+    ///
+    /// Please contact our SRG SSR Digital Analytics team (ADI) to obtain configuration parameters suitable for your
+    /// application.
     public struct Configuration {
         let vendor: Vendor
         let sourceKey: String
         let site: String
 
-        /// Configure analytics. `sourceKey` and `site` must be obtained from the SRG SSR Digital Analytics team (ADI).
+        /// Creates an analytics configuration.
         /// - Parameters:
         ///   - vendor: The vendor which the application belongs to.
         ///   - sourceKey: The source key.
@@ -26,14 +36,6 @@ public class Analytics {
             self.sourceKey = sourceKey
             self.site = site
         }
-    }
-
-    /// Application states.
-    public enum ApplicationState {
-        /// Foreground and background.
-        case foregroundAndBackground
-        /// Foreground only.
-        case foreground
     }
 
     /// The singleton instance.
@@ -46,9 +48,12 @@ public class Analytics {
 
     private init() {}
 
-    /// Start analytics with the specified configuration. Must be called from your
-    /// `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)` delegate method. Throws if started more
-    ///  than once.
+    /// Starts analytics with the specified configuration.
+    ///
+    /// This method must be called from your `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
+    /// delegate method implementation, otherwise the behavior is undefined.
+    ///
+    /// The method throws if called more than once.
     /// - Parameter configuration: The configuration to use.
     public func start(with configuration: Configuration) throws {
         guard self.configuration == nil else {
@@ -63,21 +68,19 @@ public class Analytics {
         commandersActService.start(with: configuration)
     }
 
-    /// Track a page view.
+    /// Tracks a page view.
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
-    ///   - state: The application states for which the page can be tracked. Defaults to `.foreground`. The
-    ///     `.foregroundAndBackground` option should only be used in the rare cases where page views must be recorded
-    ///     also while the application is in background, e.g. when tracking a CarPlay user interface.
-    public func trackPageView(title: String, levels: [String] = [], in state: ApplicationState = .foreground) {
+    ///   - mode: The modes for which page views are recorded. Defaults to `.foreground`.
+    public func trackPageView(title: String, levels: [String] = [], for mode: PageViewMode = .foreground) {
         assert(!title.isBlank, "A title is required")
-        guard state == .foregroundAndBackground || UIApplication.shared.applicationState != .background else { return }
+        guard mode == .foregroundAndBackground || UIApplication.shared.applicationState != .background else { return }
         comScoreService.trackPageView(title: title, levels: levels)
         commandersActService.trackPageView(title: title, levels: levels)
     }
 
-    /// Send an event.
+    /// Sends an event.
     /// - Parameters:
     ///   - name: The event name.
     ///   - type: The event type.

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -10,6 +10,7 @@ import UIKit
 /// A single entry-point for analytics conforming to the SRG SSR standards.
 ///
 /// SRG SSR applications must use this singleton to gather analytics. These include:
+///
 /// - Page views: Which views are presented to the user.
 /// - Events: Arbitrary events which need to be recorded (e.g. user interaction with a button).
 /// - Streaming: Streaming analytics collected with standard `PlayerItemTracker` implementations.
@@ -26,6 +27,7 @@ public class Analytics {
         let site: String
 
         /// Creates an analytics configuration.
+        ///
         /// - Parameters:
         ///   - vendor: The vendor which the application belongs to.
         ///   - sourceKey: The source key.
@@ -49,11 +51,12 @@ public class Analytics {
 
     /// Starts analytics with the specified configuration.
     ///
+    /// - Parameter configuration: The configuration to use.
+    ///
     /// This method must be called from your `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
     /// delegate method implementation, otherwise the behavior is undefined.
     ///
     /// The method throws if called more than once.
-    /// - Parameter configuration: The configuration to use.
     public func start(with configuration: Configuration) throws {
         guard self.configuration == nil else {
             throw AnalyticsError.alreadyStarted
@@ -68,6 +71,7 @@ public class Analytics {
     }
 
     /// Tracks a page view.
+    ///
     /// - Parameters:
     ///   - title: The page title.
     ///   - levels: The page levels.
@@ -80,6 +84,7 @@ public class Analytics {
     }
 
     /// Sends an event.
+    /// 
     /// - Parameters:
     ///   - name: The event name.
     ///   - type: The event type.

--- a/Sources/Analytics/AnalyticsListener.swift
+++ b/Sources/Analytics/AnalyticsListener.swift
@@ -9,30 +9,35 @@ import ComScore
 import Foundation
 import TCServerSide_noIDFA
 
-/// Provide a context in which analytics events are captured. Should never be used in production, only for
-/// development purposes (e.g. unit tests). Must be started first.
+/// A listener for analytics events.
+///
+/// The listener must be started first and provides two methods with which comScore, respectively Commanders Act
+/// events can be captured.
+///
+/// Note that `AnalyticsListener` is a development-oriented tool (e.g. unit testing) which must never be used directly
+/// in production code.
 public enum AnalyticsListener {
     private static let sessionIdentifierKey = "listener_session_id"
     private static var sessionIdentifier: String?
 
-    /// Start the listener.
+    /// Starts the listener.
     /// - Parameter completion: A completion called when the listener has been started.
     public static func start(completion: @escaping () -> Void) {
         ComScoreInterceptor.start(completion: completion)
     }
 
-    /// Capture comScore events.
-    /// - Parameter perform: A closure to be executed. Receives a publisher which emits the events received during
-    ///   the capture.
+    /// Captures comScore events.
+    /// - Parameter perform: A closure to be executed within the capture session. The session provides a publisher
+    ///   which emits the associated events.
     public static func captureComScoreEvents(perform: (AnyPublisher<ComScoreEvent, Never>) -> Void) {
         captureEvents(perform: perform) { identifier in
             ComScoreInterceptor.eventPublisher(for: identifier)
         }
     }
 
-    /// Capture Commanders Act events.
-    /// - Parameter perform: A closure to be executed. Receives a publisher which emits the events received during
-    ///   the capture.
+    /// Captures Commanders Act events.
+    /// - Parameter perform: A closure to be executed within the capture session. The session provides a publisher
+    ///   which emits the associated events.
     public static func captureCommandersActEvents(perform: (AnyPublisher<CommandersActEvent, Never>) -> Void) {
         captureEvents(perform: perform) { identifier in
             CommandersActInterceptor.eventPublisher(for: identifier)

--- a/Sources/Analytics/AnalyticsListener.swift
+++ b/Sources/Analytics/AnalyticsListener.swift
@@ -21,12 +21,14 @@ public enum AnalyticsListener {
     private static var sessionIdentifier: String?
 
     /// Starts the listener.
+    ///
     /// - Parameter completion: A completion called when the listener has been started.
     public static func start(completion: @escaping () -> Void) {
         ComScoreInterceptor.start(completion: completion)
     }
 
     /// Captures comScore events.
+    ///
     /// - Parameter perform: A closure to be executed within the capture session. The session provides a publisher
     ///   which emits the associated events.
     public static func captureComScoreEvents(perform: (AnyPublisher<ComScoreEvent, Never>) -> Void) {
@@ -36,6 +38,7 @@ public enum AnalyticsListener {
     }
 
     /// Captures Commanders Act events.
+    /// 
     /// - Parameter perform: A closure to be executed within the capture session. The session provides a publisher
     ///   which emits the associated events.
     public static func captureCommandersActEvents(perform: (AnyPublisher<CommandersActEvent, Never>) -> Void) {

--- a/Sources/Analytics/ComScore/ComScoreEvent.swift
+++ b/Sources/Analytics/ComScore/ComScoreEvent.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-/// A comScore event.
+/// An event sent by the comScore SDK.
 public struct ComScoreEvent {
-    /// Event names.
+    /// A name describing a comScore event.
     public enum Name: String {
         case play
         case pause
@@ -19,7 +19,7 @@ public struct ComScoreEvent {
     /// The event name.
     public let name: Name
 
-    /// Labels associated with the event.
+    /// The labels associated with the event.
     public let labels: ComScoreLabels
 
     init?(from labels: ComScoreLabels) {

--- a/Sources/Analytics/ComScore/ComScoreInterceptor.swift
+++ b/Sources/Analytics/ComScore/ComScoreInterceptor.swift
@@ -13,7 +13,7 @@ private enum ComScoreRequestInfoKey: String {
     case queryItems = "ComScoreRequestQueryItems"
 }
 
-/// Intercepts comScore requests and emits event information with a publisher.
+/// A tool that intercepts comScore requests and turns them into an event stream.
 enum ComScoreInterceptor {
     private static var started = false
     private static var cancellables = Set<AnyCancellable>()

--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -10,81 +10,81 @@ import Foundation
 public struct ComScoreLabels {
     let dictionary: [String: String]
 
-    var ns_st_ev: String? {
-        extract()
-    }
-
-    var ns_ap_ev: String? {
-        extract()
-    }
-
     var listener_session_id: String? {
+        extract()
+    }
+
+    public var ns_st_ev: String? {
+        extract()
+    }
+
+    public var ns_ap_ev: String? {
         extract()
     }
 
     // MARK: Common labels
 
     /// The value of `c2` (comScore account).
-    var c2: String? {
+    public var c2: String? {
         extract()
     }
 
     /// The value of `ns_ap_an` (application name).
-    var ns_ap_an: String? {
+    public var ns_ap_an: String? {
         extract()
     }
 
     // MARK: Mediapulse labels
 
     /// The value of `mp_brand` (vendor).
-    var mp_brand: String? {
+    public var mp_brand: String? {
         extract()
     }
 
     /// The value of `mp_v` (application version).
-    var mp_v: String? {
+    public var mp_v: String? {
         extract()
     }
 
     // MARK: Page view labels
 
     /// The value of `ns_category` (name of the section).
-    var ns_category: String? {
+    public var ns_category: String? {
         extract()
     }
 
     // MARK: Streaming labels
 
     /// The value of `ns_st_mp` (media player name).
-    var ns_st_mp: String? {
+    public var ns_st_mp: String? {
         extract()
     }
 
     /// The value of `ns_st_mv` (media player version).
-    var ns_st_mv: String? {
+    public var ns_st_mv: String? {
         extract()
     }
 
     /// The value of `ns_st_po` (playback position).
-    var ns_st_po: Double? {
+    public var ns_st_po: Double? {
         guard let value: Double = extract() else { return nil }
         return value / 1000
     }
 
     /// The value of `ns_st_ldw` (DVR window length).
-    var ns_st_ldw: Double? {
+    public var ns_st_ldw: Double? {
         guard let value: Double = extract() else { return nil }
         return value / 1000
     }
 
     /// The value of `ns_st_ldo` (DVR live edge offset).
-    var ns_st_ldo: Double? {
+    public var ns_st_ldo: Double? {
         guard let value: Double = extract() else { return nil }
         return value / 1000
     }
 
     /// The value of `ns_st_rt` (playback rate).
-    var ns_st_rt: Int? {
+    public var ns_st_rt: Int? {
         extract()
     }
 

--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Labels associated with a comScore event.
+/// The labels associated with a comScore event.
 public struct ComScoreLabels {
     let dictionary: [String: String]
 
@@ -22,6 +22,72 @@ public struct ComScoreLabels {
         extract()
     }
 
+    // MARK: Common labels
+
+    /// The value of `c2` (comScore account).
+    var c2: String? {
+        extract()
+    }
+
+    /// The value of `ns_ap_an` (application name).
+    var ns_ap_an: String? {
+        extract()
+    }
+
+    // MARK: Mediapulse labels
+
+    /// The value of `mp_brand` (vendor).
+    var mp_brand: String? {
+        extract()
+    }
+
+    /// The value of `mp_v` (application version).
+    var mp_v: String? {
+        extract()
+    }
+
+    // MARK: Page view labels
+
+    /// The value of `ns_category` (name of the section).
+    var ns_category: String? {
+        extract()
+    }
+
+    // MARK: Streaming labels
+
+    /// The value of `ns_st_mp` (media player name).
+    var ns_st_mp: String? {
+        extract()
+    }
+
+    /// The value of `ns_st_mv` (media player version).
+    var ns_st_mv: String? {
+        extract()
+    }
+
+    /// The value of `ns_st_po` (playback position).
+    var ns_st_po: Double? {
+        guard let value: Double = extract() else { return nil }
+        return value / 1000
+    }
+
+    /// The value of `ns_st_ldw` (DVR window length).
+    var ns_st_ldw: Double? {
+        guard let value: Double = extract() else { return nil }
+        return value / 1000
+    }
+
+    /// The value of `ns_st_ldo` (DVR live edge offset).
+    var ns_st_ldo: Double? {
+        guard let value: Double = extract() else { return nil }
+        return value / 1000
+    }
+
+    /// The value of `ns_st_rt` (playback rate).
+    var ns_st_rt: Int? {
+        extract()
+    }
+
     private func extract<T: LosslessStringConvertible>(_ key: String = #function) -> T? {
         guard let value = dictionary[key] else { return nil }
         return .init(value)
@@ -29,75 +95,5 @@ public struct ComScoreLabels {
 
     subscript<T: LosslessStringConvertible>(key: String) -> T? {
         extract(key)
-    }
-}
-
-/// Common labels.
-public extension ComScoreLabels {
-    /// Value of `c2` (comScore account).
-    var c2: String? {
-        extract()
-    }
-
-    /// Value of `ns_ap_an` (application name).
-    var ns_ap_an: String? {
-        extract()
-    }
-}
-
-/// Mediapulse labels.
-public extension ComScoreLabels {
-    /// Value of `mp_brand` (vendor).
-    var mp_brand: String? {
-        extract()
-    }
-
-    /// Value of `mp_v` (application version).
-    var mp_v: String? {
-        extract()
-    }
-}
-
-/// Labels related to page views.
-public extension ComScoreLabels {
-    /// Value of `ns_category` (name of the section).
-    var ns_category: String? {
-        extract()
-    }
-}
-
-/// Labels related to streaming.
-public extension ComScoreLabels {
-    /// Value of `ns_st_mp` (media player name).
-    var ns_st_mp: String? {
-        extract()
-    }
-
-    /// Value of `ns_st_mv` (media player version).
-    var ns_st_mv: String? {
-        extract()
-    }
-
-    /// Value of `ns_st_po` (playback position).
-    var ns_st_po: Double? {
-        guard let value: Double = extract() else { return nil }
-        return value / 1000
-    }
-
-    /// Value of `ns_st_ldw` (DVR window length).
-    var ns_st_ldw: Double? {
-        guard let value: Double = extract() else { return nil }
-        return value / 1000
-    }
-
-    /// Value of `ns_st_ldo` (DVR live edge offset).
-    var ns_st_ldo: Double? {
-        guard let value: Double = extract() else { return nil }
-        return value / 1000
-    }
-
-    /// Value of `ns_st_rt` (playback rate).
-    var ns_st_rt: Int? {
-        extract()
     }
 }

--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -14,15 +14,12 @@ public struct ComScoreLabels {
         extract()
     }
 
-    public var ns_st_ev: String? {
-        extract()
-    }
+    // MARK: Common labels
 
+    /// The value of `ns_ap_ev` (application event).
     public var ns_ap_ev: String? {
         extract()
     }
-
-    // MARK: Common labels
 
     /// The value of `c2` (comScore account).
     public var c2: String? {
@@ -54,6 +51,11 @@ public struct ComScoreLabels {
     }
 
     // MARK: Streaming labels
+
+    /// The value of `ns_st_ev` (streaming event).
+    public var ns_st_ev: String? {
+        extract()
+    }
 
     /// The value of `ns_st_mp` (media player name).
     public var ns_st_mp: String? {

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -10,7 +10,11 @@ import CoreMedia
 import Foundation
 import Player
 
-/// Stream tracker for comScore. Implements streaming measurements according to Mediapulse official specifications.
+/// A comScore tracker for streaming.
+///
+/// This tracker implements streaming measurements according to Mediapulse official specifications.
+///
+/// Analytics have to be properly started for the tracker to collect events, see `Analytics.start(with:)`.
 public final class ComScoreTracker: PlayerItemTracker {
     private var streamingAnalytics = SCORStreamingAnalytics()
     private var cancellables = Set<AnyCancellable>()

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -135,7 +135,7 @@ private extension SCORStreamingAnalytics {
 }
 
 public extension ComScoreTracker {
-    /// Metadata.
+    /// comScore tracker metadata.
     struct Metadata {
         let labels: [String: String]
         let streamType: StreamType
@@ -144,7 +144,8 @@ public extension ComScoreTracker {
             .init(labels: [:], streamType: .unknown)
         }
 
-        /// The initializer.
+        /// Creates comScore metadata.
+        ///
         /// - Parameters:
         ///   - labels: The labels.
         ///   - streamType: The stream type.

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-/// A Commanders Act event.
+/// An event sent by the Commanders Act SDK.
 public struct CommandersActEvent {
-    /// Event names.
+    /// A name describing a Commanders Act event.
     public enum Name: String {
         case play
         case pause
@@ -24,7 +24,7 @@ public struct CommandersActEvent {
     /// The event name.
     public let name: Name
 
-    /// Labels associated with the event.
+    /// The labels associated with the event.
     public let labels: CommandersActLabels
 
     init?(from labels: CommandersActLabels) {

--- a/Sources/Analytics/CommandersAct/CommandersActInterceptor.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActInterceptor.swift
@@ -8,7 +8,7 @@ import Combine
 import Foundation
 import TCServerSide_noIDFA
 
-/// Intercepts Commanders Act requests and emits event information with a publisher.
+/// A tool that intercepts Commanders Act requests and turns them into an event stream.
 enum CommandersActInterceptor {
     static func eventPublisher(for identifier: String) -> AnyPublisher<CommandersActEvent, Never> {
         NotificationCenter.default.publisher(for: .init(rawValue: kTCNotification_HTTPRequest))

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -98,7 +98,7 @@ public struct CommandersActLabels: Decodable {
     public let event_value_4: String?
 
     /// The value of `event_value_5`.
-    public let event_value_5: String
+    public let event_value_5: String?
 
     // MARK: Streaming labels
 

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Labels associated with a Commanders Act event.
+/// The labels associated with a Commanders Act event.
 public struct CommandersActLabels: Decodable {
     private let _media_bandwidth: String?
     private let _media_playback_rate: String?
@@ -18,109 +18,117 @@ public struct CommandersActLabels: Decodable {
     let listener_session_id: String?
     let media_title: String?
 
-    /// Value of `app_library_version`.
+    // MARK: Common labels
+
+    /// The value of `app_library_version`.
     public let app_library_version: String?
 
-    /// Value of `navigation_app_site_name`.
+    /// The value of `navigation_app_site_name`.
     public let navigation_app_site_name: String?
 
-    /// Value of `navigation_property_type`.
-    public let navigation_property_type: String?
-
-    /// Value of `navigation_bu_distributer`.
-    public let navigation_bu_distributer: String?
-
-    /// Value of `navigation_device`.
+    /// The value of `navigation_device`.
     public let navigation_device: String?
 
-    /// Value of `navigation_level_0`.
+    // MARK: Page view labels
+
+    /// The value of `navigation_property_type`.
+    public let navigation_property_type: String?
+
+    /// The value of `navigation_bu_distributer`.
+    public let navigation_bu_distributer: String?
+
+    /// The value of `navigation_level_0`.
     public let navigation_level_0: String?
 
-    /// Value of `navigation_level_1`.
+    /// The value of `navigation_level_1`.
     public let navigation_level_1: String?
 
-    /// Value of `navigation_level_2`.
+    /// The value of `navigation_level_2`.
     public let navigation_level_2: String?
 
-    /// Value of `navigation_level_3`.
+    /// The value of `navigation_level_3`.
     public let navigation_level_3: String?
 
-    /// Value of `navigation_level_4`.
+    /// The value of `navigation_level_4`.
     public let navigation_level_4: String?
 
-    /// Value of `navigation_level_5`.
+    /// The value of `navigation_level_5`.
     public let navigation_level_5: String?
 
-    /// Value of `navigation_level_6`.
+    /// The value of `navigation_level_6`.
     public let navigation_level_6: String?
 
-    /// Value of `navigation_level_7`.
+    /// The value of `navigation_level_7`.
     public let navigation_level_7: String?
 
-    /// Value of `navigation_level_8`.
+    /// The value of `navigation_level_8`.
     public let navigation_level_8: String?
 
-    /// Value of `navigation_level_9`.
+    /// The value of `navigation_level_9`.
     public let navigation_level_9: String?
 
-    /// Value of `page_type`.
+    /// The value of `page_type`.
     public let page_type: String?
 
-    /// Value of `event_title`.
+    // MARK: Event labels
+
+    /// The value of `event_title`.
     /// FIXME: This field was introduced to avoid clashes with `event_name` but still needs to be discussed.
     public let event_title: String?
 
-    /// Value of `event_type`.
+    /// The value of `event_type`.
     public let event_type: String?
 
-    /// Value of `event_value`.
+    /// The value of `event_value`.
     public let event_value: String?
 
-    /// Value of `event_source`.
+    /// The value of `event_source`.
     public let event_source: String?
 
-    /// Value of `event_value_1`.
+    /// The value of `event_value_1`.
     public let event_value_1: String?
 
-    /// Value of `event_value_2`.
+    /// The value of `event_value_2`.
     public let event_value_2: String?
 
-    /// Value of `event_value_3`.
+    /// The value of `event_value_3`.
     public let event_value_3: String?
 
-    /// Value of `event_value_4`.
+    /// The value of `event_value_4`.
     public let event_value_4: String?
 
-    /// Value of `event_value_5`.
-    public let event_value_5: String?
+    /// The value of `event_value_5`.
+    public let event_value_5: String
 
-    /// Value of `media_player_display`.
+    // MARK: Streaming labels
+
+    /// The value of `media_player_display`.
     public let media_player_display: String?
 
-    /// Value of `media_player_version`.
+    /// The value of `media_player_version`.
     public let media_player_version: String?
 
-    /// Value of `media_bandwidth`.
+    /// The value of `media_bandwidth`.
     public var media_bandwidth: Double? {
         extract(\._media_bandwidth)
     }
 
-    /// Value of `media_playback_rate`.
+    /// The value of `media_playback_rate`.
     public var media_playback_rate: Float? {
         extract(\._media_playback_rate)
     }
 
-    /// Value of `media_position`.
+    /// The value of `media_position`.
     public var media_position: Int? {
         extract(\._media_position)
     }
 
-    /// Value of `media_timeshift`.
+    /// The value of `media_timeshift`.
     public var media_timeshift: Int? {
         extract(\._media_timeshift)
     }
 
-    /// Value of `media_volume`.
+    /// The value of `media_volume`.
     public var media_volume: Int? {
         extract(\._media_volume)
     }

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -9,7 +9,11 @@ import Combine
 import Foundation
 import Player
 
-/// Stream tracker for Commanders Act. Implements streaming measurements according to SRG SSR official specifications.
+/// A Commanders Act tracker for streaming.
+///
+/// This tracker implements streaming measurements according to SRG SSR official specifications.
+///
+/// Analytics have to be properly started for the tracker to collect events, see `Analytics.start(with:)`.
 public final class CommandersActTracker: PlayerItemTracker {
     private var cancellables = Set<AnyCancellable>()
     private var streamingAnalytics: CommandersActStreamingAnalytics?

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -112,7 +112,7 @@ private extension CommandersActTracker {
 }
 
 public extension CommandersActTracker {
-    /// Metadata.
+    /// Commanders Act tracker metadata.
     struct Metadata {
         let labels: [String: String]
         let streamType: StreamType
@@ -121,9 +121,10 @@ public extension CommandersActTracker {
             .init(labels: [:], streamType: .unknown)
         }
 
-        /// Create metadata.
+        /// Creates Commanders Act metadata.
+        ///
         /// - Parameters:
-        ///   - labels: Labels associated with the content being played.
+        ///   - labels: The labels associated with the content being played.
         ///   - streamType: The stream type.
         public init(labels: [String: String], streamType: StreamType) {
             self.labels = labels

--- a/Sources/Analytics/PageViewMode.swift
+++ b/Sources/Analytics/PageViewMode.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// A mode for which page views must be measured.
+public enum PageViewMode {
+    /// A mode allowing page views both in foreground and background.
+    ///
+    /// You must avoid measuring page views when your application is in background, except in very specific use cases
+    /// (e.g. measuring a CarPlay user interface while the main application is in background).
+    case foregroundAndBackground
+    /// A mode allowing page views in foreground only.
+    ///
+    /// Page views must only be measured when your application is in background. This is therefore the recommended mode
+    /// for most applications.
+    case foreground
+}

--- a/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
@@ -6,14 +6,34 @@
 
 import UIKit
 
-/// Protocol for custom containers to implement automatic page view tracking propagation to their children. Standard
-/// UIKit containers already conform to this protocol and do not require any additional work. Custom containers
-/// should conform to this protocol to precisely declare which ones of their children are visible. If the protocol
-/// is not implemented all its children are considered to be visible.
+/// A protocol that view controller containers can implement to customize automatic page view tracking.
 ///
-/// The implementation of a custom container might also need to inform the automatic page view tracking engine of
-/// child controller appearance, see `UIViewController.setNeedsAutomaticPageViewTracking(in:)` documentation for
-/// more information.
+/// Automatic page view tracking can be optionally adopted by view controllers, as described in `PageViewTracking`
+/// documentation.
+///
+/// When containers are involved, though, which children view controller events should be automatically propagated to
+/// must be correctly configured depending on the container type:
+///
+/// - If page view events must be automatically forwarded to all children no additional work is required.
+/// - If page view events must be automatically forwarded to only selected children then a container must implement
+///   the `ContainerPageViewTracking` protocol to declare which ones of its children must be considered active for
+///   propagation.
+///
+/// When implementing a custom container you might sometimes need to inform the automatic page view tracking engine of
+/// child controller appearance so that correct propagation can be triggered. Refer to
+/// `UIViewController.setNeedsAutomaticPageViewTracking(in:)` documentation for more information.
+///
+/// ### Native UIKit Container Support
+///
+/// Some standard UIKit containers conform to `ContainerPageViewTracking` to implement correct propagation:
+///
+/// - `UINavigationController`: The top view controller is active.
+/// - `UIPageViewController`: The currently visible view controller is active.
+/// - `UISplitViewController`: The view controllers returned by `UISplitViewController.viewControllers` are active.
+/// - `UITabBarController`: The currently visible view controller is active.
+///
+/// Other UIKit containers do not need to conform to `ContainerPageViewTracking` as default event propagation yields
+/// correct behavior for them.
 public protocol ContainerPageViewTracking {
     /// The list of currently active children in the view controller container.
     var activeChildren: [UIViewController] { get }

--- a/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
@@ -13,6 +13,7 @@ import UIKit
 ///
 /// When containers are involved, though, which children view controller events should be automatically propagated to
 /// must be correctly configured depending on the container type:
+///
 /// - If page view events must be automatically forwarded to all children no additional work is required.
 /// - If page view events must be automatically forwarded to only selected children then a container must implement
 ///   the `ContainerPageViewTracking` protocol to declare which ones of its children must be considered active for
@@ -25,6 +26,7 @@ import UIKit
 /// ### Native UIKit Container Support
 ///
 /// Some standard UIKit containers conform to `ContainerPageViewTracking` to implement correct propagation:
+///
 /// - `UINavigationController`: The top view controller is active.
 /// - `UIPageViewController`: The currently visible view controller is active.
 /// - `UISplitViewController`: The view controllers returned by `UISplitViewController.viewControllers` are active.

--- a/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
@@ -13,7 +13,6 @@ import UIKit
 ///
 /// When containers are involved, though, which children view controller events should be automatically propagated to
 /// must be correctly configured depending on the container type:
-///
 /// - If page view events must be automatically forwarded to all children no additional work is required.
 /// - If page view events must be automatically forwarded to only selected children then a container must implement
 ///   the `ContainerPageViewTracking` protocol to declare which ones of its children must be considered active for
@@ -26,7 +25,6 @@ import UIKit
 /// ### Native UIKit Container Support
 ///
 /// Some standard UIKit containers conform to `ContainerPageViewTracking` to implement correct propagation:
-///
 /// - `UINavigationController`: The top view controller is active.
 /// - `UIPageViewController`: The currently visible view controller is active.
 /// - `UISplitViewController`: The view controllers returned by `UISplitViewController.viewControllers` are active.

--- a/Sources/Analytics/UserInterface/PageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/PageViewTracking.swift
@@ -10,7 +10,6 @@ import UIKit
 ///
 /// View controllers whose usage must be measured should conform to the `PageViewTracking` protocol, which describes
 /// the associated measurement data:
-///
 /// - Page title.
 /// - Page levels.
 ///
@@ -20,7 +19,6 @@ import UIKit
 /// ### Automatic Tracking
 ///
 /// In automatic mode a page view is automatically emitted for a `PageViewTracking`-conforming view controller when:
-///
 /// - Its `viewDidAppear(_:)` method is called.
 /// - The application returns from background and the view controller is active (which in general means its is visible,
 ///   though this can depend on which container displays the view controller, see `ContainerPageViewTracking`).

--- a/Sources/Analytics/UserInterface/PageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/PageViewTracking.swift
@@ -10,6 +10,7 @@ import UIKit
 ///
 /// View controllers whose usage must be measured should conform to the `PageViewTracking` protocol, which describes
 /// the associated measurement data:
+/// 
 /// - Page title.
 /// - Page levels.
 ///
@@ -19,6 +20,7 @@ import UIKit
 /// ### Automatic Tracking
 ///
 /// In automatic mode a page view is automatically emitted for a `PageViewTracking`-conforming view controller when:
+///
 /// - Its `viewDidAppear(_:)` method is called.
 /// - The application returns from background and the view controller is active (which in general means its is visible,
 ///   though this can depend on which container displays the view controller, see `ContainerPageViewTracking`).
@@ -30,8 +32,8 @@ import UIKit
 /// available at the time `viewDidAppear(_:)` is called, e.g. if this information is retrieved asynchronously. Beware
 /// that in this case you are responsible of calling `UIViewController.trackPageView()` when:
 ///
-///   - The view is visible and you received the information you needed for the page view.
-///   - The application returns from background and the information you need for the page view is readily available.
+/// - The view is visible and you received the information you needed for the page view.
+/// - The application returns from background and the information you need for the page view is readily available.
 ///
 /// ### Raw Page View Tracking
 ///
@@ -135,9 +137,10 @@ extension UIViewController {
         trackPageView(automatic: true, recursive: false, for: .foreground)
     }
 
-    /// Call this method to track a page view event manually for the receiver, using data declared by `PageViewTracking`
-    /// conformance. This method does nothing if the receiver does not conform to the `PageViewTracking` protocol and
-    /// is mostly useful when automatic tracking has been disabled.
+    /// Perform manual page view tracking for the receiver, using data declared by `PageViewTracking` conformance.
+    ///
+    /// This method does nothing if the receiver does not conform to the `PageViewTracking` protocol and is mostly
+    /// useful when automatic tracking has been disabled by setting `isTrackedAutomatically` to `false`.
     public func trackPageView() {
         trackPageView(automatic: false, recursive: false, for: .foreground)
     }
@@ -161,6 +164,9 @@ extension UIViewController {
 
     /// Informs the automatic page view tracking engine that page view events generation should be evaluated again.
     ///
+    /// - Parameter viewController: The view controller for which automatic page view event generation must be
+    ///   evaluated again.
+    ///
     /// You should call this method after a child view controller has been added to a custom container to notify the
     /// automatic page view tracking engine. This ensures that correct page view event generation and propagation can
     /// be triggered if needed.
@@ -173,9 +179,6 @@ extension UIViewController {
     /// keeping them alive while inactive (custom tab bar controllers, for example). For containers hiding children
     /// which have disappeared (similarly to what navigation controllers do), calling this method is not required, as
     /// standard view appearance namely suffices to trigger automatic page views again when required.
-    ///
-    /// - Parameter viewController: The view controller for which automatic page view event generation must be
-    ///   evaluated again.
     public func setNeedsAutomaticPageViewTracking(in viewController: UIViewController) {
         guard trackedChildren.contains(viewController) else { return }
         viewController.trackPageView(automatic: true, recursive: true, for: .foreground)

--- a/Sources/Analytics/UserInterface/View.swift
+++ b/Sources/Analytics/UserInterface/View.swift
@@ -37,7 +37,6 @@ public extension View {
     /// Ensures page views are automatically tracked for the receiver.
     ///
     /// A page view will be automatically emitted when:
-    ///
     /// - The receiver appears on screen.
     /// - The application returns from background with the receiver visible.
     func tracked(title: String, levels: [String] = []) -> some View {

--- a/Sources/Analytics/UserInterface/View.swift
+++ b/Sources/Analytics/UserInterface/View.swift
@@ -34,11 +34,12 @@ private struct PageTrackingView: UIViewControllerRepresentable {
 }
 
 public extension View {
-    /// Ensure a page view is sent for the receiver when it appears on screen, or when the application returns from
-    /// background with the view visible.
-    /// - Parameters:
-    ///   - title: The page title.
-    ///   - levels: Page levels.
+    /// Ensures page views are automatically tracked for the receiver.
+    ///
+    /// A page view will be automatically emitted when:
+    ///
+    /// - The receiver appears on screen.
+    /// - The application returns from background with the receiver visible.
     func tracked(title: String, levels: [String] = []) -> some View {
         background {
             PageTrackingView(title: title, levels: levels)

--- a/Sources/Analytics/Vendor.swift
+++ b/Sources/Analytics/Vendor.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// The vendor for which analytics are collected.
+/// A vendor for which analytics are collected.
 public enum Vendor: String {
     /// SRF.
     case SRF

--- a/Sources/Circumspect/Expectations/ExpectAtLeastPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectAtLeastPublished.swift
@@ -8,7 +8,7 @@ import Combine
 import XCTest
 
 public extension XCTestCase {
-    /// Expect a publisher to emit at least a list of expected values.
+    /// Expects a publisher to emit at least a list of expected values.
     func expectAtLeastPublished<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -31,7 +31,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit at least a list of expected values.
+    /// Expects a publisher to emit at least a list of expected values.
     func expectAtLeastEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -51,7 +51,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit at least a list of expected values.
+    /// Expects a publisher to emit at least a list of expected values.
     func expectAtLeastSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -71,8 +71,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit at least a list of expected values, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expects a publisher to emit at least a list of expected values, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectAtLeastPublishedNext<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -95,8 +96,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit at least a list of expected values, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expects a publisher to emit at least a list of expected values, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectAtLeastEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -118,8 +120,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit at least a list of expected values, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expects a publisher to emit at least a list of expected values, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectAtLeastSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,

--- a/Sources/Circumspect/Expectations/ExpectNothingPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectNothingPublished.swift
@@ -8,7 +8,7 @@ import Combine
 import XCTest
 
 public extension XCTestCase {
-    /// Ensure a publisher does not emit any value during some time interval.
+    /// Expects a publisher to not emit any value during some time interval.
     func expectNothingPublished<P: Publisher>(
         from publisher: P,
         during interval: DispatchTimeInterval = .seconds(20),
@@ -26,7 +26,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Ensure a publisher does not emit any value during some time interval.
+    /// Expects a publisher to not emit any value during some time interval.
     func expectNothingPublishedNext<P: Publisher>(
         from publisher: P,
         during interval: DispatchTimeInterval = .seconds(20),

--- a/Sources/Circumspect/Expectations/ExpectNotifications.swift
+++ b/Sources/Circumspect/Expectations/ExpectNotifications.swift
@@ -10,7 +10,7 @@ import XCTest
 /// Remark: Nimble provides support for notifications but its collector is not thread-safe and might crash during
 ///         collection.
 public extension XCTestCase {
-    /// Wait until a list of notifications has been received.
+    /// Waits until a list of notifications has been received.
     func expectAtLeastReceived(
         notifications: [Notification],
         for names: Set<Notification.Name>,
@@ -34,7 +34,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect notifications during some time interval and match them against an expected result.
+    /// Collects notifications during some time interval and match them against an expected result.
     func expectReceived(
         notifications: [Notification],
         for names: Set<Notification.Name>,
@@ -58,7 +58,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Ensure no notifications are emitted during some time interval.
+    /// Expects no notifications to be emitted during some time interval.
     func expectNoNotifications(
         for names: Set<Notification.Name>,
         object: AnyObject? = nil,

--- a/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
@@ -8,7 +8,7 @@ import Combine
 import XCTest
 
 public extension XCTestCase {
-    /// Expect a publisher to emit a list of expected values and complete.
+    /// Expects a publisher to emit a list of expected values and complete.
     func expectOnlyPublished<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -31,7 +31,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete.
+    /// Expects a publisher to emit a list of expected values and complete.
     func expectOnlyEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -51,7 +51,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete.
+    /// Expects a publisher to emit a list of expected values and complete.
     func expectOnlySimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -71,8 +71,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expect a publisher to emit a list of expected values and complete, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectOnlyPublishedNext<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -95,8 +96,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expects a publisher to emit a list of expected values and complete, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectOnlyEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -118,8 +120,9 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete, ignoring the first value. Useful when testing
-    /// publishers which automatically deliver a non-relevant stored value upon subscription.
+    /// Expects a publisher to emit a list of expected values and complete, ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectOnlySimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,

--- a/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
@@ -71,7 +71,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Expect a publisher to emit a list of expected values and complete, ignoring the first value.
+    /// Expects a publisher to emit a list of expected values and complete, ignoring the first value.
     ///
     /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectOnlyPublishedNext<P: Publisher, T>(

--- a/Sources/Circumspect/Expectations/ExpectPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectPublished.swift
@@ -8,7 +8,7 @@ import Combine
 import XCTest
 
 public extension XCTestCase {
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result.
     func expectPublished<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -31,7 +31,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result.
     func expectEqualPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -53,7 +53,7 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result.
     func expectSimilarPublished<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -75,9 +75,10 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result,
-    /// ignoring the first value. Useful when testing publishers which automatically deliver a non-relevant stored
-    /// value upon subscription.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result,
+    /// ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectPublishedNext<P: Publisher, T>(
         values: [T],
         from publisher: P,
@@ -100,9 +101,10 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result,
-    /// ignoring the first value. Useful when testing publishers which automatically deliver a non-relevant stored
-    /// value upon subscription.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result,
+    /// ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectEqualPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,
@@ -124,9 +126,10 @@ public extension XCTestCase {
         )
     }
 
-    /// Collect values emitted by a publisher during some time interval and match them against an expected result,
-    /// ignoring the first value. Useful when testing publishers which automatically deliver a non-relevant stored
-    /// value upon subscription.
+    /// Collects values emitted by a publisher during some time interval and matches them against an expected result,
+    /// ignoring the first value.
+    ///
+    /// Useful when testing publishers which automatically deliver a non-relevant stored value upon subscription.
     func expectSimilarPublishedNext<P: Publisher>(
         values: [P.Output],
         from publisher: P,

--- a/Sources/Circumspect/Expectations/ExpectResult.swift
+++ b/Sources/Circumspect/Expectations/ExpectResult.swift
@@ -8,7 +8,7 @@ import Combine
 import XCTest
 
 public extension XCTestCase {
-    /// Expect a publisher to complete successfully.
+    /// Expects a publisher to complete successfully.
     func expectSuccess<P: Publisher>(
         from publisher: P,
         timeout: DispatchTimeInterval = .seconds(20),
@@ -39,7 +39,7 @@ public extension XCTestCase {
         waitForExpectations(timeout: timeout.double())
     }
 
-    /// Expect a publisher to complete with a failure.
+    /// Expects a publisher to complete with a failure.
     func expectFailure<P: Publisher>(
         _ error: Error? = nil,
         from publisher: P,

--- a/Sources/Circumspect/Matchers.swift
+++ b/Sources/Circumspect/Matchers.swift
@@ -7,9 +7,9 @@
 import Difference
 import Nimble
 
-/// Match against an expected value using some comparator.
-/// Directly borrowed from https://github.com/Quick/Nimble/blob/main/Sources/Nimble/Matchers/Equal.swift
+/// Matches against an expected value using some comparator.
 public func equal<T>(_ expectedValue: T?, by areEquivalent: @escaping (T, T) -> Bool) -> Predicate<T> {
+    // Directly borrowed from https://github.com/Quick/Nimble/blob/main/Sources/Nimble/Matchers/Equal.swift
     Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, message in
         let actualValue = try actualExpression.evaluate()
         switch (expectedValue, actualValue) {
@@ -24,9 +24,9 @@ public func equal<T>(_ expectedValue: T?, by areEquivalent: @escaping (T, T) -> 
     }
 }
 
-/// Nimble matcher displaying mismatches in a friendly way.
-/// Borrowed from https://github.com/krzysztofzablocki/Difference
+/// Matches against an expected value using some comparator, displaying mismatches in a user-readable form.
 public func equalDiff<T>(_ expectedValue: T?, by areEquivalent: @escaping (T, T) -> Bool) -> Predicate<T> {
+    // Borrowed from https://github.com/krzysztofzablocki/Difference
     Predicate.define("equal <\(stringify(expectedValue))>") { actualExpression, message in
         let actualValue = try actualExpression.evaluate()
         switch (expectedValue, actualValue) {
@@ -43,7 +43,7 @@ public func equalDiff<T>(_ expectedValue: T?, by areEquivalent: @escaping (T, T)
     }
 }
 
-/// Nimble matcher displaying equality differences in a friendly way.
+/// Matches against an expected equatable value, displaying mismatches in a user-readable form.
 public func equalDiff<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
     equalDiff(expectedValue, by: ==)
 }

--- a/Sources/Circumspect/Nimble.swift
+++ b/Sources/Circumspect/Nimble.swift
@@ -9,6 +9,7 @@ import Foundation
 /// Returns whether Nimble throw assertions are available or not.
 ///
 /// Call this function at the start of test methods using Nimble `throwAssertion()`. This ensures that:
+/// 
 /// - No crashes occur on tvOS when a debugger is attached.
 /// - Tests never run endlessly.
 public func nimbleThrowAssertionsAvailable() -> Bool {

--- a/Sources/Circumspect/Nimble.swift
+++ b/Sources/Circumspect/Nimble.swift
@@ -6,11 +6,15 @@
 
 import Foundation
 
-/// Use before tests using Nimble `throwAssertion()` which lead to crashes on tvOS if a debugger is attached, but
-/// also to tests never finishing in general.
-public func nimbleThrowAssertionsEnabled() -> Bool {
+/// Returns whether Nimble throw assertions are available or not.
+///
+/// Call this function at the start of test methods using Nimble `throwAssertion()`. This ensures that:
+///
+/// - No crashes occur on tvOS when a debugger is attached.
+/// - Tests never run endlessly.
+public func nimbleThrowAssertionsAvailable() -> Bool {
 #if os(tvOS)
-    if ProcessInfo.processInfo.environment["tvOSNimbleThrowAssertionsEnabled"] == "true" {
+    if ProcessInfo.processInfo.environment["tvOSnimbleThrowAssertionsAvailable"] == "true" {
         print("[INFO] This test contains Nimble throwing assertions and has been disabled.")
         return true
     }

--- a/Sources/Circumspect/Nimble.swift
+++ b/Sources/Circumspect/Nimble.swift
@@ -9,7 +9,6 @@ import Foundation
 /// Returns whether Nimble throw assertions are available or not.
 ///
 /// Call this function at the start of test methods using Nimble `throwAssertion()`. This ensures that:
-///
 /// - No crashes occur on tvOS when a debugger is attached.
 /// - Tests never run endlessly.
 public func nimbleThrowAssertionsAvailable() -> Bool {

--- a/Sources/Circumspect/ObservableObject.swift
+++ b/Sources/Circumspect/ObservableObject.swift
@@ -11,12 +11,13 @@ public extension ObservableObject {
     /// Creates a publisher providing the value of an observable object at the specified key path each time the
     /// object changes.
     ///
+    /// - Parameter keyPath: The key path to observe.
+    /// - Returns: A publisher emitting values for the observed key path each time the receiver changes.
+    ///
     /// This publisher makes it possible to generate an update stream for non-published properties of an observable
     /// object.
     ///
     /// Note that the current value is automatically emitted upon subscription.
-    /// - Parameter keyPath: The key path to observe.
-    /// - Returns: A publisher emitting values for the observed key path each time the receiver changes.
     func changePublisher<Output>(at keyPath: KeyPath<Self, Output>) -> AnyPublisher<Output, Never> {
         objectWillChange
             .receive(on: DispatchQueue.main)        // Simulates `objectDidChange` to ensure the object is up to date

--- a/Sources/Circumspect/ObservableObject.swift
+++ b/Sources/Circumspect/ObservableObject.swift
@@ -8,9 +8,13 @@ import Combine
 import Foundation
 
 public extension ObservableObject {
-    /// Create a publisher providing the value of an observable object at the specified key path each time the
-    /// object changes. Makes it possible to create a publisher also for non-published properties of an observable
-    /// object. Emits the current value upon subscription.
+    /// Creates a publisher providing the value of an observable object at the specified key path each time the
+    /// object changes.
+    ///
+    /// This publisher makes it possible to generate an update stream for non-published properties of an observable
+    /// object.
+    ///
+    /// Note that the current value is automatically emitted upon subscription.
     /// - Parameter keyPath: The key path to observe.
     /// - Returns: A publisher emitting values for the observed key path each time the receiver changes.
     func changePublisher<Output>(at keyPath: KeyPath<Self, Output>) -> AnyPublisher<Output, Never> {

--- a/Sources/Circumspect/Publishers.swift
+++ b/Sources/Circumspect/Publishers.swift
@@ -7,16 +7,10 @@
 import Combine
 import XCTest
 
-/// Ideas borrowed from https://www.swiftbysundell.com/articles/unit-testing-combine-based-swift-code/
+// Ideas borrowed from https://www.swiftbysundell.com/articles/unit-testing-combine-based-swift-code/
+
 public extension XCTestCase {
-    /// Wait for a publisher to complete and return its result.
-    /// - Parameters:
-    ///   - publisher: Publisher to monitor.
-    ///   - timeout: Timeout after which the expectation fails.
-    ///   - file: File where the expectation is made.
-    ///   - line: Line where the expectation is made.
-    ///   - executing: Code which must be executed while waiting on the expectation.
-    /// - Returns: The result of the publisher.
+    /// Waits for a publisher to complete and returns its result.
     @discardableResult
     func waitForResult<P: Publisher>(
         from publisher: P,
@@ -56,14 +50,7 @@ public extension XCTestCase {
         return try XCTUnwrap(result, "The publisher did not produce any result", file: file, line: line)
     }
 
-    /// Wait for a publisher to complete and return its output.
-    /// - Parameters:
-    ///   - publisher: Publisher to monitor.
-    ///   - timeout: Timeout after which the expectation fails.
-    ///   - file: File where the expectation is made.
-    ///   - line: Line where the expectation is made.
-    ///   - executing: Code which must be executed while waiting on the expectation.
-    /// - Returns: The collected output.
+    /// Waits for a publisher to complete and returns its output.
     @discardableResult
     func waitForOutput<P: Publisher>(
         from publisher: P,
@@ -82,14 +69,7 @@ public extension XCTestCase {
         return try result.get()
     }
 
-    /// Wait for a publisher to complete with a single output. Fails if not the case.
-    /// - Parameters:
-    ///   - publisher: Publisher to monitor.
-    ///   - timeout: Timeout after which the expectation fails.
-    ///   - file: File where the expectation is made.
-    ///   - line: Line where the expectation is made.
-    ///   - executing: Code which must be executed while waiting on the expectation.
-    /// - Returns: The output.
+    /// Waits for a publisher to complete with a single output. Fails if not the case.
     @discardableResult
     func waitForSingleOutput<P: Publisher>(
         from publisher: P,
@@ -112,14 +92,7 @@ public extension XCTestCase {
         return singleOutput
     }
 
-    /// Wait for a publisher to complete with a failure. Fails if not the case.
-    /// - Parameters:
-    ///   - publisher: Publisher to monitor.
-    ///   - timeout: Timeout after which the expectation fails.
-    ///   - file: File where the expectation is made.
-    ///   - line: Line where the expectation is made.
-    ///   - executing: Code which must be executed while waiting on the expectation.
-    /// - Returns: The failure reason.
+    /// Waits for a publisher to complete with a failure. Fails if not the case.
     @discardableResult
     func waitForFailure<P: Publisher>(
         from publisher: P,
@@ -144,14 +117,7 @@ public extension XCTestCase {
         }
     }
 
-    /// Collect output emitted by a publisher during some interval.
-    /// - Parameters:
-    ///   - publisher: Publisher to monitor.
-    ///   - interval: Timeout after which the expectation fails.
-    ///   - file: File where the expectation is made.
-    ///   - line: Line where the expectation is made.
-    ///   - executing: Code which must be executed while waiting on the expectation.
-    /// - Returns: The collected output.
+    /// Collects output emitted by a publisher during some interval.
     func collectOutput<P: Publisher>(
         from publisher: P,
         during interval: DispatchTimeInterval = .seconds(20),
@@ -180,14 +146,14 @@ public extension XCTestCase {
 }
 
 public extension Publisher where Failure == Never {
-    /// Collect the specified number of items (including the current one) before completing.
+    /// Collects the specified number of items (including the current one) before completing.
     func collectFirst(_ count: Int) -> AnyPublisher<[Output], Never> {
         collect(count)
             .first()
             .eraseToAnyPublisher()
     }
 
-    /// Collect the next number of items before completing.
+    /// Collects the next number of items before completing.
     func collectNext(_ count: Int) -> AnyPublisher<[Output], Never> {
         dropFirst()
             .collect(count)

--- a/Sources/Circumspect/Similarity.swift
+++ b/Sources/Circumspect/Similarity.swift
@@ -14,7 +14,7 @@ infix operator ~~ : ComparisonPrecedence
 /// You can implement similarity for types not conforming to `Equatable` but which still need to be meaningfully
 /// compared in tests.
 public protocol Similar {
-    /// Returns `true` iff the two sides can be considered to be similar.
+    /// Returns whether the two sides can be considered to be similar.
     static func ~~ (lhs: Self, rhs: Self) -> Bool
 }
 

--- a/Sources/Circumspect/Similarity.swift
+++ b/Sources/Circumspect/Similarity.swift
@@ -9,18 +9,21 @@ import Nimble
 
 infix operator ~~ : ComparisonPrecedence
 
-/// Defines similarity for types not conforming to `Equatable` and which need to be meaningfully compared in tests.
+/// A protocol to define similarity for types.
+///
+/// You can implement similarity for types not conforming to `Equatable` but which still need to be meaningfully
+/// compared in tests.
 public protocol Similar {
-    /// Must return `true` iff the two sides can be considered to be similar.
+    /// Returns `true` iff the two sides can be considered to be similar.
     static func ~~ (lhs: Self, rhs: Self) -> Bool
 }
 
-/// Nimble matcher displaying similarity differences in a friendly way.
+/// Matches against an expected similar value, displaying mismatches in a user-readable form.
 public func equalDiff<T: Similar>(_ expectedValue: T?) -> Nimble.Predicate<T> {
     equalDiff(expectedValue, by: ~~)
 }
 
-/// Nimble matcher displaying mismatches as differences.
+/// Matches against an expected similar value.
 public func equal<T: Similar>(_ expectedValue: T?) -> Nimble.Predicate<T> {
     equal(expectedValue, by: ~~)
 }

--- a/Sources/Circumspect/TimeInterval.swift
+++ b/Sources/Circumspect/TimeInterval.swift
@@ -7,7 +7,7 @@
 import Dispatch
 
 public extension DispatchTimeInterval {
-    /// Transform the receiver into a double.
+    /// Transforms the receiver into a double.
     func double() -> Double {
         switch self {
         case let .seconds(value):

--- a/Sources/Circumspect/XCTestCase.swift
+++ b/Sources/Circumspect/XCTestCase.swift
@@ -7,7 +7,7 @@
 import XCTest
 
 public extension XCTestCase {
-    /// Wait for a specified time interval.
+    /// Waits for a specified time interval.
     /// - Parameter interval: The wait interval.
     func wait(for interval: DispatchTimeInterval) {
         XCTWaiter().wait(for: [XCTestExpectation()], timeout: interval.double())

--- a/Sources/Circumspect/XCTestCase.swift
+++ b/Sources/Circumspect/XCTestCase.swift
@@ -8,6 +8,7 @@ import XCTest
 
 public extension XCTestCase {
     /// Waits for a specified time interval.
+    /// 
     /// - Parameter interval: The wait interval.
     func wait(for interval: DispatchTimeInterval) {
         XCTWaiter().wait(for: [XCTestExpectation()], timeout: interval.double())

--- a/Sources/Core/Array.swift
+++ b/Sources/Core/Array.swift
@@ -7,14 +7,14 @@
 import Foundation
 
 public extension Array where Element: Hashable {
-    /// Remove duplicates from the array.
-    /// - Returns: The array without duplicate items. Order is preserved.
+    /// Removes duplicates from the receiver, preserving the initial item order.
+    /// - Returns: The array without duplicate items.
     func removeDuplicates() -> [Element] {
         var itemDictionnary = [Element: Bool]()
         return filter { itemDictionnary.updateValue(true, forKey: $0) == nil }
     }
 
-    /// Return the item at the specified index in a safe way.
+    /// Safely returns the item at the specified index.
     /// - Parameter index: The index.
     /// - Returns: The item at the specified index or `nil` if the index is not within range.
     subscript(safeIndex index: Int) -> Element? {

--- a/Sources/Core/Array.swift
+++ b/Sources/Core/Array.swift
@@ -8,6 +8,7 @@ import Foundation
 
 public extension Array where Element: Hashable {
     /// Removes duplicates from the receiver, preserving the initial item order.
+    ///
     /// - Returns: The array without duplicate items.
     func removeDuplicates() -> [Element] {
         var itemDictionnary = [Element: Bool]()
@@ -15,6 +16,7 @@ public extension Array where Element: Hashable {
     }
 
     /// Safely returns the item at the specified index.
+    /// 
     /// - Parameter index: The index.
     /// - Returns: The item at the specified index or `nil` if the index is not within range.
     subscript(safeIndex index: Int) -> Element? {

--- a/Sources/Core/Binding.swift
+++ b/Sources/Core/Binding.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 public extension Binding {
     /// Creates a binding to an object key path.
+    /// 
     /// - Parameters:
     ///   - object: The object to bind to.
     ///   - keyPath: The key path to bind to.

--- a/Sources/Core/Binding.swift
+++ b/Sources/Core/Binding.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 public extension Binding {
-    /// Create a binding to an object property.
+    /// Creates a binding to an object key path.
     /// - Parameters:
     ///   - object: The object to bind to.
     ///   - keyPath: The key path to bind to.

--- a/Sources/Core/BodyCounter.swift
+++ b/Sources/Core/BodyCounter.swift
@@ -83,14 +83,15 @@ public extension View {
         }
     }
 
-    /// Decorate the view with a bordered debugging frame whose attached label displays how many times the view
+    /// Decorates the view with a bordered debugging frame whose attached label displays how many times the view
     /// body has been evaluated.
     ///
     /// This feature is only available in debug builds and requires the application to be run with the
-    /// `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set. It is also automatically enabled in Xcode previews.
+    /// `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set.
     ///
+    /// This feature is always automatically enabled in Xcode previews.
     /// - Parameters:
-    ///   - color: The frame and label color.
+    ///   - color: The frame color.
     func _debugBodyCounter(color: UIColor = .red) -> some View {
 #if DEBUG
         overlay(debugBodyCounterOverlay(color: color))

--- a/Sources/Core/BodyCounter.swift
+++ b/Sources/Core/BodyCounter.swift
@@ -86,12 +86,12 @@ public extension View {
     /// Decorates the view with a bordered debugging frame whose attached label displays how many times the view
     /// body has been evaluated.
     ///
+    /// - Parameter color: The frame color.
+    ///
     /// This feature is only available in debug builds and requires the application to be run with the
     /// `PILLARBOX_DEBUG_BODY_COUNTER` environment variable set.
     ///
     /// This feature is always automatically enabled in Xcode previews.
-    /// - Parameters:
-    ///   - color: The frame color.
     func _debugBodyCounter(color: UIColor = .red) -> some View {
 #if DEBUG
         overlay(debugBodyCounterOverlay(color: color))

--- a/Sources/Core/Comparable.swift
+++ b/Sources/Core/Comparable.swift
@@ -8,6 +8,7 @@ import Foundation
 
 public extension Comparable {
     /// Clamps a comparable value to a given range.
+    /// 
     /// - Parameter range: The range.
     /// - Returns: The value clamped to the specified range.
     func clamped(to range: ClosedRange<Self>) -> Self {

--- a/Sources/Core/Comparable.swift
+++ b/Sources/Core/Comparable.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 public extension Comparable {
-    /// Clamp a comparable value to a given range.
+    /// Clamps a comparable value to a given range.
     /// - Parameter range: The range.
     /// - Returns: The value clamped to the specified range.
     func clamped(to range: ClosedRange<Self>) -> Self {

--- a/Sources/Core/Publishers.swift
+++ b/Sources/Core/Publishers.swift
@@ -11,9 +11,10 @@ public extension Publishers {
     /// Accumulates the results of a list of publishers and delivers them as a stream of arrays containing the latest
     /// values in publisher order.
     ///
-    /// The first value is emitted once all publishers have at least emitted a value once.
     /// - Parameter publishers: The publishers to accumulate.
     /// - Returns: The resulting publisher.
+    ///
+    /// The first value is emitted once all publishers have at least emitted a value once.
     static func AccumulateLatestMany<Upstream>(
         _ publishers: Upstream...
     ) -> AnyPublisher<[Upstream.Output], Upstream.Failure> where Upstream: Publisher {
@@ -23,9 +24,10 @@ public extension Publishers {
     /// Accumulates the results of a list of publishers and delivers them as a stream of arrays containing the latest
     /// values in publisher order.
     ///
-    /// The first array is emitted once all publishers have at least emitted a value once.
     /// - Parameter publishers: The publishers to accumulate.
     /// - Returns: The resulting publisher.
+    ///
+    /// The first array is emitted once all publishers have at least emitted a value once.
     static func AccumulateLatestMany<Upstream, S>(
         _ publishers: S
     ) -> AnyPublisher<[Upstream.Output], Upstream.Failure> where Upstream: Publisher, S: Swift.Sequence, S.Element == Upstream {
@@ -61,6 +63,7 @@ public extension Publishers {
 
 public extension Publishers {
     /// Makes the upstream publisher publish each time another signal publisher emits some value.
+    ///
     /// - Parameters:
     ///   - signal: The signal to listen to. If `nil` the upstream publisher will never publish.
     ///   - publisher: The publisher to execute.
@@ -79,6 +82,7 @@ public extension Publishers {
     }
 
     /// Makes the upstream publisher execute once and repeat each time another signal publisher emits some value.
+    ///
     /// - Parameters:
     ///   - signal: The signal to listen to. If `nil` the upstream publisher executes only once.
     ///   - publisher: The publisher to execute.
@@ -108,6 +112,8 @@ public extension Publisher {
     /// Includes the current element as well as the previous element from the upstream publisher in a tuple where the
     /// previous element is optional.
     ///
+    /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
+    ///
     /// The first time the upstream publisher emits an element, the previous element will be `nil`.
     ///
     /// ```swift
@@ -117,8 +123,6 @@ public extension Publisher {
     ///     .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
     /// // Prints: "(nil, 1) (Optional(1), 2) (Optional(2), 3) (Optional(3), 4) (Optional(4), 5) ".
     /// ```
-    ///
-    /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
     func withPrevious() -> AnyPublisher<(previous: Output?, current: Output), Failure> {
         scan(Optional<(Output?, Output)>.none) { ($0?.1, $1) }
             .compactMap { $0 }
@@ -127,6 +131,10 @@ public extension Publisher {
 
     /// Includes the current element as well as the previous element from the upstream publisher in a tuple where the
     /// previous element is not optional.
+    ///
+    /// - Parameter initialPreviousValue: The initial value to use as the previous value when the upstream publisher
+    ///   emits for the first time.
+    /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
     ///
     /// The first time the upstream publisher emits an element, the previous element will be the `initialPreviousValue`.
     ///
@@ -137,10 +145,6 @@ public extension Publisher {
     ///     .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
     /// // Prints: "(0, 1) (1, 2) (2, 3) (3, 4) (4, 5) ".
     /// ```
-    ///
-    /// - Parameter initialPreviousValue: The initial value to use as the previous value when the upstream publisher
-    ///   emits for the first time.
-    /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
     func withPrevious(_ initialPreviousValue: Output) -> AnyPublisher<(previous: Output, current: Output), Failure> {
         scan((initialPreviousValue, initialPreviousValue)) { ($0.1, $1) }.eraseToAnyPublisher()
     }
@@ -149,14 +153,14 @@ public extension Publisher {
 public extension NotificationCenter {
     /// Returns a publisher that emits events when broadcasting notifications.
     ///
-    /// Unlike usual notification publishers this publisher does not retain the observed object, preventing reference
-    /// cycles.
-    ///
     /// - Parameters:
     ///   - name: The name of the notification to publish.
     ///   - object: The object posting the named notification. If `nil` the publisher emits elements for any object
     ///   producing a notification with the given name.
     /// - Returns: A publisher that emits events when broadcasting notifications.
+    ///
+    /// Unlike usual notification publishers this publisher does not retain the observed object, preventing reference
+    /// cycles.
     func weakPublisher<T: AnyObject>(for name: Notification.Name, object: T?) -> AnyPublisher<Notification, Never> {
         if let object {
             return publisher(for: name)
@@ -180,12 +184,13 @@ public extension NotificationCenter {
 public extension Publisher {
     /// Captures an object weakly and provides one of its properties as additional output.
     ///
-    /// Does not emit when the object is `nil`.
     /// - Parameters:
     ///   - other: The object to weakly capture.
     ///   - keyPath: The key path for which to provide values.
     /// - Returns: A publisher combining the original output with values from the weakly captured object at the
-    /// specified key path.
+    ///   specified key path.
+    ///
+    /// Does not emit when the object is `nil`.
     func weakCapture<T: AnyObject, V>(_ other: T?, at keyPath: KeyPath<T, V>) -> AnyPublisher<(Output, V), Failure> {
         compactMap { [weak other] output -> (Output, V)? in
             guard let other else { return nil }
@@ -196,15 +201,16 @@ public extension Publisher {
 
     /// Captures an object weakly and provides it as additional output.
     ///
-    /// Does not emit when the object is `nil`.
-    /// - Parameters:
-    ///   - other: The object to weakly capture.
+    /// - Parameter other: The object to weakly capture.
     /// - Returns: A publisher combining the original output with the weakly captured object (if not `nil`).
+    ///
+    /// Does not emit when the object is `nil`.
     func weakCapture<T: AnyObject>(_ other: T?) -> AnyPublisher<(Output, T), Failure> {
         weakCapture(other, at: \T.self)
     }
 
     /// Safely receives elements from the upstream on the main thread.
+    /// 
     /// - Returns: A publisher delivering elements on the main thread.
     func receiveOnMainThread() -> AnyPublisher<Output, Failure> {
         map { output in

--- a/Sources/Core/Publishers.swift
+++ b/Sources/Core/Publishers.swift
@@ -8,8 +8,10 @@ import Combine
 import Foundation
 
 public extension Publishers {
-    /// Accumulate the results of a list of publishers and deliver them as a stream of arrays containing the latest
-    /// values in publisher order. The first array is emitted once all publishers have at least emitted a value once.
+    /// Accumulates the results of a list of publishers and delivers them as a stream of arrays containing the latest
+    /// values in publisher order.
+    ///
+    /// The first value is emitted once all publishers have at least emitted a value once.
     /// - Parameter publishers: The publishers to accumulate.
     /// - Returns: The resulting publisher.
     static func AccumulateLatestMany<Upstream>(
@@ -18,8 +20,10 @@ public extension Publishers {
         AccumulateLatestMany(publishers)
     }
 
-    /// Accumulate the results of a list of publishers and deliver them as a stream of arrays containing the latest
-    /// values in publisher order. The first array is emitted once all publishers have at least emitted a value once.
+    /// Accumulates the results of a list of publishers and delivers them as a stream of arrays containing the latest
+    /// values in publisher order.
+    ///
+    /// The first array is emitted once all publishers have at least emitted a value once.
     /// - Parameter publishers: The publishers to accumulate.
     /// - Returns: The resulting publisher.
     static func AccumulateLatestMany<Upstream, S>(
@@ -56,10 +60,9 @@ public extension Publishers {
 }
 
 public extension Publishers {
-    /// Make the upstream publisher publish each time a second signal publisher emits some value. If no signal is provided
-    /// the publisher never executes.
+    /// Makes the upstream publisher publish each time another signal publisher emits some value.
     /// - Parameters:
-    ///   - signal: The signal to listen to.
+    ///   - signal: The signal to listen to. If `nil` the upstream publisher will never publish.
     ///   - publisher: The publisher to execute.
     /// - Returns: The resulting publisher.
     static func Publish<S, P>(
@@ -75,10 +78,9 @@ public extension Publishers {
             .eraseToAnyPublisher()
     }
 
-    /// Make the upstream publisher execute once and repeat each time a second signal publisher emits some value. If no
-    /// signal is provided the publisher simply executes once and never repeats.
+    /// Makes the upstream publisher execute once and repeat each time another signal publisher emits some value.
     /// - Parameters:
-    ///   - signal: The signal to listen to.
+    ///   - signal: The signal to listen to. If `nil` the upstream publisher executes only once.
     ///   - publisher: The publisher to execute.
     /// - Returns: The resulting publisher.
     static func PublishAndRepeat<S, P>(
@@ -101,16 +103,20 @@ public extension Publishers {
 }
 
 // Borrowed from https://stackoverflow.com/a/67133582/760435
+
 public extension Publisher {
     /// Includes the current element as well as the previous element from the upstream publisher in a tuple where the
-    /// previous element is optional. The first time the upstream publisher emits an element, the previous element will
-    /// be `nil`.
+    /// previous element is optional.
     ///
-    ///     let range = (1...5)
-    ///     cancellable = range.publisher
-    ///         .withPrevious()
-    ///         .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
-    ///      // Prints: "(nil, 1) (Optional(1), 2) (Optional(2), 3) (Optional(3), 4) (Optional(4), 5) ".
+    /// The first time the upstream publisher emits an element, the previous element will be `nil`.
+    ///
+    /// ```swift
+    /// let range = (1...5)
+    /// cancellable = range.publisher
+    ///     .withPrevious()
+    ///     .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
+    /// // Prints: "(nil, 1) (Optional(1), 2) (Optional(2), 3) (Optional(3), 4) (Optional(4), 5) ".
+    /// ```
     ///
     /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
     func withPrevious() -> AnyPublisher<(previous: Output?, current: Output), Failure> {
@@ -120,16 +126,19 @@ public extension Publisher {
     }
 
     /// Includes the current element as well as the previous element from the upstream publisher in a tuple where the
-    /// previous element is not optional. The first time the upstream publisher emits an element, the previous element
-    /// will be the `initialPreviousValue`.
+    /// previous element is not optional.
     ///
-    ///     let range = (1...5)
-    ///     cancellable = range.publisher
-    ///         .withPrevious(0)
-    ///         .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
-    ///      // Prints: "(0, 1) (1, 2) (2, 3) (3, 4) (4, 5) ".
+    /// The first time the upstream publisher emits an element, the previous element will be the `initialPreviousValue`.
     ///
-    /// - Parameter initialPreviousValue: The initial value to use as the "previous" value when the upstream publisher
+    /// ```swift
+    /// let range = (1...5)
+    /// cancellable = range.publisher
+    ///     .withPrevious(0)
+    ///     .sink { print ("(\($0.previous), \($0.current))", terminator: " ") }
+    /// // Prints: "(0, 1) (1, 2) (2, 3) (3, 4) (4, 5) ".
+    /// ```
+    ///
+    /// - Parameter initialPreviousValue: The initial value to use as the previous value when the upstream publisher
     ///   emits for the first time.
     /// - Returns: A publisher of a tuple of the previous and current elements from the upstream publisher.
     func withPrevious(_ initialPreviousValue: Output) -> AnyPublisher<(previous: Output, current: Output), Failure> {
@@ -138,12 +147,16 @@ public extension Publisher {
 }
 
 public extension NotificationCenter {
-    /// The usual notification publisher retains the observed object, potentially creating cycles. The following
-    /// publisher avoids this issue by only weakly capturing the observed object.
+    /// Returns a publisher that emits events when broadcasting notifications.
+    ///
+    /// Unlike usual notification publishers this publisher does not retain the observed object, preventing reference
+    /// cycles.
+    ///
     /// - Parameters:
-    ///   - name: The notification to observe.
-    ///   - object: The object to observe (weakly captured).
-    /// - Returns: A notification publisher.
+    ///   - name: The name of the notification to publish.
+    ///   - object: The object posting the named notification. If `nil` the publisher emits elements for any object
+    ///   producing a notification with the given name.
+    /// - Returns: A publisher that emits events when broadcasting notifications.
     func weakPublisher<T: AnyObject>(for name: Notification.Name, object: T?) -> AnyPublisher<Notification, Never> {
         if let object {
             return publisher(for: name)
@@ -165,12 +178,14 @@ public extension NotificationCenter {
 }
 
 public extension Publisher {
-    /// Capture another object weakly and provide one of its properties as additional output. Does not emit when the
-    /// object is `nil`.
+    /// Captures an object weakly and provides one of its properties as additional output.
+    ///
+    /// Does not emit when the object is `nil`.
     /// - Parameters:
-    ///   - other: The other object to weakly capture.
+    ///   - other: The object to weakly capture.
     ///   - keyPath: The key path for which to provide values.
-    /// - Returns: A publisher combining the original output with properties from the weakly captured object.
+    /// - Returns: A publisher combining the original output with values from the weakly captured object at the
+    /// specified key path.
     func weakCapture<T: AnyObject, V>(_ other: T?, at keyPath: KeyPath<T, V>) -> AnyPublisher<(Output, V), Failure> {
         compactMap { [weak other] output -> (Output, V)? in
             guard let other else { return nil }
@@ -179,15 +194,17 @@ public extension Publisher {
         .eraseToAnyPublisher()
     }
 
-    /// Capture another object weakly and provide it as additional output. Does not emit when the object is `nil`.
+    /// Captures an object weakly and provides it as additional output.
+    ///
+    /// Does not emit when the object is `nil`.
     /// - Parameters:
-    ///   - other: The other object to weakly capture.
+    ///   - other: The object to weakly capture.
     /// - Returns: A publisher combining the original output with the weakly captured object (if not `nil`).
     func weakCapture<T: AnyObject>(_ other: T?) -> AnyPublisher<(Output, T), Failure> {
         weakCapture(other, at: \T.self)
     }
 
-    /// Safely receive elements from the publisher on the main thread.
+    /// Safely receives elements from the upstream on the main thread.
     /// - Returns: A publisher delivering elements on the main thread.
     func receiveOnMainThread() -> AnyPublisher<Output, Failure> {
         map { output in

--- a/Sources/Core/RangeReplaceableCollection.swift
+++ b/Sources/Core/RangeReplaceableCollection.swift
@@ -8,6 +8,7 @@ import Foundation
 
 public extension RangeReplaceableCollection {
     /// Moves an item from a given index to another one in the receiver.
+    /// 
     /// - Parameters:
     ///   - fromIndex: The index of the item to move.
     ///   - index: The index of the item before which the item must be inserted. Use `endIndex` to move an item to

--- a/Sources/Core/RangeReplaceableCollection.swift
+++ b/Sources/Core/RangeReplaceableCollection.swift
@@ -7,11 +7,11 @@
 import Foundation
 
 public extension RangeReplaceableCollection {
-    /// Move an item from a given index to another one in the collection.
+    /// Moves an item from a given index to another one in the receiver.
     /// - Parameters:
     ///   - fromIndex: The index of the item to move.
     ///   - index: The index of the item before which the item must be inserted. Use `endIndex` to move an item to
-    ///     the back of the collection.
+    ///     the back of the receiver.
     mutating func move(from fromIndex: Index, to index: Index) {
         guard fromIndex != index else { return }
         if fromIndex > index {

--- a/Sources/Core/Time.swift
+++ b/Sources/Core/Time.swift
@@ -7,12 +7,12 @@
 import AVFoundation
 
 public extension CMTimeRange {
-    /// A Boolean value that indicates whether the time range is valid and not empty.
+    /// Returns a Boolean value that indicates whether the time range is valid and not empty.
     var isValidAndNotEmpty: Bool {
         isValid && !isEmpty
     }
 
-    /// Return a time range comparator having some tolerance.
+    /// Returns a time range comparator having some tolerance.
     static func close(within tolerance: CMTime) -> ((CMTimeRange?, CMTimeRange?) -> Bool) {
         precondition(CMTimeCompare(tolerance, .zero) == 1)
         let timeClose = CMTime.close(within: tolerance)
@@ -28,14 +28,14 @@ public extension CMTimeRange {
         }
     }
 
-    /// Return a time range comparator having some tolerance.
+    /// Returns a time range comparator having some tolerance.
     static func close(within tolerance: TimeInterval) -> ((CMTimeRange?, CMTimeRange?) -> Bool) {
         close(within: CMTimeMakeWithSeconds(tolerance, preferredTimescale: Int32(NSEC_PER_SEC)))
     }
 }
 
 public extension CMTime {
-    /// Return a time comparator having some tolerance.
+    /// Returns a time comparator having some tolerance.
     static func close(within tolerance: CMTime) -> ((CMTime?, CMTime?) -> Bool) {
         precondition(CMTimeCompare(.zero, tolerance) != 1)
         return { time1, time2 in
@@ -50,7 +50,7 @@ public extension CMTime {
         }
     }
 
-    /// Return a time comparator having some tolerance.
+    /// Returns a time comparator having some tolerance.
     static func close(within tolerance: TimeInterval) -> ((CMTime?, CMTime?) -> Bool) {
         close(within: CMTimeMakeWithSeconds(tolerance, preferredTimescale: Int32(NSEC_PER_SEC)))
     }

--- a/Sources/Core/Trigger.swift
+++ b/Sources/Core/Trigger.swift
@@ -23,6 +23,7 @@ public struct Trigger {
     public init() {}
 
     /// Creates an associated signal activated by some integer index.
+    ///
     /// - Parameter index: The index used for activation.
     /// - Returns: The signal.
     public func signal(activatedBy index: Index) -> Signal {
@@ -34,8 +35,9 @@ public struct Trigger {
 
     /// Activates associated signal publishers matching the provided integer index.
     ///
-    /// Signal publishers emit a single void value upon activation.
     /// - Parameter index: The index used for activation.
+    ///
+    /// Signal publishers emit a single void value upon activation.
     public func activate(for index: Index) {
         sender.send(index)
     }
@@ -43,6 +45,7 @@ public struct Trigger {
 
 public extension Trigger {
     /// Creates an associated signal activated by some hashable value.
+    ///
     /// - Parameter t: The hashable value used for activation.
     /// - Returns: The signal.
     func signal<T>(activatedBy t: T) -> Signal where T: Hashable {
@@ -51,8 +54,9 @@ public extension Trigger {
 
     /// Activates associated signal publishers matching the provided hashable value.
     ///
-    /// Signal publishers emit a single void value upon activation.
     /// - Parameter t: The hashable value used for activation.
+    ///
+    /// Signal publishers emit a single void value upon activation.
     func activate<T>(for t: T) where T: Hashable {
         activate(for: t.hashValue)
     }

--- a/Sources/Core/Trigger.swift
+++ b/Sources/Core/Trigger.swift
@@ -6,9 +6,10 @@
 
 import Combine
 
-/// A trigger is a device used to control a set of signal publishers. Signal publishers are publishers remotely
-/// controlled by the trigger and which emit a void value when activated. Signal publishers never complete and thus
-/// can be activated as many times as needed.
+/// A device used to control a set of other publishers.
+///
+/// A trigger is a small device from which other publishers, called signal publishers, can be created. These publishers
+/// can be activated at any time by the trigger.
 public struct Trigger {
     /// The index type.
     public typealias Index = Int
@@ -18,10 +19,10 @@ public struct Trigger {
 
     private let sender = PassthroughSubject<Index, Never>()
 
-    /// Create a trigger.
+    /// Creates a trigger.
     public init() {}
 
-    /// Create an associated signal activated by some integer index.
+    /// Creates an associated signal activated by some integer index.
     /// - Parameter index: The index used for activation.
     /// - Returns: The signal.
     public func signal(activatedBy index: Index) -> Signal {
@@ -31,26 +32,26 @@ public struct Trigger {
             .eraseToAnyPublisher()
     }
 
-    /// Activate associated signal publishers matching the provided integer index, making them emit a single void value.
+    /// Activates associated signal publishers matching the provided integer index.
+    ///
+    /// Signal publishers emit a single void value upon activation.
     /// - Parameter index: The index used for activation.
     public func activate(for index: Index) {
         sender.send(index)
     }
 }
 
-/**
- *  Extension for using hashable types as indices.
- */
-
 public extension Trigger {
-    /// Create an associated signal activated by some hashable value.
+    /// Creates an associated signal activated by some hashable value.
     /// - Parameter t: The hashable value used for activation.
     /// - Returns: The signal.
     func signal<T>(activatedBy t: T) -> Signal where T: Hashable {
         signal(activatedBy: t.hashValue)
     }
 
-    /// Activate associated signal publishers matching the provided hashable value, making them emit a single void value.
+    /// Activates associated signal publishers matching the provided hashable value.
+    ///
+    /// Signal publishers emit a single void value upon activation.
     /// - Parameter t: The hashable value used for activation.
     func activate<T>(for t: T) where T: Hashable {
         activate(for: t.hashValue)

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -6,11 +6,11 @@
 
 import Foundation
 
-/// Server.
+/// A server environment.
 public enum Server {
     /// Production.
     case production
-    /// State.
+    /// Stage.
     case stage
     /// Test.
     case test

--- a/Sources/CoreBusiness/Extensions/URLSession.swift
+++ b/Sources/CoreBusiness/Extensions/URLSession.swift
@@ -7,28 +7,24 @@
 import Foundation
 
 extension URLSession {
-    /// Convenience method to load data using an URLRequest, creates and resumes an `URLSessionDataTask` internally.
-    /// Same as `data(for:delegate:)` but throwing HTTP errors when encountered.
-    ///
-    /// - Parameter request: The URLRequest for which to load data.
-    /// - Parameter delegate: Task-specific delegate.
+    /// Loads data for a request, throwing when HTTP errors are encountered.
+    /// - Parameter request: The request for which to load data.
+    /// - Parameter delegate: The task-specific delegate.
     /// - Returns: Data and response.
     func httpData(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
-        let (data, response) = try await data(for: request)
+        let (data, response) = try await data(for: request, delegate: delegate)
         if let httpError = DataError.http(from: response) {
             throw httpError
         }
         return (data, response)
     }
 
-    /// Convenience method to load data using an URL, creates and resumes an `URLSessionDataTask` internally. Same
-    /// as `data(from:delegate:)` but throwing HTTP errors when encountered.
-    ///
+    /// Loads data for a URL, throwing when HTTP errors are encountered.
     /// - Parameter url: The URL for which to load data.
-    /// - Parameter delegate: Task-specific delegate.
+    /// - Parameter delegate: The task-specific delegate.
     /// - Returns: Data and response.
     func httpData(from url: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
-        let (data, response) = try await data(from: url)
+        let (data, response) = try await data(from: url, delegate: delegate)
         if let httpError = DataError.http(from: response) {
             throw httpError
         }

--- a/Sources/CoreBusiness/Extensions/URLSession.swift
+++ b/Sources/CoreBusiness/Extensions/URLSession.swift
@@ -8,8 +8,10 @@ import Foundation
 
 extension URLSession {
     /// Loads data for a request, throwing when HTTP errors are encountered.
-    /// - Parameter request: The request for which to load data.
-    /// - Parameter delegate: The task-specific delegate.
+    ///
+    /// - Parameters:
+    ///   - request: The request for which to load data.
+    ///   - delegate: The task-specific delegate to use.
     /// - Returns: Data and response.
     func httpData(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
         let (data, response) = try await data(for: request, delegate: delegate)
@@ -20,8 +22,10 @@ extension URLSession {
     }
 
     /// Loads data for a URL, throwing when HTTP errors are encountered.
-    /// - Parameter url: The URL for which to load data.
-    /// - Parameter delegate: The task-specific delegate.
+    ///
+    /// - Parameters:
+    ///   - url: The URL for which to load data.
+    ///   - delegate: The task-specific delegate to use.
     /// - Returns: Data and response.
     func httpData(from url: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
         let (data, response) = try await data(from: url, delegate: delegate)

--- a/Sources/CoreBusiness/Model/BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/BlockingReason.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Content blocking reasons.
+/// A content blocking reason.
 public enum BlockingReason: String, Decodable {
     /// Not suitable under the age of 12.
     case ageRating12 = "AGERATING12"
@@ -32,7 +32,7 @@ public enum BlockingReason: String, Decodable {
     /// Unknown reason.
     case unknown = "UNKNOWN"
 
-    /// A standard description for the blocking reason.
+    /// The standard description for the blocking reason.
     public var description: String {
         switch self {
         case .ageRating12:

--- a/Sources/CoreBusiness/Model/Chapter.swift
+++ b/Sources/CoreBusiness/Model/Chapter.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Content associated with a playback context and providing a playable resource.
+/// A content providing a playable resource.
 public struct Chapter: Decodable {
     enum CodingKeys: String, CodingKey {
         case _analyticsData = "analyticsData"
@@ -34,7 +34,9 @@ public struct Chapter: Decodable {
     /// The chapter description.
     public let description: String?
 
-    /// The chapter image URL. Use `SRGDataProvider.imagePublisher(for:width:)` to obtain a scaled downloadable version.
+    /// The chapter image URL.
+    ///
+    /// Use `SRGDataProvider.imagePublisher(for:width:)` to obtain a scaled downloadable version.
     public let imageUrl: URL
 
     /// The content type.
@@ -43,7 +45,7 @@ public struct Chapter: Decodable {
     /// The publication date.
     public let date: Date
 
-    /// Available resources.
+    /// The available resources.
     public let resources: [Resource]
 
     /// The date at which the content is made available.

--- a/Sources/CoreBusiness/Model/Chapter.swift
+++ b/Sources/CoreBusiness/Model/Chapter.swift
@@ -70,6 +70,7 @@ public struct Chapter: Decodable {
     private let _analyticsMetadata: [String: String]?
 
     /// Returns whether the content is blocked for some reason.
+    /// 
     /// - Parameter date: The date at which the availability must be evaluated.
     /// - Returns: The blocking reason.
     public func blockingReason(at date: Date = Date()) -> BlockingReason? {

--- a/Sources/CoreBusiness/Model/DRM.swift
+++ b/Sources/CoreBusiness/Model/DRM.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-/// Describes DRM protection.
+/// A DRM protection description.
 public struct DRM: Decodable {
-    /// DRM types.
+    /// A DRM type.
     public enum `Type`: String, Decodable {
         /// FairPlay.
         case fairPlay = "FAIRPLAY"

--- a/Sources/CoreBusiness/Model/MediaComposition.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Describes a playback context.
+/// A description of a playback context.
 public struct MediaComposition: Decodable {
     enum CodingKeys: String, CodingKey {
         case _analyticsData = "analyticsData"
@@ -16,7 +16,7 @@ public struct MediaComposition: Decodable {
         case show
     }
 
-    /// The URN of the chapter to be played..
+    /// The URN of the chapter to be played.
     public let chapterUrn: String
 
     /// The available chapters.

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -55,7 +55,7 @@ public struct MediaMetadata: AssetMetadata {
         resource.streamType
     }
 
-    /// Consolidated comScore analytics data.
+    /// The consolidated comScore analytics data.
     var analyticsData: [String: String] {
         var analyticsData = mediaComposition.mainChapter.analyticsData
         guard !analyticsData.isEmpty else { return [:] }
@@ -64,7 +64,7 @@ public struct MediaMetadata: AssetMetadata {
         return analyticsData
     }
 
-    /// Consolidated Commanders Act analytics data.
+    /// The consolidated Commanders Act analytics data.
     var analyticsMetadata: [String: String] {
         var analyticsMetadata = mediaComposition.mainChapter.analyticsMetadata
         guard !analyticsMetadata.isEmpty else { return [:] }

--- a/Sources/CoreBusiness/Model/Resource.swift
+++ b/Sources/CoreBusiness/Model/Resource.swift
@@ -7,7 +7,7 @@
 import Foundation
 import Player
 
-/// Describes a playable resource.
+/// A description of a playable resource.
 public struct Resource: Decodable {
     enum CodingKeys: String, CodingKey {
         case _analyticsData = "analyticsData"

--- a/Sources/CoreBusiness/Model/Show.swift
+++ b/Sources/CoreBusiness/Model/Show.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Describes a show.
+/// A show description.
 public struct Show: Decodable {
     /// The show title.
     public let title: String

--- a/Sources/CoreBusiness/Model/StreamingMethod.swift
+++ b/Sources/CoreBusiness/Model/StreamingMethod.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-/// Streaming methods.
+/// A streaming method description.
 public enum StreamingMethod: String, Decodable {
-    /// Progressive stream.
+    /// Progressive streaming.
     case progressive = "PROGRESSIVE"
 
     /// M3U8 streaming.
@@ -35,7 +35,7 @@ public enum StreamingMethod: String, Decodable {
     /// Unknown.
     case unknown = "UNKNOWN"
 
-    /// Supported streaming methods on Apple platforms.
+    /// The supported streaming methods on Apple platforms.
     public static var supportedMethods: [Self] {
         [.progressive, .m3uPlaylist, .hls, .http, .https]
     }

--- a/Sources/CoreBusiness/Model/TokenType.swift
+++ b/Sources/CoreBusiness/Model/TokenType.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Token types.
+/// A token type.
 public enum TokenType: String, Decodable {
     /// No token.
     case none = "NONE"

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -11,7 +11,9 @@ import Player
 import UIKit
 
 public extension PlayerItem {
-    /// Create a player item from a URN.
+    /// Creates a player item from a URN.
+    ///
+    /// The item is automatically tracked according to SRG SSR analytics standards.
     /// - Parameters:
     ///   - urn: The URN to play.
     ///   - server: The server which the URN is played from.

--- a/Sources/CoreBusiness/PlayerItem.swift
+++ b/Sources/CoreBusiness/PlayerItem.swift
@@ -13,10 +13,11 @@ import UIKit
 public extension PlayerItem {
     /// Creates a player item from a URN.
     ///
-    /// The item is automatically tracked according to SRG SSR analytics standards.
     /// - Parameters:
     ///   - urn: The URN to play.
     ///   - server: The server which the URN is played from.
+    ///
+    /// The item is automatically tracked according to SRG SSR analytics standards.
     static func urn(
         _ urn: String,
         server: Server = .production,

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -216,7 +216,7 @@ public extension Asset where M == Never {
 
 extension Asset {
     static var loading: Self {
-        // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
+        // Provides a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
         .init(
             id: UUID(),
             resource: .custom(url: URL(string: "pillarbox://loading.m3u8")!, delegate: LoadingResourceLoaderDelegate()),
@@ -227,7 +227,7 @@ extension Asset {
     }
 
     static func failed(error: Error) -> Self {
-        // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
+        // Provides a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
         .init(
             id: UUID(),
             resource: .custom(url: URL(string: "pillarbox://failing.m3u8")!, delegate: FailedResourceLoaderDelegate(error: error)),

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -33,7 +33,8 @@ public struct Asset<M: AssetMetadata>: Assetable {
     private let configuration: (AVPlayerItem) -> Void
     private let trackerAdapters: [TrackerAdapter<M>]
 
-    /// A simple asset playable from a URL.
+    /// Returns a simple asset playable from a URL.
+    /// 
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - metadata: The metadata associated with the asset.
@@ -53,14 +54,16 @@ public struct Asset<M: AssetMetadata>: Assetable {
         )
     }
 
-    /// An asset loaded with custom resource loading. The scheme of the URL to be played has to be recognized by
-    /// the associated resource loader delegate.
+    /// Returns an asset loaded with custom resource loading.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The custom resource loader to use.
     ///   - metadata: The metadata associated with the asset.
     ///   - configuration: A closure to configure player items created from the receiver.
     /// - Returns: The asset.
+    ///
+    /// The scheme of the URL to be played has to be recognized by the associated resource loader delegate.
     public static func custom(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -76,7 +79,8 @@ public struct Asset<M: AssetMetadata>: Assetable {
         )
     }
 
-    /// An encrypted asset loaded with a content key session.
+    /// Returns an encrypted asset loaded with a content key session.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The content key session delegate to use.
@@ -146,7 +150,8 @@ public struct Asset<M: AssetMetadata>: Assetable {
 }
 
 public extension Asset where M == Never {
-    /// A simple asset playable from a URL.
+    /// Returns a simple asset playable from a URL.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - configuration: A closure to configure player items created from the receiver.
@@ -164,13 +169,15 @@ public extension Asset where M == Never {
         )
     }
 
-    /// An asset loaded with custom resource loading. The scheme of the URL to be played has to be recognized by
-    /// the associated resource loader delegate.
+    /// Returns an asset loaded with custom resource loading.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The custom resource loader to use.
     ///   - configuration: A closure to configure player items created from the receiver.
     /// - Returns: The asset.
+    ///
+    /// The scheme of the URL to be played has to be recognized by the associated resource loader delegate.
     static func custom(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -185,7 +192,8 @@ public extension Asset where M == Never {
         )
     }
 
-    /// An encrypted asset loaded with a content key session.
+    /// Returns an encrypted asset loaded with a content key session.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The content key session delegate to use.
@@ -241,7 +249,8 @@ extension AVPlayerItem {
         }
     }
 
-    /// Assign an identifier to identify player items delivered by the same data source.
+    /// Assigns an identifier to identify player items delivered by the same data source.
+    /// 
     /// - Parameter id: The id to assign.
     /// - Returns: The receiver with the id assigned to it.
     fileprivate func withId(_ id: UUID) -> AVPlayerItem {

--- a/Sources/Player/ControlCenter/NowPlaying.swift
+++ b/Sources/Player/ControlCenter/NowPlaying.swift
@@ -7,21 +7,23 @@
 import CoreMedia
 import UIKit
 
-/// Metadata used to display what is currently being played, most notably in the Control Center.
+/// Metadata providing information about what is currently being played.
+///
+/// This metadata is most notably displayed in the Control Center.
 public struct NowPlayingMetadata {
-    /// Title.
+    /// The title.
     let title: String?
 
-    /// Subtitle.
+    /// The subtitle.
     let subtitle: String?
 
-    /// Description.
+    /// The description.
     let description: String?
 
-    /// Image.
+    /// The image suitable for artwork display.
     let image: UIImage?
 
-    /// Create a now playing metadata.
+    /// Creates now playing metadata.
     public init(title: String? = nil, subtitle: String? = nil, description: String? = nil, image: UIImage? = nil) {
         self.title = title
         self.subtitle = subtitle
@@ -30,12 +32,12 @@ public struct NowPlayingMetadata {
     }
 }
 
-/// Types related to current metadata display in the control center.
+/// A type providing Control Center metadata.
 public enum NowPlaying {
-    /// Now playing information.
+    /// Standard now playing metadata.
     public typealias Info = [String: Any]
 
-    /// Playback properties for the now playing item.
+    /// A list of properties for the now playing item.
     struct Properties {
         let timeRange: CMTimeRange
         let itemDuration: CMTime

--- a/Sources/Player/Extensions/AVContentKeyRequest.swift
+++ b/Sources/Player/Extensions/AVContentKeyRequest.swift
@@ -7,9 +7,10 @@
 import AVFoundation
 
 public extension AVContentKeyRequest {
-    /// Informs the receiver that obtaining a content key response has failed, resulting in failure handling. Unlike
-    /// `processContentKeyResponseError(_:)` this method ensures error information can be reliably forwarded to the
-    /// player item being loaded in case of failure.
+    /// Informs the receiver that obtaining a content key response has failed, resulting in failure handling.
+    ///
+    /// Unlike `processContentKeyResponseError(_:)` this method ensures error information can be reliably
+    /// forwarded to the player item being loaded in case of failure.
     /// - Parameter error: An error object indicating the reason for the failure.
     func processContentKeyResponseErrorReliably(_ error: Error) {
         if let nsError = NSError.error(from: error) {

--- a/Sources/Player/Extensions/AVContentKeyRequest.swift
+++ b/Sources/Player/Extensions/AVContentKeyRequest.swift
@@ -9,9 +9,10 @@ import AVFoundation
 public extension AVContentKeyRequest {
     /// Informs the receiver that obtaining a content key response has failed, resulting in failure handling.
     ///
+    /// - Parameter error: An error object indicating the reason for the failure.
+    ///
     /// Unlike `processContentKeyResponseError(_:)` this method ensures error information can be reliably
     /// forwarded to the player item being loaded in case of failure.
-    /// - Parameter error: An error object indicating the reason for the failure.
     func processContentKeyResponseErrorReliably(_ error: Error) {
         if let nsError = NSError.error(from: error) {
             processContentKeyResponseError(nsError)

--- a/Sources/Player/Extensions/AVPlayer.swift
+++ b/Sources/Player/Extensions/AVPlayer.swift
@@ -7,12 +7,16 @@
 import AVFoundation
 
 extension AVPlayer {
-    /// The available time range or `.invalid` when not known.
+    /// The available time range.
+    ///
+    /// Returns `.invalid` when the time range is unknown.
     var timeRange: CMTimeRange {
         currentItem?.timeRange ?? .invalid
     }
 
-    /// The current item duration or `.invalid` when not known.
+    /// The current item duration.
+    ///
+    /// Returns `.invalid` when the duration is unknown.
     var itemDuration: CMTime {
         guard let currentItem else { return .invalid }
         let duration = currentItem.duration

--- a/Sources/Player/Interfaces/AssetMetadata.swift
+++ b/Sources/Player/Interfaces/AssetMetadata.swift
@@ -8,17 +8,18 @@ import Foundation
 
 /// A protocol representing metadata associated with an asset.
 public protocol AssetMetadata {
-    /// Returns metadata used to display what is currently being played, most notably in the Control Center.
+    /// Returns metadata used to display what is currently being played.
+    ///
+    /// This metadata is most notably displayed in the Control Center.
     func nowPlayingMetadata() -> NowPlayingMetadata
 }
 
-/// An extension to provide a default implementation for the `nowPlayingMetadata()` method.
+/// An extension providing a default implementation for the `nowPlayingMetadata()` method.
 public extension AssetMetadata {
-    /// Returns an instance of `NowPlayingMetadata` with default values.
+    /// Returns a `NowPlayingMetadata` instance with default values.
     func nowPlayingMetadata() -> NowPlayingMetadata {
         .init()
     }
 }
 
-/// An extension to conform the `Never` type to `AssetMetadata` protocol.
 extension Never: AssetMetadata {}

--- a/Sources/Player/Interfaces/Assetable.swift
+++ b/Sources/Player/Interfaces/Assetable.swift
@@ -6,7 +6,7 @@
 
 import AVFoundation
 
-/// Describes an asset in an opaque way.
+/// A protocol describing an asset.
 protocol Assetable {
     var id: UUID { get }
     var resource: Resource { get }
@@ -26,7 +26,7 @@ extension Assetable {
 }
 
 extension AVPlayerItem {
-    /// Return the list of `AVPlayerItems` to load into an `AVQueuePlayer` when a list of assets replaces a previous
+    /// Returns the list of `AVPlayerItems` to load into an `AVQueuePlayer` when a list of assets replaces a previous
     /// one.
     /// - Parameters:
     ///   - currentAssets: The current list of assets.

--- a/Sources/Player/Interfaces/Assetable.swift
+++ b/Sources/Player/Interfaces/Assetable.swift
@@ -28,6 +28,7 @@ extension Assetable {
 extension AVPlayerItem {
     /// Returns the list of `AVPlayerItems` to load into an `AVQueuePlayer` when a list of assets replaces a previous
     /// one.
+    /// 
     /// - Parameters:
     ///   - currentAssets: The current list of assets.
     ///   - previousAssets: The previous list of assets.

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -218,7 +218,7 @@ extension QueuePlayer {
         Self.logger.info("Sentinel detected unhandled completion and fixed it")
     }
 
-    /// Perform a low-level seek without seek tracking.
+    /// Performs a low-level seek without seek tracking.
     private func rawSeek(to time: CMTime) {
         super.seek(to: time)
     }

--- a/Sources/Player/Player+Items.swift
+++ b/Sources/Player/Player+Items.swift
@@ -19,26 +19,27 @@ public extension Player {
         }
     }
 
-    /// Items before the current item (not included).
-    /// - Returns: Items.
+    /// The items located before the current item (not included).
     var previousItems: [PlayerItem] {
         guard let currentIndex else { return [] }
         return Array(storedItems.prefix(upTo: currentIndex))
     }
 
-    /// Items past the current item (not included).
-    /// - Returns: Items.
+    /// The items located after the current item (not included).
     var nextItems: [PlayerItem] {
         guard let currentIndex else { return Array(storedItems) }
         return Array(storedItems.suffix(from: currentIndex).dropFirst())
     }
 
-    /// Insert an item before another item. Does nothing if the item already belongs to the deque.
+    /// Inserts an item before another one.
+    ///
     /// - Parameters:
     ///   - item: The item to insert.
     ///   - beforeItem: The item before which insertion must take place. Pass `nil` to insert the item at the front
     ///     of the deque.
     /// - Returns: `true` iff the item could be inserted.
+    ///
+    /// Does nothing if the item already belongs to the deque.
     @discardableResult
     func insert(_ item: PlayerItem, before beforeItem: PlayerItem?) -> Bool {
         guard canInsert(item, before: beforeItem) else { return false }
@@ -52,12 +53,15 @@ public extension Player {
         return true
     }
 
-    /// Insert an item after another item. Does nothing if the item already belongs to the deque.
+    /// Inserts an item after another one.
+    ///
     /// - Parameters:
     ///   - item: The item to insert.
     ///   - afterItem: The item after which insertion must take place. Pass `nil` to insert the item at the back of
     ///     the deque. If this item does not exist the method does nothing.
     /// - Returns: `true` iff the item could be inserted.
+    ///
+    /// Does nothing if the item already belongs to the deque.
     @discardableResult
     func insert(_ item: PlayerItem, after afterItem: PlayerItem?) -> Bool {
         guard canInsert(item, after: afterItem) else { return false }
@@ -71,7 +75,8 @@ public extension Player {
         return true
     }
 
-    /// Prepend an item to the deque.
+    /// Prepends an item to the deque.
+    ///
     /// - Parameter item: The item to prepend.
     /// - Returns: `true` iff the item could be prepended.
     @discardableResult
@@ -79,7 +84,8 @@ public extension Player {
         insert(item, before: nil)
     }
 
-    /// Append an item to the deque.
+    /// Appends an item to the deque.
+    ///
     /// - Parameter item: The item to append.
     /// - Returns: `true` iff the item could be appended.
     @discardableResult
@@ -87,7 +93,8 @@ public extension Player {
         insert(item, after: nil)
     }
 
-    /// Move an item before another item.
+    /// Moves an item before another one.
+    ///
     /// - Parameters:
     ///   - item: The item to move. The method does nothing if the item does not belong to the deque.
     ///   - beforeItem: The item before which the moved item must be relocated. Pass `nil` to move the item to the
@@ -108,7 +115,8 @@ public extension Player {
         return true
     }
 
-    /// Move an item after another item.
+    /// Moves an item after another one.
+    ///
     /// - Parameters:
     ///   - item: The item to move.
     ///   - afterItem: The item after which the moved item must be relocated. Pass `nil` to move the item to the
@@ -129,13 +137,14 @@ public extension Player {
         return true
     }
 
-    /// Remove an item from the deque.
+    /// Removes an item from the deque.
+    ///
     /// - Parameter item: The item to remove.
     func remove(_ item: PlayerItem) {
         storedItems.removeAll { $0 === item }
     }
 
-    /// Remove all items in the deque.
+    /// Removes all items from the deque.
     func removeAllItems() {
         storedItems.removeAll()
     }

--- a/Sources/Player/Player+Navigation.swift
+++ b/Sources/Player/Player+Navigation.swift
@@ -8,31 +8,36 @@ import AVFoundation
 import DequeModule
 
 public extension Player {
-    /// Check whether returning to the previous item in the deque is possible.`
+    /// Checks whether returning to the previous item in the deque is possible.
+    ///
     /// - Returns: `true` if possible.
     func canReturnToPreviousItem() -> Bool {
         canReturnToItem(before: currentIndex, in: storedItems)
     }
 
-    /// Return to the previous item in the deque. Skips failed items.
+    /// Returns to the previous item in the deque.
+    ///
+    /// Skips failed items.
     func returnToPreviousItem() {
         guard canReturnToPreviousItem() else { return }
         queuePlayer.replaceItems(with: AVPlayerItem.playerItems(from: returningItems))
     }
 
-    /// Check whether moving to the next item in the deque is possible.`
+    /// Checks whether moving to the next item in the deque is possible.
+    ///
     /// - Returns: `true` if possible.
     func canAdvanceToNextItem() -> Bool {
         canAdvanceToItem(after: currentIndex, in: storedItems)
     }
 
-    /// Move to the next item in the deque.
+    /// Moves to the next item in the deque.
     func advanceToNextItem() {
         guard canAdvanceToNextItem() else { return }
         queuePlayer.replaceItems(with: AVPlayerItem.playerItems(from: advancingItems))
     }
 
-    /// Set the item at the specified index to become the current one.
+    /// Makes the item at the specified index become the current one.
+    ///
     /// - Parameter index: The item index.
     func setCurrentIndex(_ index: Int) throws {
         guard index != currentIndex else { return }
@@ -53,12 +58,12 @@ extension Player {
 }
 
 private extension Player {
-    /// Return the list of items to be loaded to return to the previous (playable) item.
+    /// Returns the list of items to be loaded to return to the previous (playable) item.
     var returningItems: [PlayerItem] {
         Self.items(before: currentIndex, in: storedItems)
     }
 
-    /// Return the list of items to be loaded to advance to the next (playable) item.
+    /// Returns the list of items to be loaded to advance to the next (playable) item.
     var advancingItems: [PlayerItem] {
         Self.items(after: currentIndex, in: storedItems)
     }

--- a/Sources/Player/Player+Playback.swift
+++ b/Sources/Player/Player+Playback.swift
@@ -7,17 +7,17 @@
 import Foundation
 
 public extension Player {
-    /// Resume playback.
+    /// Resumes playback.
     func play() {
         queuePlayer.play()
     }
 
-    /// Pause playback.
+    /// Pauses playback.
     func pause() {
         queuePlayer.pause()
     }
 
-    /// Toggle playback between play and pause.
+    /// Toggles playback between play and pause.
     func togglePlayPause() {
         if queuePlayer.rate != 0 {
             queuePlayer.pause()

--- a/Sources/Player/Player+PlaybackSpeed.swift
+++ b/Sources/Player/Player+PlaybackSpeed.swift
@@ -88,7 +88,7 @@ private extension Player {
             .eraseToAnyPublisher()
     }
 
-    // Publish speed updates triggered from `AVPlayerViewController`. Not necessary on tvOS since the standard UI
+    // Publishes speed updates triggered from `AVPlayerViewController`. Not necessary on tvOS since the standard UI
     // does not provide speed controls.
     func avPlayerViewControllerPlaybackSpeedUpdatePublisher() -> AnyPublisher<PlaybackSpeedUpdate, Never> {
 #if os(iOS)

--- a/Sources/Player/Player+PlaybackSpeed.swift
+++ b/Sources/Player/Player+PlaybackSpeed.swift
@@ -18,9 +18,12 @@ public extension Player {
         _playbackSpeed.effectiveRange
     }
 
-    /// Set the desired playback speed. This value might not be applied immediately or might not be applicable at all,
-    /// check `effectivePlaybackSpeed` for the actually applied speed.
+    /// Sets the desired playback speed.
+    ///
     /// - Parameter playbackSpeed: The playback speed.
+    ///
+    /// This value might not be applied immediately or might not be applicable at all. You must check
+    /// `effectivePlaybackSpeed` to obtain the actually applied speed.
     func setDesiredPlaybackSpeed(_ playbackSpeed: Float) {
         desiredPlaybackSpeedPublisher.send(playbackSpeed)
     }

--- a/Sources/Player/Player+Restart.swift
+++ b/Sources/Player/Player+Restart.swift
@@ -7,14 +7,15 @@
 import Foundation
 
 public extension Player {
-    /// Check whether the player has finished playing its content and can be restarted.
+    /// Checks whether the player has finished playing its content and can be restarted.
+    ///
     /// - Returns: `true` if possible.
     func canRestart() -> Bool {
         guard !storedItems.isEmpty else { return false }
         return currentItem.smoothPlayerItem(in: storedItems) == nil
     }
 
-    /// Restart playback if possible.
+    /// Restarts playback if possible.
     func restart() {
         guard canRestart() else { return }
         try? setCurrentIndex(0)

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -7,7 +7,8 @@
 import CoreMedia
 
 public extension Player {
-    /// Check whether seeking to a specific time is possible.
+    /// Checks whether seeking to a specific time is possible.
+    ///
     /// - Parameter time: The time to seek to.
     /// - Returns: `true` if possible.
     func canSeek(to time: CMTime) -> Bool {
@@ -15,7 +16,8 @@ public extension Player {
         return timeRange.start <= time && time <= timeRange.end
     }
 
-    /// Seek to a given position.
+    /// Seeks to a given position.
+    /// 
     /// - Parameters:
     ///   - position: The position to seek to.
     ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before

--- a/Sources/Player/Player+Skip.swift
+++ b/Sources/Player/Player+Skip.swift
@@ -7,13 +7,15 @@
 import CoreMedia
 
 public extension Player {
-    /// Check whether skipping backward is possible.
+    /// Checks whether skipping backward is possible.
+    ///
     /// - Returns: `true` if possible.
     func canSkipBackward() -> Bool {
         timeRange.isValidAndNotEmpty
     }
 
-    /// Check whether skipping forward is possible.
+    /// Checks whether skipping forward is possible.
+    ///
     /// - Returns: `true` if possible.
     func canSkipForward() -> Bool {
         guard timeRange.isValidAndNotEmpty else { return false }
@@ -26,14 +28,16 @@ public extension Player {
         }
     }
 
-    /// Skip backward.
+    /// Skips backward.
+    ///
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipBackward(completion: @escaping (Bool) -> Void = { _ in }) {
         skip(withInterval: backwardSkipTime, toleranceBefore: .positiveInfinity, toleranceAfter: .zero, completion: completion)
     }
 
-    /// Skip forward.
+    /// Skips forward.
+    /// 
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipForward(completion: @escaping (Bool) -> Void = { _ in }) {

--- a/Sources/Player/Player+SkipToDefault.swift
+++ b/Sources/Player/Player+SkipToDefault.swift
@@ -7,7 +7,8 @@
 import CoreMedia
 
 public extension Player {
-    /// Return whether the current player item player can be returned to its default position.
+    /// Returns whether the current player item player can be returned to its default position.
+    ///
     /// - Returns: `true` if skipping to the default position is possible.
     func canSkipToDefault() -> Bool {
         switch streamType {
@@ -20,7 +21,8 @@ public extension Player {
         }
     }
 
-    /// Return the current item to its default position.
+    /// Returns the current item to its default position.
+    /// 
     /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
     ///   whether the skip could finish without being cancelled.
     func skipToDefault(completion: @escaping (Bool) -> Void = { _ in }) {

--- a/Sources/Player/Player+SmartNavigation.swift
+++ b/Sources/Player/Player+SmartNavigation.swift
@@ -8,13 +8,22 @@ import AVFoundation
 import DequeModule
 
 public extension Player {
-    /// Check whether returning to the previous content is possible.`
+    /// Checks whether returning to the previous content is possible.
+    ///
     /// - Returns: `true` if possible.
+    ///
+    /// Smart navigation takes into account the current position in an item. If close enough to the item start position
+    /// then navigation will be moved to the previous item, otherwise playback will be returned to the item start
+    /// position. This behavior is only applied for on-demand streams.
     func canReturnToPrevious() -> Bool {
         canReturn(before: currentIndex, in: storedItems, streamType: streamType)
     }
 
-    /// Return to the previous content.
+    /// Returns to the previous content.
+    ///
+    /// Smart navigation takes into account the current position in an item. If close enough to the item start position
+    /// then navigation will be moved to the previous item, otherwise playback will be returned to the item start
+    /// position. This behavior is only applied for on-demand streams.
     func returnToPrevious() {
         if shouldSeekToStartTime() {
             seek(near(.zero))
@@ -24,13 +33,14 @@ public extension Player {
         }
     }
 
-    /// Check whether moving to the next content is possible.`
+    /// Checks whether moving to the next content is possible.
+    ///
     /// - Returns: `true` if possible.
     func canAdvanceToNext() -> Bool {
         canAdvanceToNextItem()
     }
 
-    /// Move to the next content.
+    /// Moves to the next content.
     func advanceToNext() {
         advanceToNextItem()
     }

--- a/Sources/Player/Player+TimePublisher.swift
+++ b/Sources/Player/Player+TimePublisher.swift
@@ -8,17 +8,20 @@ import Combine
 import CoreMedia
 
 public extension Player {
-    /// Return a publisher periodically emitting the current time while the player is playing content. Does not emit any
-    /// value on subscription and only emits valid times.
+    /// Returns a publisher periodically emitting the current time while the player is playing content.
+    ///
     /// - Parameters:
     ///   - interval: The interval at which events must be emitted.
     ///   - queue: The queue on which values are published.
     /// - Returns: The publisher.
+    ///
+    /// The publisher does not emit any value on subscription. Only valid times are emitted.
     func periodicTimePublisher(forInterval interval: CMTime, queue: DispatchQueue = .main) -> AnyPublisher<CMTime, Never> {
         Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: queue)
     }
 
-    /// Return a publisher emitting when traversing the specified times during normal playback.
+    /// Returns a publisher emitting a void value when traversing the specified times during normal playback.
+    /// 
     /// - Parameters:
     ///   - times: The times to observe.
     ///   - queue: The queue on which values are published.

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -11,35 +11,37 @@ import DequeModule
 import MediaPlayer
 import TimelaneCombine
 
-/// An audio / video player maintaining its items as a double-ended queue (deque).
+/// An observable audio / video player maintaining its items as a double-ended queue (deque).
 public final class Player: ObservableObject, Equatable {
     private static weak var currentPlayer: Player?
 
-    /// Current playback state.
+    /// The current playback state.
     @Published public private(set) var playbackState: PlaybackState = .idle
 
-    /// Current presentation size. Might be zero for audio content or `nil` when unknown.
+    /// The current presentation size.
+    ///
+    /// Might be zero for audio content or `nil` when unknown.
     @Published public private(set) var presentationSize: CGSize?
 
-    /// Returns whether the player is currently buffering.
+    /// A Boolean describing whether the player is currently buffering.
     @Published public private(set) var isBuffering = false
 
-    /// Returns whether the player is currently seeking to another position.
+    /// A Boolean describing whether the player is currently seeking to another position.
     @Published public private(set) var isSeeking = false
 
     /// The index of the current item in the queue.
     @Published public private(set) var currentIndex: Int?
 
-    /// Duration of a chunk for the currently played item.
+    /// The duration of a chunk for the currently played item.
     @Published public private(set) var chunkDuration: CMTime = .invalid
 
-    /// Indicates whether the player is currently playing video in external playback mode.
+    /// A Boolean describing whether the player is currently playing video in external playback mode.
     @Published public private(set) var isExternalPlaybackActive = false
 
-    /// Set whether trackers are enabled or not.
+    /// A Boolean setting whether trackers must be enabled or not.
     @Published public var isTrackingEnabled = true
 
-    /// Set whether the audio output of the player is muted.
+    /// A Boolean setting whether the audio output of the player must be muted.
     @Published public var isMuted = true {
         didSet {
             queuePlayer.isMuted = isMuted
@@ -67,7 +69,7 @@ public final class Player: ObservableObject, Equatable {
     /// The player configuration
     public let configuration: PlayerConfiguration
 
-    /// The type of stream currently played.
+    /// The type of stream currently being played.
     public var streamType: StreamType {
         StreamType(for: timeRange, itemDuration: itemDuration)
     }
@@ -83,23 +85,29 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer.currentTime().clamped(to: timeRange)
     }
 
-    /// The available time range or `.invalid` when not known.
+    /// The available time range.
+    ///
+    /// `.invalid` when unknown.
     public var timeRange: CMTimeRange {
         queuePlayer.timeRange
     }
 
-    /// Returns whether the player is currently busy (buffering or seeking).
+    /// A Boolean describing whether the player is currently busy (buffering or seeking).
     public var isBusy: Bool {
         isBuffering || isSeeking
     }
 
-    /// The low-level system player. Exposed for specific read-only needs like interfacing with `AVPlayer`-based
-    /// 3rd party APIs. Mutating the state of this player directly is not supported and leads to undefined behavior.
+    /// The low-level system player.
+    ///
+    /// Exposed for specific read-only needs like interfacing with `AVPlayer`-based 3rd party APIs. Mutating the state
+    /// of this player directly is not supported and leads to undefined behavior.
     public var systemPlayer: AVPlayer {
         queuePlayer
     }
 
-    /// The current item duration or `.invalid` when not known.
+    /// The current item duration.
+    ///
+    /// `.invalid` when unknown.
     var itemDuration: CMTime {
         queuePlayer.itemDuration
     }
@@ -113,7 +121,8 @@ public final class Player: ObservableObject, Equatable {
     // swiftlint:disable:next private_subject
     var desiredPlaybackSpeedPublisher = PassthroughSubject<Float, Never>()
 
-    /// Create a player with a given item queue.
+    /// Creates a player with a given item queue.
+    ///
     /// - Parameters:
     ///   - items: The items to be queued initially.
     ///   - configuration: The configuration to apply to the player.
@@ -131,7 +140,8 @@ public final class Player: ObservableObject, Equatable {
         configurePublishedPropertyPublishers()
     }
 
-    /// Create a player with a single item in its queue.
+    /// Creates a player with a single item in its queue.
+    ///
     /// - Parameters:
     ///   - item: The item to queue.
     ///   - configuration: The configuration to apply to the player.
@@ -143,8 +153,9 @@ public final class Player: ObservableObject, Equatable {
         lhs === rhs
     }
 
-    /// Enable AirPlay and Control Center integration for the receiver, making the player the current active one. At most
-    /// one player can be active at any time.
+    /// Enables AirPlay and Control Center integration for the receiver, making the player the current active one.
+    ///
+    /// At most one player can be active at any time.
     public func becomeActive() {
         guard Self.currentPlayer != self else { return }
         Self.currentPlayer?.isActive = false
@@ -152,9 +163,10 @@ public final class Player: ObservableObject, Equatable {
         Self.currentPlayer = self
     }
 
-    /// Disable AirPlay and Control Center integration for the receiver. Does nothing if the receiver is currently
-    /// inactive. Calling `resignActive()` is superfluous if `becomeActive` is called on a different player instance
-    /// or if the player gets destroyed.
+    /// Disables AirPlay and Control Center integration for the receiver.
+    ///
+    /// Does nothing if the receiver is currently inactive. Calling `resignActive()` is superfluous if `becomeActive`
+    /// is called on a different player instance or if the player gets destroyed.
     public func resignActive() {
         guard Self.currentPlayer == self else { return }
         isActive = false

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -7,24 +7,26 @@
 import AVFoundation
 import CoreMedia
 
-/// Player configuration.
+/// A player configuration.
 public struct PlayerConfiguration {
     /// A Boolean value that indicates whether the player allows switching to external playback mode.
     public let allowsExternalPlayback: Bool
 
     /// A Boolean value that indicates whether the player allows switching to external playback when mirroring.
+    ///
     /// This property has no effect when `allowsExternalPlayback` is false.
     public let usesExternalPlaybackWhileMirroring: Bool
 
-    /// Indicates whether video playback prevents display and device sleep.
+    /// A Boolean indicating whether video playback prevents display and device sleep.
     public let preventsDisplaySleepDuringVideoPlayback: Bool
 
     /// A policy that determines how playback of audiovisual media continues when the app transitions
     /// to the background.
     public let audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy
 
-    /// Enables smart playlist navigation (calling `returnToPrevious()` returns to the previous item in a playlist
-    /// only within its first few seconds, otherwise resumes the current item at its beginning).
+    /// A Boolean controlling whether smart playlist navigation is enabled.
+    ///
+    /// See `returnToPrevious()` for more information.
     public let isSmartNavigationEnabled: Bool
 
     /// The forward skip interval in seconds.
@@ -33,16 +35,7 @@ public struct PlayerConfiguration {
     /// The backward skip interval in seconds.
     public let backwardSkipInterval: TimeInterval
 
-    /// Create a player configuration.
-    /// - Parameters:
-    ///   - allowsExternalPlayback: Allows switching to external playback mode.
-    ///   - usesExternalPlaybackWhileMirroring: Allows switching to external playback when mirroring.
-    ///   - preventsDisplaySleepDuringVideoPlayback: Indicates whether video playback prevents display and device sleep.
-    ///   - audiovisualBackgroundPlaybackPolicy: Policy that determines how playback of audiovisual media continues
-    ///     when the app transitions to the background.
-    ///   - smartNavigationEnabled: Enables smart playlist navigation (see `isSmartNavigationEnabled`).
-    ///   - backwardSkipInterval: The forward skip interval in seconds.
-    ///   - forwardSkipInterval: The backward skip interval in seconds.
+    /// Creates a player configuration.
     public init(
         allowsExternalPlayback: Bool = true,
         usesExternalPlaybackWhileMirroring: Bool = false,

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -8,13 +8,13 @@ import AVFoundation
 import Combine
 import Core
 
-/// An item to be inserted into the player.
+/// An item to be inserted into a player.
 public final class PlayerItem: Equatable {
     @Published private(set) var asset: any Assetable
 
     private let id = UUID()
 
-    /// Create the item from an `Asset` publisher data source.
+    /// Creates the item from an `Asset` publisher data source.
     public init<P, M>(publisher: P, trackerAdapters: [TrackerAdapter<M>] = []) where P: Publisher, M: AssetMetadata, P.Output == Asset<M> {
         asset = Asset<M>.loading.withId(id).withTrackerAdapters(trackerAdapters)
         publisher
@@ -29,7 +29,8 @@ public final class PlayerItem: Equatable {
             .assign(to: &$asset)
     }
 
-    /// Create a player item from a URL.
+    /// Creates a player item from a URL.
+    ///
     /// - Parameters:
     ///   - url: The URL to play.
     ///   - configuration: A closure to configure player items created from the receiver.
@@ -47,7 +48,8 @@ public final class PlayerItem: Equatable {
 }
 
 public extension PlayerItem {
-    /// A simple playable item.
+    /// Returns a simple playable item.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - metadata: The metadata associated with the item.
@@ -63,8 +65,8 @@ public extension PlayerItem {
         .init(asset: .simple(url: url, metadata: metadata, configuration: configuration), trackerAdapters: trackerAdapters)
     }
 
-    /// An item loaded with custom resource loading. The scheme of the URL to be played has to be recognized by
-    /// the associated resource loader delegate.
+    /// Returns an item loaded with custom resource loading.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The custom resource loader to use.
@@ -72,6 +74,8 @@ public extension PlayerItem {
     ///   - trackerAdapters: An array of `TrackerAdapter` instances to use for tracking playback events.
     ///   - configuration: A closure to configure player items created from the receiver.
     /// - Returns: The item.
+    ///
+    /// The scheme of the URL to be played has to be recognized by the associated resource loader delegate.
     static func custom<M>(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -82,7 +86,8 @@ public extension PlayerItem {
         .init(asset: .custom(url: url, delegate: delegate, metadata: metadata, configuration: configuration), trackerAdapters: trackerAdapters)
     }
 
-    /// An encrypted item loaded with a content key session.
+    /// Returns an encrypted item loaded with a content key session.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The content key session delegate to use.
@@ -102,7 +107,8 @@ public extension PlayerItem {
 }
 
 public extension PlayerItem {
-    /// A simple playable item.
+    /// Returns a simple playable item.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - trackerAdapters: An array of `TrackerAdapter` instances to use for tracking playback events.
@@ -116,14 +122,16 @@ public extension PlayerItem {
         .init(asset: .simple(url: url, configuration: configuration), trackerAdapters: trackerAdapters)
     }
 
-    /// An item loaded with custom resource loading. The scheme of the URL to be played has to be recognized by
-    /// the associated resource loader delegate.
+    /// Returns an item loaded with custom resource loading.
+    ///
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The custom resource loader to use.
     ///   - trackerAdapters: An array of `TrackerAdapter` instances to use for tracking playback events.
     ///   - configuration: A closure to configure player items created from the receiver.
     /// - Returns: The item.
+    ///
+    /// The scheme of the URL to be played has to be recognized by the associated resource loader delegate.
     static func custom(
         url: URL,
         delegate: AVAssetResourceLoaderDelegate,
@@ -133,7 +141,8 @@ public extension PlayerItem {
         .init(asset: .custom(url: url, delegate: delegate, configuration: configuration), trackerAdapters: trackerAdapters)
     }
 
-    /// An encrypted item loaded with a content key session.
+    /// Returns an encrypted item loaded with a content key session.
+    /// 
     /// - Parameters:
     ///   - url: The URL to be played.
     ///   - delegate: The content key session delegate to use.

--- a/Sources/Player/Publishers/AVAssetPublishers.swift
+++ b/Sources/Player/Publishers/AVAssetPublishers.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import Combine
 
 public extension AVAsset {
-    /// Produce a given asset property.
+    /// Returns a publisher emitting values for a given asset property.
     func propertyPublisher<T>(_ property: AVAsyncProperty<AVAsset, T>) -> AnyPublisher<T, Error> {
         Future { promise in
             Task {
@@ -24,7 +24,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>
@@ -43,7 +43,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,
@@ -64,7 +64,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C, D>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,
@@ -86,7 +86,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C, D, E>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,
@@ -109,7 +109,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C, D, E, F>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,
@@ -133,7 +133,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C, D, E, F, G>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,
@@ -160,7 +160,7 @@ public extension AVAsset {
         .eraseToAnyPublisher()
     }
 
-    /// Produce given asset properties.
+    /// Returns a publisher emitting values for given asset properties.
     func propertyPublisher<A, B, C, D, E, F, G, H>(
         _ propertyA: AVAsyncProperty<AVAsset, A>,
         _ propertyB: AVAsyncProperty<AVAsset, B>,

--- a/Sources/Player/Publishers/AVPlayerPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerPublishers.swift
@@ -31,8 +31,10 @@ extension AVPlayer {
         .eraseToAnyPublisher()
     }
 
-    /// A publisher returning current item duration. Unlike `AVPlayerItem` this publisher returns `.invalid` when
-    /// the duration is unknown (`.indefinite` is still a valid value for DVR streams).
+    /// Returns a publisher emitting values for the current item duration.
+    ///
+    /// Unlike `AVPlayerItem` this publisher returns `.invalid` when the duration is unknown. Note that `.indefinite`
+    /// is a valid duration for DVR streams.
     func currentItemDurationPublisher() -> AnyPublisher<CMTime, Never> {
         publisher(for: \.currentItem)
             .map { item -> AnyPublisher<CMTime, Never> in

--- a/Sources/Player/Publishers/QueuePlayerPublishers.swift
+++ b/Sources/Player/Publishers/QueuePlayerPublishers.swift
@@ -36,7 +36,7 @@ extension QueuePlayer {
         .eraseToAnyPublisher()
     }
 
-    /// Publishes current time, taking into account seeks to smooth out emitted values.
+    /// Publishes the current time, smoothing out emitted values during seeks.
     func smoothCurrentTimePublisher(interval: CMTime, queue: DispatchQueue) -> AnyPublisher<CMTime, Never> {
         Publishers.CombineLatest(
             Publishers.PeriodicTimePublisher(for: self, interval: interval, queue: queue),

--- a/Sources/Player/ResourceLoading/AssetResourceLoadingRequest.swift
+++ b/Sources/Player/ResourceLoading/AssetResourceLoadingRequest.swift
@@ -10,9 +10,10 @@ public extension AVAssetResourceLoadingRequest {
     /// Causes the receiver to handle the failure to load a resource for which a resource loader’s delegate took
     /// responsibility.
     ///
+    /// - Parameter error: An error object indicating the reason for the failure.
+    ///
     /// Unlike `finishLoading(with:)` this method ensures error information can be reliably forwarded to the player
     /// item being loaded in case of failure.
-    /// - Parameter error: An error object indicating the reason for the failure.
     func finishLoadingReliably(with error: Error?) {
         let nsError = NSError.error(from: error)
         if let nsError {
@@ -22,6 +23,7 @@ public extension AVAssetResourceLoadingRequest {
     }
 
     /// Redirects the receiver to another URL.
+    /// 
     /// - Parameter url: The URL to redirect the receiver to.
     func redirect(to url: URL) {
         var redirectRequest = request

--- a/Sources/Player/ResourceLoading/AssetResourceLoadingRequest.swift
+++ b/Sources/Player/ResourceLoading/AssetResourceLoadingRequest.swift
@@ -8,8 +8,10 @@ import AVFoundation
 
 public extension AVAssetResourceLoadingRequest {
     /// Causes the receiver to handle the failure to load a resource for which a resource loader’s delegate took
-    /// responsibility. Unlike `finishLoading(with:)` this method ensures error information can be reliably
-    /// forwarded to the player item being loaded in case of failure.
+    /// responsibility.
+    ///
+    /// Unlike `finishLoading(with:)` this method ensures error information can be reliably forwarded to the player
+    /// item being loaded in case of failure.
     /// - Parameter error: An error object indicating the reason for the failure.
     func finishLoadingReliably(with error: Error?) {
         let nsError = NSError.error(from: error)
@@ -19,7 +21,7 @@ public extension AVAssetResourceLoadingRequest {
         finishLoading(with: nsError)
     }
 
-    /// Redirect the receiver to another URL.
+    /// Redirects the receiver to another URL.
     /// - Parameter url: The URL to redirect the receiver to.
     func redirect(to url: URL) {
         var redirectRequest = request

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -31,12 +31,14 @@ public protocol PlayerItemTracker: AnyObject {
     associatedtype Metadata
 
     /// Creates the tracker.
+    ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
     ///   - metadataPublisher: The publisher that provides metadata updates.
     init(configuration: Configuration, metadataPublisher: AnyPublisher<Metadata, Never>)
 
     /// The lifecycle method called when the tracker is enabled for a player.
+    ///
     /// - Parameter player: The player for which the tracker must be enabled.
     func enable(for player: Player)
 
@@ -46,6 +48,7 @@ public protocol PlayerItemTracker: AnyObject {
 
 public extension PlayerItemTracker {
     /// Creates an adapter for the receiver with the provided mapping to its metadata format.
+    ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
     ///   - mapper: A closure that maps the tracker's metadata to another metadata.
@@ -55,6 +58,7 @@ public extension PlayerItemTracker {
     }
 
     /// Creates an adapter for the receiver.
+    ///
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter(configuration: Configuration) -> TrackerAdapter<Never> {
@@ -64,6 +68,7 @@ public extension PlayerItemTracker {
 
 public extension PlayerItemTracker where Metadata == Void {
     /// Creates an adapter for the receiver.
+    ///
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter<M>(configuration: Configuration) -> TrackerAdapter<M> where M: AssetMetadata {
@@ -73,6 +78,7 @@ public extension PlayerItemTracker where Metadata == Void {
 
 public extension PlayerItemTracker where Configuration == Void {
     /// Creates an adapter for the receiver.
+    ///
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter<M>(mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> where M: AssetMetadata {
@@ -80,6 +86,7 @@ public extension PlayerItemTracker where Configuration == Void {
     }
 
     /// Creates an adapter for the receiver.
+    ///
     /// - Returns: The tracker adapter.
     static func adapter() -> TrackerAdapter<Never> {
         TrackerAdapter(trackerType: Self.self, configuration: (), mapper: nil)
@@ -88,6 +95,7 @@ public extension PlayerItemTracker where Configuration == Void {
 
 public extension PlayerItemTracker where Metadata == Void, Configuration == Void {
     /// Creates an adapter for the receiver.
+    /// 
     /// - Returns: The tracker adapter.
     static func adapter<M>() -> TrackerAdapter<M> where M: AssetMetadata {
         TrackerAdapter(trackerType: Self.self, configuration: ()) { _ in }

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -7,31 +7,45 @@
 import Combine
 import Foundation
 
-/// Common contract for player item tracker implementation. Initialization and deinitialization methods can be used
-/// to track items even when they are not currently being played.
+/// A protocol for player item tracking implementation.
+///
+/// If your application needs to track items being played, for example for analytics or diagnostics purposes, implement
+/// this protocol to hook into the playback lifecycle. This allows you to setup your tracker at and to relinquish
+/// associated resources when appropriate.
+///
+/// The protocol provides two associated types through which your tracker can define any configuration or metadata it
+/// requires. Trackers are never instantiated directly but rather using adapter methods which let you map metadata
+/// provided by a player item to the required tracker metadata.
+///
+/// This protocol can only be applied to reference types. This makes it possible to use initialization and
+/// deinitialization methods to perform tracking also when the item is currently not being played.
 public protocol PlayerItemTracker: AnyObject {
-    /// A type describing the configuration required by the tracker. May be `Void` if none.
+    /// A type describing the configuration required by the tracker.
+    ///
+    /// Use `Void` if no configuration is required.
     associatedtype Configuration
 
-    /// A type describing metadata required by the tracker. May be `Void` if none.
+    /// A type describing metadata required by the tracker.
+    ///
+    /// Use `Void` if no metadata is required.
     associatedtype Metadata
 
-    /// Initialize the tracker.
+    /// Creates the tracker.
     /// - Parameters:
     ///   - configuration: The tracker configuration.
     ///   - metadataPublisher: The publisher that provides metadata updates.
     init(configuration: Configuration, metadataPublisher: AnyPublisher<Metadata, Never>)
 
-    /// Called when the tracker is enabled for a player.
+    /// The lifecycle method called when the tracker is enabled for a player.
     /// - Parameter player: The player for which the tracker must be enabled.
     func enable(for player: Player)
 
-    /// Called when the tracker is disabled.
+    /// The lifecycle method called when the tracker is disabled.
     func disable()
 }
 
 public extension PlayerItemTracker {
-    /// Create an adapter for the receiver with the provided mapping to its metadata format.
+    /// Creates an adapter for the receiver with the provided mapping to its metadata format.
     /// - Parameters:
     ///   - configuration: The tracker configuration.
     ///   - mapper: A closure that maps the tracker's metadata to another metadata.
@@ -40,7 +54,7 @@ public extension PlayerItemTracker {
         TrackerAdapter(trackerType: Self.self, configuration: configuration, mapper: mapper)
     }
 
-    /// Create an adapter for the receiver.
+    /// Creates an adapter for the receiver.
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter(configuration: Configuration) -> TrackerAdapter<Never> {
@@ -49,7 +63,7 @@ public extension PlayerItemTracker {
 }
 
 public extension PlayerItemTracker where Metadata == Void {
-    /// Create an adapter for the receiver.
+    /// Creates an adapter for the receiver.
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter<M>(configuration: Configuration) -> TrackerAdapter<M> where M: AssetMetadata {
@@ -58,14 +72,14 @@ public extension PlayerItemTracker where Metadata == Void {
 }
 
 public extension PlayerItemTracker where Configuration == Void {
-    /// Create an adapter for the receiver.
+    /// Creates an adapter for the receiver.
     /// - Parameter configuration: The tracker configuration.
     /// - Returns: The tracker adapter.
     static func adapter<M>(mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> where M: AssetMetadata {
         TrackerAdapter(trackerType: Self.self, configuration: (), mapper: mapper)
     }
 
-    /// Create an adapter for the receiver.
+    /// Creates an adapter for the receiver.
     /// - Returns: The tracker adapter.
     static func adapter() -> TrackerAdapter<Never> {
         TrackerAdapter(trackerType: Self.self, configuration: (), mapper: nil)
@@ -73,7 +87,7 @@ public extension PlayerItemTracker where Configuration == Void {
 }
 
 public extension PlayerItemTracker where Metadata == Void, Configuration == Void {
-    /// Create an adapter for the receiver.
+    /// Creates an adapter for the receiver.
     /// - Returns: The tracker adapter.
     static func adapter<M>() -> TrackerAdapter<M> where M: AssetMetadata {
         TrackerAdapter(trackerType: Self.self, configuration: ()) { _ in }

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -15,6 +15,7 @@ public struct TrackerAdapter<M: AssetMetadata> {
     private let update: (M) -> Void
 
     /// Creates an adapter for a type of tracker with the provided mapping to its metadata format.
+    /// 
     /// - Parameters:
     ///   - trackerType: The type of the tracker to instantiate and manage.
     ///   - configuration: The tracker configuration.

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -7,13 +7,14 @@
 import Combine
 import Foundation
 
-/// An adapter which instantiates and manages a tracker of a specified type, transforming metadata delivered by the
-/// tracked player item into the metadata format required by the tracker.
+/// An adapter which instantiates and manages a tracker of a specified type.
+///
+/// An adapter transforms metadata delivered by a player item into the metadata format required by the tracker.
 public struct TrackerAdapter<M: AssetMetadata> {
     private let tracker: any PlayerItemTracker
     private let update: (M) -> Void
 
-    /// Create an adapter for a type of tracker with the provided mapping to its metadata format.
+    /// Creates an adapter for a type of tracker with the provided mapping to its metadata format.
     /// - Parameters:
     ///   - trackerType: The type of the tracker to instantiate and manage.
     ///   - configuration: The tracker configuration.

--- a/Sources/Player/Types/Errors.swift
+++ b/Sources/Player/Types/Errors.swift
@@ -31,8 +31,9 @@ extension NSError {
         return userInfo
     }
 
-    /// Convert any error to a true `NSError`. This is not the same as bridging an `Error` to `NSError` (which is
-    /// always possible but is not equivalent).
+    /// Converts any error to a true `NSError`.
+    ///
+    /// This process is not the same as bridging an `Error` to `NSError` (which is always possible but not equivalent).
     /// - Parameter error: The error to convert.
     /// - Returns: The converted error (or the provided error if already an `NSError`).
     static func error(from error: Error?) -> NSError? {

--- a/Sources/Player/Types/Errors.swift
+++ b/Sources/Player/Types/Errors.swift
@@ -33,9 +33,10 @@ extension NSError {
 
     /// Converts any error to a true `NSError`.
     ///
-    /// This process is not the same as bridging an `Error` to `NSError` (which is always possible but not equivalent).
     /// - Parameter error: The error to convert.
     /// - Returns: The converted error (or the provided error if already an `NSError`).
+    ///
+    /// This process is not the same as bridging an `Error` to `NSError` (which is always possible but not equivalent).
     static func error(from error: Error?) -> NSError? {
         guard let error else { return nil }
         guard type(of: error) != NSError.self else { return error as NSError }

--- a/Sources/Player/Types/ItemState.swift
+++ b/Sources/Player/Types/ItemState.swift
@@ -99,10 +99,11 @@ enum ItemState: Equatable {
     }
 
     /// Returns the error associated with an item, caching the first encountered error.
+    ///
     /// - Parameters:
     ///   - item: The item to consider.
     ///   - error: An error related to the item and which might be supplied by another channel (e.g. notification).
-    ///   Takes precedence over error information attached to the item when present.
+    ///     Takes precedence over error information attached to the item when present.
     /// - Returns: The error
     private static func consolidatedError(for item: AVPlayerItem, error: Error? = nil) -> Error {
         if let cachedError = item.cachedError {

--- a/Sources/Player/Types/ItemState.swift
+++ b/Sources/Player/Types/ItemState.swift
@@ -79,8 +79,9 @@ enum ItemState: Equatable {
         return [NSLocalizedDescriptionKey: comment]
     }
 
-    /// Consolidate intrinsic error and error log information. Only reliable the first time the item transitions to
-    /// the failed status as of iOS and tvOS 16.1.
+    /// Consolidates intrinsic error and error log information.
+    ///
+    /// Consolidation is only reliable the first time the item transitions to the failed status as of iOS and tvOS 16.1.
     private static func intrinsicError(for item: AVPlayerItem) -> Error {
         if let errorLog = item.errorLog(), let event = errorLog.events.last {
             return NSError(
@@ -97,11 +98,11 @@ enum ItemState: Equatable {
         }
     }
 
-    /// Return the error associated with an item. Caches the first encountered error.
+    /// Returns the error associated with an item, caching the first encountered error.
     /// - Parameters:
     ///   - item: The item to consider.
     ///   - error: An error related to the item and which might be supplied by another channel (e.g. notification).
-    ///     Takes precedence over error information attached to the item when present.
+    ///   Takes precedence over error information attached to the item when present.
     /// - Returns: The error
     private static func consolidatedError(for item: AVPlayerItem, error: Error? = nil) -> Error {
         if let cachedError = item.cachedError {

--- a/Sources/Player/Types/MediaType.swift
+++ b/Sources/Player/Types/MediaType.swift
@@ -6,9 +6,9 @@
 
 import Foundation
 
-/// Media types.
+/// A media type.
 public enum MediaType {
-    /// Not yet determined.
+    /// Unknown media type.
     case unknown
     /// Audio.
     case audio

--- a/Sources/Player/Types/PlaybackState.swift
+++ b/Sources/Player/Types/PlaybackState.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Playback states.
+/// A playback state.
 public enum PlaybackState: Equatable {
     /// The player is idle.
     case idle

--- a/Sources/Player/Types/Position.swift
+++ b/Sources/Player/Types/Position.swift
@@ -25,6 +25,7 @@ public struct Position {
 }
 
 /// Returns a position with explicitly associated tolerances.
+///
 /// - Parameters:
 ///   - time: The time to reach.
 ///   - toleranceBefore: The tolerance allowed before the time to reach.
@@ -35,6 +36,7 @@ public func to(_ time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) 
 }
 
 /// Returns a precise position.
+///
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func at(_ time: CMTime) -> Position {
@@ -42,6 +44,7 @@ public func at(_ time: CMTime) -> Position {
 }
 
 /// Returns an approximate position.
+///
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func near(_ time: CMTime) -> Position {
@@ -49,6 +52,7 @@ public func near(_ time: CMTime) -> Position {
 }
 
 /// Returns an approximate position always located before the specified time.
+///
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func before(_ time: CMTime) -> Position {
@@ -56,6 +60,7 @@ public func before(_ time: CMTime) -> Position {
 }
 
 /// Returns an approximate position always located after the specified time.
+/// 
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func after(_ time: CMTime) -> Position {

--- a/Sources/Player/Types/Position.swift
+++ b/Sources/Player/Types/Position.swift
@@ -6,7 +6,7 @@
 
 import CoreMedia
 
-/// Describes a position to reach.
+/// A description for a position to reach.
 public struct Position {
     /// The time to reach.
     public let time: CMTime
@@ -24,7 +24,7 @@ public struct Position {
     }
 }
 
-/// A position with explicitly associated tolerances.
+/// Returns a position with explicitly associated tolerances.
 /// - Parameters:
 ///   - time: The time to reach.
 ///   - toleranceBefore: The tolerance allowed before the time to reach.
@@ -34,28 +34,28 @@ public func to(_ time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime) 
     .init(time: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter)
 }
 
-/// A precise position.
+/// Returns a precise position.
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func at(_ time: CMTime) -> Position {
     .init(time: time, toleranceBefore: .zero, toleranceAfter: .zero)
 }
 
-/// An approximate position.
+/// Returns an approximate position.
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func near(_ time: CMTime) -> Position {
     .init(time: time, toleranceBefore: .positiveInfinity, toleranceAfter: .positiveInfinity)
 }
 
-/// An approximate position, but always located before the specified time.
+/// Returns an approximate position always located before the specified time.
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func before(_ time: CMTime) -> Position {
     .init(time: time, toleranceBefore: .positiveInfinity, toleranceAfter: .zero)
 }
 
-/// An approximate position, but always located after the specified time.
+/// Returns an approximate position always located after the specified time.
 /// - Parameter time: The time to reach.
 /// - Returns: A position.
 public func after(_ time: CMTime) -> Position {

--- a/Sources/Player/Types/SeekBehavior.swift
+++ b/Sources/Player/Types/SeekBehavior.swift
@@ -6,10 +6,10 @@
 
 import Foundation
 
-/// Seek behavior during progress updates.
+/// A behavior for progress updates during a seek operation.
 public enum SeekBehavior {
-    /// Seek immediately when updated.
+    /// A behavior updating progress immediately during a seek.
     case immediate
-    /// Deferred until interaction ends.
+    /// A behavior deferring progress update after a seek ends.
     case deferred
 }

--- a/Sources/Player/Types/StreamType.swift
+++ b/Sources/Player/Types/StreamType.swift
@@ -7,9 +7,9 @@
 import CoreMedia
 import Foundation
 
-/// Stream types.
+/// A stream type.
 public enum StreamType {
-    /// Not yet determined.
+    /// Unknown stream.
     case unknown
     /// On-demand stream.
     case onDemand

--- a/Sources/Player/UserInterface/ActivityGestureRecognizer.swift
+++ b/Sources/Player/UserInterface/ActivityGestureRecognizer.swift
@@ -6,8 +6,9 @@
 
 import UIKit
 
-/// A gesture recognizer which detects all kinds of user activities and calls the associated action on its target if any
-/// activity is detected.
+/// A gesture recognizer which detects all kinds of user activities.
+///
+/// When a user activity is detected the gesture recognizer calls the associated action on its target.
 @available(tvOS, unavailable)
 final class ActivityGestureRecognizer: UIGestureRecognizer {
     // Heavily inspired by MPActivityGestureRecognizer from the MediaPlayer framework

--- a/Sources/Player/UserInterface/InteractionHostView.swift
+++ b/Sources/Player/UserInterface/InteractionHostView.swift
@@ -58,7 +58,7 @@ struct InteractionHostView<Content: View>: UIViewControllerRepresentable {
         _content = .constant(content)
     }
 
-    // Return a `UIHostingController` directly to ensure correct safe area insets
+    // Returns a `UIHostingController` directly to ensure correct safe area insets.
     func makeUIViewController(context: Context) -> InteractionHostingController<Content> {
         InteractionHostingController(rootView: content())
     }

--- a/Sources/Player/UserInterface/InteractionView.swift
+++ b/Sources/Player/UserInterface/InteractionView.swift
@@ -6,8 +6,9 @@
 
 import SwiftUI
 
-/// A view which is able to determine whether interaction occurs with its content. The view lays out its children
-/// like a `ZStack`.
+/// A view which is able to determine whether interaction occurs with its content.
+///
+/// The view lays out its children like a `ZStack`.
 @available(tvOS, unavailable)
 public struct InteractionView<Content: View>: View {
     @Binding private var isInteracting: Bool
@@ -24,7 +25,7 @@ public struct InteractionView<Content: View>: View {
         .ignoresSafeArea()
     }
 
-    /// Create the interaction view.
+    /// Creates the interaction view.
     /// - Parameters:
     ///   - isInteracting: A binding to a Boolean indicating whether the user is currently interacting with the view.
     ///   - action: The action to trigger when user interaction is detected.

--- a/Sources/Player/UserInterface/InteractionView.swift
+++ b/Sources/Player/UserInterface/InteractionView.swift
@@ -16,7 +16,7 @@ public struct InteractionView<Content: View>: View {
     @Binding private var content: () -> Content
 
     public var body: some View {
-        // Ignore the safe area to have support for safe area insets similar to a `ZStack`.
+        // Ignores the safe area to have support for safe area insets similar to a `ZStack`.
         InteractionHostView(isInteracting: _isInteracting, action: action) {
             ZStack {
                 content()
@@ -26,6 +26,7 @@ public struct InteractionView<Content: View>: View {
     }
 
     /// Creates the interaction view.
+    /// 
     /// - Parameters:
     ///   - isInteracting: A binding to a Boolean indicating whether the user is currently interacting with the view.
     ///   - action: The action to trigger when user interaction is detected.

--- a/Sources/Player/UserInterface/LayoutReader.swift
+++ b/Sources/Player/UserInterface/LayoutReader.swift
@@ -39,6 +39,7 @@ public struct LayoutReader<Content: View>: View {
     }
 
     /// Creates a layout reader.
+    /// 
     /// - Parameters:
     ///   - layoutInfo: The layout information.
     ///   - content: The wrapped content.

--- a/Sources/Player/UserInterface/LayoutReader.swift
+++ b/Sources/Player/UserInterface/LayoutReader.swift
@@ -13,22 +13,23 @@ public struct LayoutInfo {
         .init(isOverCurrentContext: false, isFullScreen: false)
     }
 
-    /// Return whether the view covers its current context.
+    /// A Boolean describing whether the view covers its current context.
     public let isOverCurrentContext: Bool
 
-    /// Return whether the view covers the whole screen
+    /// A Boolean describing whether the view covers the whole screen.
     public let isFullScreen: Bool
 }
 
-/// A view which is able to determine whether it is covering its current context or full screen. The view lays out
-/// its children like a `ZStack`.
+/// A view which is able to determine layout information.
+///
+/// The view lays out its children like a `ZStack`.
 @available(tvOS, unavailable)
 public struct LayoutReader<Content: View>: View {
     @Binding private var layoutInfo: LayoutInfo
     @Binding private var content: () -> Content
 
     public var body: some View {
-        // Ignore the safe area to have support for safe area insets similar to a `ZStack`.
+        // Ignores the safe area to have support for safe area insets similar to a `ZStack`.
         LayoutReaderHost(layoutInfo: $layoutInfo) {
             ZStack {
                 content()
@@ -37,7 +38,7 @@ public struct LayoutReader<Content: View>: View {
         .ignoresSafeArea()
     }
 
-    /// Create the layout reader.
+    /// Creates a layout reader.
     /// - Parameters:
     ///   - layoutInfo: The layout information.
     ///   - content: The wrapped content.

--- a/Sources/Player/UserInterface/LayoutReaderHost.swift
+++ b/Sources/Player/UserInterface/LayoutReaderHost.swift
@@ -64,7 +64,7 @@ struct LayoutReaderHost<Content: View>: UIViewControllerRepresentable {
         _content = .constant(content)
     }
 
-    // Return a `UIHostingController` directly to ensure correct safe area insets
+    // Returns a `UIHostingController` directly to ensure correct safe area insets
     func makeUIViewController(context: Context) -> LayoutReaderHostingController<Content> {
         LayoutReaderHostingController(rootView: content())
     }

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -8,14 +8,18 @@ import Combine
 import CoreMedia
 import SwiftUI
 
-/// Tracks playback progress. Progress trackers can be locally instantiated in a SwiftUI view hierarchy to trigger
-/// view updates at a specific pace, avoiding unnecessary refreshes in other parts of the view hierarchy that do
-/// not need to be periodically refreshed.
+/// An observable object which tracks playback progress.
+///
+/// Progress trackers can be instantiated in a SwiftUI view hierarchy to trigger local view updates at a specific
+/// pace, avoiding unnecessary refreshes in other parts of the view hierarchy that do not need to be periodically
+/// refreshed.
 public final class ProgressTracker: ObservableObject {
-    /// The player to attach. Use `View.bind(_:to:)` in SwiftUI code.
+    /// The player to attach.
+    ///
+    /// Use `View.bind(_:to:)` in SwiftUI code.
     @Published public var player: Player?
 
-    /// Must be set to `true` to report user interaction to the progress tracker.
+    /// A Boolean describing whether user interaction is currently changing the progress value.
     @Published public var isInteracting = false {
         willSet {
             guard !newValue else { return }
@@ -27,8 +31,11 @@ public final class ProgressTracker: ObservableObject {
 
     private let seekBehavior: SeekBehavior
 
-    /// The current progress. Might be different from the player progress when interaction takes place. This property
-    /// returns 0 also when no progress information is available, which you can check using `isProgressAvailable`.
+    /// The current progress.
+    ///
+    /// The returned value might be different from the player progress when interaction takes place.
+    ///
+    /// This property returns 0 when no progress information is available, which you can check using `isProgressAvailable`.
     public var progress: Float {
         get {
             _progress ?? 0
@@ -41,13 +48,16 @@ public final class ProgressTracker: ObservableObject {
         }
     }
 
-    /// The time corresponding to the current progress. Might be different from the player current time when
-    /// interaction takes place. Guaranteed to be valid when returned.
+    /// The time corresponding to the current progress.
+    ///
+    /// The returned value might be different from the player current time when interaction takes place.
+    ///
+    /// Non-`nil` returned times are guaranteed to be valid.
     public var time: CMTime? {
         time(forProgress: _progress)
     }
 
-    /// Range for progress values.
+    /// The allowed range for progress values.
     public var range: ClosedRange<Float> {
         _progress != nil ? 0...1 : 0...0
     }
@@ -56,13 +66,15 @@ public final class ProgressTracker: ObservableObject {
         _progress != nil
     }
 
-    /// The current time range. Guaranteed to be valid when returned.
+    /// The current time range.
+    ///
+    /// Non-`nil` returned ranges are guaranteed to be valid.
     public var timeRange: CMTimeRange? {
         guard let timeRange = player?.timeRange, timeRange.isValidAndNotEmpty else { return nil }
         return timeRange
     }
 
-    /// Create a tracker updating its progress at the specified interval.
+    /// Creates a progress tracker updating its progress at the specified interval.
     /// - Parameter interval: The interval at which progress must be updated.
     public init(interval: CMTime, seekBehavior: SeekBehavior = .immediate) {
         self.seekBehavior = seekBehavior
@@ -120,7 +132,7 @@ public final class ProgressTracker: ObservableObject {
 }
 
 public extension View {
-    /// Bind a progress tracker to a player.
+    /// Binds a progress tracker to a player.
     /// - Parameters:
     ///   - progressTracker: The progress tracker to bind.
     ///   - player: The player to observe.

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -75,6 +75,7 @@ public final class ProgressTracker: ObservableObject {
     }
 
     /// Creates a progress tracker updating its progress at the specified interval.
+    /// 
     /// - Parameter interval: The interval at which progress must be updated.
     public init(interval: CMTime, seekBehavior: SeekBehavior = .immediate) {
         self.seekBehavior = seekBehavior
@@ -133,6 +134,7 @@ public final class ProgressTracker: ObservableObject {
 
 public extension View {
     /// Binds a progress tracker to a player.
+    ///
     /// - Parameters:
     ///   - progressTracker: The progress tracker to bind.
     ///   - player: The player to observe.

--- a/Sources/Player/UserInterface/RoutePickerView.swift
+++ b/Sources/Player/UserInterface/RoutePickerView.swift
@@ -8,14 +8,17 @@ import AVKit
 import SwiftUI
 
 /// A button to pick a playback route.
+///
 /// Behavior: h-exp, v-exp
 public struct RoutePickerView: UIViewRepresentable {
     private var prioritizesVideoDevices: Bool
     fileprivate var activeTintColor: Color?
 
-    /// Create the button.
-    /// - Parameter prioritizesVideoDevices: Whether or not the route picker should sort video capable output devices
-    ///   to the top of the list. Setting this to `true` will cause the route picker view to show a videocentric icon.
+    /// Creates a route picker button.
+    ///
+    /// - Parameter prioritizesVideoDevices: A Boolean setting whether or not the route picker should sort video
+    ///   capable output devices to the top of the list. Setting this to `true` will cause the route picker view to
+    ///   show a videocentric icon.
     public init(prioritizesVideoDevices: Bool = false) {
         self.prioritizesVideoDevices = prioritizesVideoDevices
     }
@@ -33,7 +36,8 @@ public struct RoutePickerView: UIViewRepresentable {
 }
 
 public extension RoutePickerView {
-    /// The view's tint color when AirPlay is active.
+    /// Sets the view's tint color to apply when AirPlay is active.
+    ///
     /// - Parameter color: The color to apply.
     /// - Returns: The view tinted with the specified color.
     func activeTintColor(_ color: Color) -> RoutePickerView {

--- a/Sources/Player/UserInterface/Slider.swift
+++ b/Sources/Player/UserInterface/Slider.swift
@@ -8,7 +8,8 @@ import SwiftUI
 
 @available(tvOS, unavailable)
 public extension Slider {
-    /// Create a slider bound to a progress tracker.
+    /// Creates a slider bound to a progress tracker.
+    ///
     /// - Parameters:
     ///   - progressTracker: The progress tracker.
     ///   - label: A view describing the slider purpose.
@@ -37,7 +38,8 @@ public extension Slider {
 
 @available(tvOS, unavailable)
 public extension Slider where ValueLabel == EmptyView {
-    /// Create a slider bound to a progress tracker.
+    /// Creates a slider bound to a progress tracker.
+    ///
     /// - Parameters:
     ///   - progressTracker: The progress tracker.
     ///   - label: A view describing the slider purpose.
@@ -60,7 +62,8 @@ public extension Slider where ValueLabel == EmptyView {
 
 @available(tvOS, unavailable)
 public extension Slider where Label == EmptyView, ValueLabel == EmptyView {
-    /// Create a slider bound to a progress tracker.
+    /// Creates a slider bound to a progress tracker.
+    /// 
     /// - Parameters:
     ///   - progressTracker: The progress tracker.
     ///   - onEditingChanged: A closure called when editing begins or ends.

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -7,10 +7,12 @@
 import AVKit
 import SwiftUI
 
-/// A video view with standard system user experience.
+/// A view providing the standard system playback user experience.
 ///
-/// Remark: A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback
-/// button. This issue has been reported to Apple as FB11934227.
+/// ### Remark
+///
+/// A bug in AVKit currently makes `SystemVideoView` leak resources after having interacted with the playback
+/// button on iOS 16. This issue has been reported to Apple as FB11934227.
 public struct SystemVideoView: View {
     @ObservedObject private var player: Player
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -24,6 +24,7 @@ public final class VideoLayerView: UIView {
 }
 
 /// A view displaying video content provided by an associated player.
+/// 
 /// Behavior: h-exp, v-exp
 public struct VideoView: UIViewRepresentable {
     @ObservedObject private var player: Player

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -9,14 +9,18 @@ import Core
 import Foundation
 import SwiftUI
 
-/// Tracks user interface visibility, managing auto hide after a delay.
+/// An observable object tracking user interface visibility.
+///
+/// The tracker automatically turns off visibility after a delay while playing content.
 @available(tvOS, unavailable)
 public final class VisibilityTracker: ObservableObject {
     private enum TriggerId {
         case reset
     }
 
-    /// The player to attach. Use `View.bind(_:to:)` in SwiftUI code.
+    /// The player to attach.
+    ///
+    /// Use `View.bind(_:to:)` in SwiftUI code.
     @Published public var player: Player?
 
     /// Returns whether the user interface should be hidden.
@@ -29,8 +33,7 @@ public final class VisibilityTracker: ObservableObject {
 
     private let trigger = Trigger()
 
-    /// Create a tracker managing user interface visibility and automatically setting visibility to hidden after
-    /// a delay.
+    /// Creates a tracker managing user interface visibility.
     /// - Parameters:
     ///   - delay: The delay after which `isUserInterfaceHidden` is automatically reset to `true`.
     ///   - isUserInterfaceHidden: The initial value for `isUserInterfaceHidden`.
@@ -64,12 +67,12 @@ public final class VisibilityTracker: ObservableObject {
             .assign(to: &$isUserInterfaceHidden)
     }
 
-    /// Toggle user interface visibility.
+    /// Toggles user interface visibility.
     public func toggle() {
         isUserInterfaceHidden.toggle()
     }
 
-    /// Reset user interface auto hide delay.
+    /// Resets user interface auto hide delay.
     public func reset() {
         guard !isUserInterfaceHidden else { return }
         trigger.activate(for: TriggerId.reset)
@@ -78,7 +81,8 @@ public final class VisibilityTracker: ObservableObject {
 
 @available(tvOS, unavailable)
 public extension View {
-    /// Bind a visibility tracker to a player.
+    /// Binds a visibility tracker to a player.
+    /// 
     /// - Parameters:
     ///   - visibilityTracker: The visibility tracker to bind.
     ///   - player: The player to observe.

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -34,6 +34,7 @@ public final class VisibilityTracker: ObservableObject {
     private let trigger = Trigger()
 
     /// Creates a tracker managing user interface visibility.
+    /// 
     /// - Parameters:
     ///   - delay: The delay after which `isUserInterfaceHidden` is automatically reset to `true`.
     ///   - isUserInterfaceHidden: The initial value for `isUserInterfaceHidden`.

--- a/Sources/Streams/Stream.swift
+++ b/Sources/Streams/Stream.swift
@@ -6,94 +6,103 @@
 
 import CoreMedia
 
-/// Sample streams.
+/// A stream description.
 public struct Stream {
-    /// On-demand.
+    /// An on-demand stream.
     public static let onDemand: Self = .init(
         url: URL(string: "http://localhost:8123/on_demand/master.m3u8")!,
         duration: CMTime(value: 120, timescale: 1)
     )
 
-    /// Short on-demand.
+    /// A short on-demand stream.
     public static let shortOnDemand: Self = .init(
         url: URL(string: "http://localhost:8123/on_demand_short/master.m3u8")!,
         duration: CMTime(value: 1, timescale: 1)
     )
 
-    /// Medium on-demand.
+    /// A medium-sized on-demand stream.
     public static let mediumOnDemand: Self = .init(
         url: URL(string: "http://localhost:8123/on_demand_medium/master.m3u8")!,
         duration: CMTime(value: 5, timescale: 1)
     )
 
-    /// Cropped on-demand.
+    /// A cropped on-demand stream.
     public static let croppedOnDemand: Self = .init(
         url: URL(string: "http://localhost:8123/on_demand_cropped/master.m3u8")!,
         duration: CMTime(value: 120, timescale: 1)
     )
 
-    /// Corrupt on-demand.
+    /// A corrupt on-demand stream.
     public static let corruptOnDemand: Self = .init(
         url: URL(string: "http://localhost:8123/on_demand_corrupt/master.m3u8")!,
         duration: CMTime(value: 2, timescale: 1)
     )
 
-    /// Live.
+    /// A live stream.
     public static let live: Self = .init(
         url: URL(string: "http://localhost:8123/live/master.m3u8")!,
         duration: .zero
     )
 
-    /// DVR.
+    /// A DVR stream.
     public static let dvr: Self = .init(
         url: URL(string: "http://localhost:8123/dvr/master.m3u8")!,
         duration: CMTime(value: 17 /* 20 - 3 * 1 (chunk) */, timescale: 1)
     )
 
-    /// MP3.
+    /// An MP3 stream.
     public static let mp3: Self = .init(
         url: Bundle.module.url(forResource: "silence", withExtension: "mp3")!,
         duration: CMTime(value: 5, timescale: 1)
     )
 
-    /// Unavailable.
+    /// An unavailable stream.
     public static let unavailable: Self = .init(
         url: URL(string: "http://localhost:8123/unavailable/master.m3u8")!,
         duration: .indefinite
     )
 
-    /// Custom.
+    /// A stream with a custom scheme.
+    ///
+    /// Not intended to be playable.
     public static let custom: Self = .init(
         url: URL(string: "custom://arbitrary.server/some.m3u8")!,
         duration: .indefinite
     )
 
-    /// Item.
+    /// A stream identifying some item in a playlist.
+    ///
+    /// Not intended to be playable, mostly useful for testing playlist mutations.
     public static let item: Self = .init(
         url: URL(string: "https://www.server.com/item.m3u8")!,
         duration: .indefinite
     )
 
-    /// Inserted item.
+    /// A stream identifying an item inserted into a playlist.
+    ///
+    /// Not intended to be playable, mostly useful for testing playlist mutations.
     public static let insertedItem: Self = .init(
         url: URL(string: "https://www.server.com/inserted.m3u8")!,
         duration: .indefinite
     )
 
-    /// Foreign item.
+    /// A stream identifying a foreign item not belonging to a playlist.
+    ///
+    /// Not intended to be playable, mostly useful for testing playlist mutations.
     public static let foreignItem: Self = .init(
         url: URL(string: "https://www.server.com/foreign.m3u8")!,
         duration: .indefinite
     )
 
-    /// URL.
+    /// The stream URL.
     public let url: URL
 
-    /// Duration.
+    /// The stream duration.
     public let duration: CMTime
 
-    /// A stream whose master playlist contains an index. Not meant to be playable but useful for testing `AVPlayerItem`
-    /// identity.
+    /// Returns a stream identifying some item in a playlist, having a specific index.
+    ///
+    /// Not intended to be playable, mostly useful for testing playlist mutations.
     /// - Parameter index: The index.
     /// - Returns: The stream.
     public static func item(numbered index: Int) -> Self {

--- a/Tests/AnalyticsTests/AnalyticsTestCase.swift
+++ b/Tests/AnalyticsTests/AnalyticsTestCase.swift
@@ -12,12 +12,12 @@ import XCTest
 
 final class AnalyticsTestsCase: TestCase {
     func testEmptyPageViewTitle() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.trackPageView(title: " ")).to(throwAssertion())
     }
 
     func testEmptyEventTitle() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.sendEvent(name: " ")).to(throwAssertion())
     }
 }

--- a/Tests/CoreTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/CoreTests/RangeReplaceableCollectionTests.swift
@@ -36,14 +36,14 @@ final class RangeReplaceableCollectionTests: XCTestCase {
     }
 
     func testMoveFromInvalidIndex() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: -1, to: 2)).to(throwAssertion())
         expect(array.move(from: 8, to: 2)).to(throwAssertion())
     }
 
     func testMoveToInvalidIndex() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: 2, to: -1)).to(throwAssertion())
         expect(array.move(from: 2, to: 8)).to(throwAssertion())

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -24,7 +24,7 @@ private class QueuePlayerMock: QueuePlayer {
 
 final class QueuePlayerSeekTests: TestCase {
     func testNotificationsForSeekWithInvalidTime() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         expect { player.seek(to: .invalid) }.to(throwAssertion())

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -101,7 +101,7 @@ final class VisibilityTrackerTests: TestCase {
     }
 
     func testInvalidDelay() {
-        guard nimbleThrowAssertionsEnabled() else { return }
+        guard nimbleThrowAssertionsAvailable() else { return }
         expect(VisibilityTracker(delay: -5)).to(throwAssertion())
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR polishes overall documentation consistency following practices seen e.g. in SwiftUI documentation.

# Changes made

- Updated documentation.
- Fix minor implementation issues along the way.

# Conventions

Without delving into too many details here is the general documentation format applied:

```swift
/// An observable audio / video player maintaining its items as a double-ended queue (deque).
///
/// The player provides the following features:
/// ...
/// ### Usage
/// ...
public final class Player: ObservableObject, Equatable {
    /// The current playback state.
    @Published public private(set) var playbackState: PlaybackState = .idle

    /// Creates a player with a given item queue.
    ///
    /// - Parameters:
    ///   - items: The items to be queued initially.
    ///   - configuration: The configuration to apply to the player.
    /// 
    /// The player is initially loaded with items
    public init(items: [PlayerItem] = [], configuration: PlayerConfiguration = .init()) {}
}
```

For types:

- Types are described with a short sentence starting with _A_ or _An_ since we can instantiate several instances of them.
- A longer discussion is provided after adding an empty line.
- Sections use `###` for headers.

For properties:

- The description is kept short, starting with _The_.
- A longer discussion is provided after adding an empty line.

For methods:

- The description is kept short, starting with _The_ and a verb describing an action, like _Moves_ or _Inserts_.
- Parameters and return values are added afterwards.
- A longer discussion is provided after adding an empty line.

In general:

- Bullet points are surrounded with empty lines.
- Swift code is not indented and marked with `swift`.

Applying these rules consistently ensure great integration with Xcode.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
