### PR TITLE
Add a new `animation` method that take two values

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -31,8 +31,7 @@ private struct MainView: View {
                 timeBar()
                 volumeButton()
             }
-            .animation(.defaultLinear, value: player.isBusy)
-            .animation(.defaultLinear, value: isUserInterfaceHidden)
+            .animation(.defaultLinear, values: player.isBusy, isUserInterfaceHidden)
         }
         .bind(visibilityTracker, to: player)
         ._debugBodyCounter()
@@ -188,8 +187,7 @@ private struct PlaybackButton: View {
                 .resizable()
                 .tint(.white)
                 .opacity(player.isBusy ? 0 : 1)
-                .animation(.defaultLinear, value: player.playbackState)
-                .animation(.defaultLinear, value: player.canRestart())
+                .animation(.defaultLinear, values: player.playbackState, player.canRestart())
         }
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -11,4 +11,9 @@ extension View {
     func preventsTouchPropagation() -> some View {
         background(Color(white: 1, opacity: 0.0001))
     }
+
+    func animation<V1, V2>(_ animation: Animation?, values v1: V1, _ v2: V2) -> some View where V1: Equatable, V2: Equatable {
+        self.animation(animation, value: v1)
+            .animation(animation, value: v2)
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to use `animation` modifier with two values.

# Changes made

- New animation method added as extension of `View` within the demo app.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
