### PR TITLE
Apply the speed even though the player is paused

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -232,8 +232,8 @@ private extension Player {
     func configureRateUpdatePublisher() {
         $_playbackSpeed
             .sink { [queuePlayer] speed in
-                guard queuePlayer.rate != 0 else { return }
                 queuePlayer.defaultRate = speed.effectiveValue
+                guard queuePlayer.rate != 0 else { return }
                 queuePlayer.rate = speed.effectiveValue
             }
             .store(in: &cancellables)

--- a/Tests/PlayerTests/Player/SpeedTests.swift
+++ b/Tests/PlayerTests/Player/SpeedTests.swift
@@ -160,6 +160,17 @@ final class SpeedTests: TestCase {
         expect(player.queuePlayer.rate).toEventually(equal(2))
     }
 
+    func testSpeedUpdateWhilePausedMustUpdateRate() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        expect(player.playbackState).toEventually(equal(.paused))
+
+        player.setDesiredPlaybackSpeed(2)
+        player.play()
+
+        expect(player.queuePlayer.defaultRate).toEventually(equal(2))
+        expect(player.queuePlayer.rate).toEventually(equal(2))
+    }
+
     func testSpeedUpdateMustNotResumePlayback() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.playbackState).toEventually(equal(.paused))


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes the speed update when the player is paused.

# Changes made

- The `defaultRate` is now updated even though the player is paused. 

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
