### PR TITLE
Automatically resume playback when returning from background in specific demos

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		6F59E8A229CF31E20093E6FB /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E87529CF31E10093E6FB /* Logger.swift */; };
 		6F59E8A329CF31E20093E6FB /* ExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E87729CF31E10093E6FB /* ExamplesView.swift */; };
 		6F59E8A429CF31E20093E6FB /* ExamplesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E87829CF31E10093E6FB /* ExamplesViewModel.swift */; };
+		6F8459F22A38543400A7B5F2 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8459F12A38543400A7B5F2 /* Signal.swift */; };
 		6F917C0E2887EA8E004113BA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F917C082887EA8E004113BA /* Assets.xcassets */; };
 		6F917C112887EA8E004113BA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F917C0D2887EA8E004113BA /* Preview Assets.xcassets */; };
 		6F9B5BC928CF8C530074B9E0 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9B5BC828CF8C530074B9E0 /* OrderedCollections */; };
@@ -118,6 +119,7 @@
 		6F59E87529CF31E10093E6FB /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		6F59E87729CF31E10093E6FB /* ExamplesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExamplesView.swift; sourceTree = "<group>"; };
 		6F59E87829CF31E10093E6FB /* ExamplesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExamplesViewModel.swift; sourceTree = "<group>"; };
+		6F8459F12A38543400A7B5F2 /* Signal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
 		6F917C082887EA8E004113BA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6F917C0D2887EA8E004113BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6F9DDB40288FE8F80069B687 /* pillarbox-apple */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "pillarbox-apple"; path = ..; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 			children = (
 				6F59E87329CF31E10093E6FB /* Constant.swift */,
 				6F59E87529CF31E10093E6FB /* Logger.swift */,
+				6F8459F12A38543400A7B5F2 /* Signal.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -518,6 +521,7 @@
 				6F59E88329CF31E20093E6FB /* MediaDescription.swift in Sources */,
 				6F59E8A429CF31E20093E6FB /* ExamplesViewModel.swift in Sources */,
 				6F59E89829CF31E20093E6FB /* PlayerConfiguration.swift in Sources */,
+				6F8459F22A38543400A7B5F2 /* Signal.swift in Sources */,
 				0E84D6162A12753100EB48C5 /* SettingsMenu.swift in Sources */,
 				6F59E88B29CF31E20093E6FB /* PlaylistViewModel.swift in Sources */,
 				6F59E87F29CF31E10093E6FB /* Template.swift in Sources */,

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -18,11 +18,30 @@ struct SimplePlayerView: View {
     var body: some View {
         ZStack {
             VideoView(player: player)
-            ProgressView()
-                .opacity(player.isBusy ? 1 : 0)
+            progressView()
+            playbackButton()
         }
         .onAppear(perform: play)
         .tracked(title: "simple-player")
+    }
+
+    @ViewBuilder
+    private func progressView() -> some View {
+        ProgressView()
+            .opacity(player.isBusy ? 1 : 0)
+    }
+
+    @ViewBuilder
+    private func playbackButton() -> some View {
+        Button(action: player.togglePlayPause) {
+            Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 50)
+                .tint(.white)
+                .shadow(radius: 5)
+                .opacity(player.isBusy ? 0 : 1)
+        }
     }
 
     private func play() {

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -5,6 +5,7 @@
 //
 
 import Analytics
+import Combine
 import Player
 import SwiftUI
 
@@ -25,12 +26,21 @@ struct BlurredView: View {
         }
         .background(.black)
         .onAppear(perform: play)
+        .onReceive(applicationWillEnterForegroundPublisher()) { _ in
+            player.play()
+        }
         .tracked(title: "blurred")
     }
 
     private func play() {
         player.append(media.playerItem())
         player.play()
+    }
+
+    private func applicationWillEnterForegroundPublisher() -> AnyPublisher<Void, Never> {
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .map { _ in () }
+            .eraseToAnyPublisher()
     }
 }
 

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -26,21 +26,13 @@ struct BlurredView: View {
         }
         .background(.black)
         .onAppear(perform: play)
-        .onReceive(applicationWillEnterForegroundPublisher()) { _ in
-            player.play()
-        }
+        .onForeground(perform: player.play)
         .tracked(title: "blurred")
     }
 
     private func play() {
         player.append(media.playerItem())
         player.play()
-    }
-
-    private func applicationWillEnterForegroundPublisher() -> AnyPublisher<Void, Never> {
-        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
-            .map { _ in () }
-            .eraseToAnyPublisher()
     }
 }
 

--- a/Demo/Sources/Showcase/LinkView.swift
+++ b/Demo/Sources/Showcase/LinkView.swift
@@ -26,11 +26,16 @@ struct LinkView: View {
                 .padding()
         }
         .onAppear(perform: play)
+        .onForeground(perform: resume)
         .tracked(title: "link")
     }
 
     private func play() {
         player.append(media.playerItem())
+        player.play()
+    }
+
+    private func resume() {
         player.play()
     }
 }

--- a/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
@@ -71,8 +71,7 @@ final class StoriesViewModel: ObservableObject {
     }
 
     private func configureAutomaticResume() {
-        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
-            .map { _ in () }
+        Signal.applicationWillEnterForeground()
             .prepend(())
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
@@ -4,13 +4,16 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 import OrderedCollections
 import Player
+import UIKit
 
 final class StoriesViewModel: ObservableObject {
     private static let preloadDistance = 1
     private var players = OrderedDictionary<Story, Player?>()
+    private var cancellables = Set<AnyCancellable>()
 
     var stories: [Story] {
         Array(players.keys)
@@ -29,7 +32,7 @@ final class StoriesViewModel: ObservableObject {
         let currentStory = stories.first!
         self.currentStory = currentStory
         players = Self.players(for: stories, around: currentStory, reusedFrom: [:])
-        player(for: currentStory).play()
+        configureAutomaticResume()
     }
 
     private static func player(for story: Story) -> Player {
@@ -65,5 +68,16 @@ final class StoriesViewModel: ObservableObject {
         else {
             return Player()
         }
+    }
+
+    private func configureAutomaticResume() {
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .map { _ in () }
+            .prepend(())
+            .sink { [weak self] _ in
+                guard let self else { return }
+                player(for: currentStory).play()
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Demo/Sources/Showcase/TwinsView.swift
+++ b/Demo/Sources/Showcase/TwinsView.swift
@@ -40,11 +40,16 @@ struct TwinsView: View {
             .padding()
         }
         .onAppear(perform: play)
+        .onForeground(perform: resume)
         .tracked(title: "twins")
     }
 
     private func play() {
         player.append(media.playerItem())
+        player.play()
+    }
+
+    private func resume() {
         player.play()
     }
 }

--- a/Demo/Sources/Showcase/Wrapped/WrappedView.swift
+++ b/Demo/Sources/Showcase/Wrapped/WrappedView.swift
@@ -29,6 +29,7 @@ struct WrappedView: View {
             .padding()
         }
         .onAppear(perform: play)
+        .onForeground(perform: resume)
         .tracked(title: "wrapped")
     }
 
@@ -36,6 +37,10 @@ struct WrappedView: View {
         let player = Player(item: media.playerItem(), configuration: .externalPlaybackDisabled)
         model.player = player
         player.play()
+    }
+
+    private func resume() {
+        model.player.play()
     }
 
     private func stop() {

--- a/Demo/Sources/Tools/Signal.swift
+++ b/Demo/Sources/Tools/Signal.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import SwiftUI
+
+enum Signal {
+    static func applicationWillEnterForeground() -> AnyPublisher<Void, Never> {
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}
+
+extension View {
+    func onForeground(perform action: @escaping () -> Void) -> some View {
+        onReceive(Signal.applicationWillEnterForeground(), perform: action)
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves the demo to automatically resume playback after the app returned from background, especially in demos where no playback button is available.

# Changes made

- Add playback button to the simple demo.
- Add auto-resume to the stories example.
- Add auto-resume to the blurred, linked and twins demos.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
