### PR TITLE
Fix analytics

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -45,7 +45,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     private func configureAnalytics() {
         let configuration = Analytics.Configuration(
-            vendor: .RTS,
+            vendor: .SRG,
             sourceKey: "11111111-1111-1111-1111-111111111111",
             site: "rts-app-test-v"
         )

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -61,7 +61,7 @@ public final class ComScoreTracker: PlayerItemTracker {
 
     private func notify(playbackState: PlaybackState, isSeeking: Bool, isBuffering: Bool, player: Player) {
         guard !metadata.labels.isEmpty else { return }
-        
+
         AnalyticsListener.capture(streamingAnalytics.configuration())
         streamingAnalytics.setProperties(for: player, streamType: metadata.streamType)
 
@@ -89,46 +89,6 @@ public final class ComScoreTracker: PlayerItemTracker {
         builder.setCustomLabels(metadata.labels)
         let contentMetadata = SCORStreamingContentMetadata(builder: builder)
         streamingAnalytics.setMetadata(contentMetadata)
-    }
-}
-
-private extension SCORStreamingAnalytics {
-    private static func duration(for player: Player) -> Int {
-        player.timeRange.isValid ? Int(player.timeRange.duration.seconds.toMilliseconds) : 0
-    }
-
-    private static func position(for player: Player) -> Int {
-        player.time.isValid ? Int(player.time.seconds.toMilliseconds) : 0
-    }
-
-    private static func offset(for player: Player) -> Int {
-        guard player.timeRange.isValid, player.time.isValid else { return 0 }
-        let offset = player.timeRange.end - player.time
-        return Int(offset.seconds.toMilliseconds)
-    }
-
-    func notifyEvent(for playbackState: PlaybackState, at rate: Float) {
-        switch playbackState {
-        case .playing:
-            notifyChangePlaybackRate(rate)
-            notifyPlay()
-        case .paused:
-            notifyPause()
-        case .ended:
-            notifyEnd()
-        default:
-            break
-        }
-    }
-
-    func setProperties(for player: Player, streamType: StreamType) {
-        if streamType == .dvr {
-            start(fromDvrWindowOffset: Self.offset(for: player))
-            setDVRWindowLength(Self.duration(for: player))
-        }
-        else {
-            start(fromPosition: Self.position(for: player))
-        }
     }
 }
 

--- a/Sources/Analytics/ComScore/SCORStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/SCORStreamingAnalytics.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import ComScore
+import CoreMedia
+import Player
+
+extension SCORStreamingAnalytics {
+    private static func duration(for player: Player) -> Int {
+        player.timeRange.isValid ? Int(player.timeRange.duration.seconds.toMilliseconds) : 0
+    }
+
+    private static func position(for player: Player) -> Int {
+        player.time.isValid ? Int(player.time.seconds.toMilliseconds) : 0
+    }
+
+    private static func offset(for player: Player) -> Int {
+        guard player.timeRange.isValid, player.time.isValid else { return 0 }
+        let offset = player.timeRange.end - player.time
+        return Int(offset.seconds.toMilliseconds)
+    }
+
+    func notifyEvent(for playbackState: PlaybackState, at rate: Float) {
+        switch playbackState {
+        case .playing:
+            notifyChangePlaybackRate(rate)
+            notifyPlay()
+        case .paused:
+            notifyPause()
+        case .ended:
+            notifyEnd()
+        default:
+            break
+        }
+    }
+
+    func setProperties(for player: Player, streamType: StreamType) {
+        if streamType == .dvr {
+            start(fromDvrWindowOffset: Self.offset(for: player))
+            setDVRWindowLength(Self.duration(for: player))
+        }
+        else {
+            start(fromPosition: Self.position(for: player))
+        }
+    }
+}

--- a/Sources/Analytics/Vendor.swift
+++ b/Sources/Analytics/Vendor.swift
@@ -18,4 +18,6 @@ public enum Vendor: String {
     case RTR
     /// SWI.
     case SWI
+    /// SRG.
+    case SRG
 }

--- a/Sources/Player/Tracking/CurrentTracker.swift
+++ b/Sources/Player/Tracking/CurrentTracker.swift
@@ -13,8 +13,8 @@ final class CurrentTracker {
 
     init(item: PlayerItem, player: Player) {
         self.item = item
-        configureTrackingPublisher(player: player)
         configureAssetPublisher(for: item)
+        configureTrackingPublisher(player: player)
     }
 
     private func configureTrackingPublisher(player: Player) {

--- a/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
@@ -18,7 +18,7 @@ final class ComScorePageViewTests: ComScoreTestCase {
                 expect(labels.ns_category).to(equal("title"))
                 expect(labels.ns_st_mp).to(beNil())
                 expect(labels.ns_st_mv).to(beNil())
-                expect(labels.mp_brand).to(equal("RTS"))
+                expect(labels.mp_brand).to(equal("SRG"))
                 expect(labels.mp_v).notTo(beEmpty())
             }
         ) {

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -28,7 +28,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(labels.app_library_version).to(equal(PackageInfo.version))
                 expect(labels.navigation_app_site_name).to(equal("site"))
                 expect(labels.navigation_property_type).to(equal("app"))
-                expect(labels.navigation_bu_distributer).to(equal("RTS"))
+                expect(labels.navigation_bu_distributer).to(equal("SRG"))
             }
         ) {
             Analytics.shared.trackPageView(title: "title", levels: [

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -14,7 +14,7 @@ import XCTest
 class TestCase: XCTestCase {
     override class func setUp() {
         PollingDefaults.timeout = .seconds(20)
-        try? Analytics.shared.start(with: .init(vendor: .RTS, sourceKey: "source", site: "site"))
+        try? Analytics.shared.start(with: .init(vendor: .SRG, sourceKey: "source", site: "site"))
     }
 
     override class func tearDown() {

--- a/Tests/PlayerTests/Analytics/PlayerItemTrackerTests.swift
+++ b/Tests/PlayerTests/Analytics/PlayerItemTrackerTests.swift
@@ -72,7 +72,7 @@ final class PlayerItemTrackerTests: TestCase {
     func testMetadata() {
         let player = Player()
         let publisher = TrackerMock<String>.StatePublisher()
-        expectAtLeastEqualPublished(values: [.initialized, .enabled, .updated("title"), .disabled], from: publisher) {
+        expectAtLeastEqualPublished(values: [.initialized, .updated("title"), .enabled, .disabled], from: publisher) {
             player.append(.simple(
                 url: Stream.shortOnDemand.url,
                 metadata: AssetMetadataMock(title: "title"),
@@ -86,7 +86,7 @@ final class PlayerItemTrackerTests: TestCase {
         let player = Player()
         let publisher = TrackerMock<String>.StatePublisher()
         expectAtLeastEqualPublished(
-            values: [.initialized, .enabled, .updated("title0"), .updated("title1"), .disabled],
+            values: [.initialized, .updated("title0"), .enabled, .updated("title1"), .disabled],
             from: publisher
         ) {
             player.append(.mock(url: Stream.shortOnDemand.url, withMetadataUpdateAfter: 1, trackerAdapters: [

--- a/Tests/PlayerTests/Analytics/PlayerTrackingTests.swift
+++ b/Tests/PlayerTests/Analytics/PlayerTrackingTests.swift
@@ -71,7 +71,7 @@ final class PlayerTrackingTests: TestCase {
         let publisher = TrackerMock<String>.StatePublisher()
 
         expectEqualPublished(
-            values: [.initialized, .enabled, .updated("title")],
+            values: [.initialized, .updated("title"), .enabled],
             from: publisher,
             during: .seconds(1)
         ) {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fix some issues related to the analytics.

# Changes made

- Constant `SRG` vendor has been added for Play Suisse.
- Fix the `playrt` comScore event that was sent several times.
- Avoid the lack of metadata when the `play` event is sent.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
