### PR TITLE
419 avoid measuring video streaming in background

### DIFF
--- a/Sources/Analytics/ApplicationState.swift
+++ b/Sources/Analytics/ApplicationState.swift
@@ -1,0 +1,12 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum ApplicationState {
+    case foreground
+    case background
+}

--- a/Sources/Analytics/ComScore/ComScoreService.swift
+++ b/Sources/Analytics/ComScore/ComScoreService.swift
@@ -26,7 +26,6 @@ struct ComScoreService {
             comScoreConfiguration.addClient(with: publisherConfiguration)
 
             comScoreConfiguration.applicationVersion = applicationVersion
-            comScoreConfiguration.usagePropertiesAutoUpdateMode = .foregroundAndBackground
             comScoreConfiguration.preventAdSupportUsage = true
             comScoreConfiguration.addPersistentLabels([
                 "mp_brand": configuration.vendor.rawValue,

--- a/Sources/Analytics/UIApplication.swift
+++ b/Sources/Analytics/UIApplication.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Core
+import UIKit
+
+extension UIApplication {
+    func applicationStatePublisher() -> AnyPublisher<ApplicationState, Never> {
+        Publishers.Merge(
+            NotificationCenter.default.weakPublisher(for: UIApplication.didEnterBackgroundNotification, object: self)
+                .map { _ in .background },
+            NotificationCenter.default.weakPublisher(for: UIApplication.didBecomeActiveNotification, object: self)
+                .map { _ in .foreground }
+        )
+        .prepend(applicationState == .background ? .background : .foreground)
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to ignore ComScore streaming analytics in background.

# Changes made

- `usagePropertiesAutoUpdateMode` property is not used anymore. 
- New state `ApplicationState` has been introduced.
- A new publisher `applicationStatePublisher` has been added.
- ComScore streaming analytics are paused when the app is in background.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
