### PR TITLE
Automatically link against AdSupport.framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,10 @@ let package = Package(
                 .target(name: "Player"),
                 .product(name: "ComScore", package: "Comscore-Swift-Package-Manager"),
                 .product(name: "TCCore", package: "iOSV5"),
-                .product(name: "TCServerSide_noIDFA", package: "iOSV5")
+                .product(name: "TCServerSide", package: "iOSV5")
+            ],
+            linkerSettings: [
+                .linkedFramework("AdSupport")
             ],
             plugins: [
                 .plugin(name: "PackageInfoPlugin")

--- a/Sources/Analytics/AnalyticsListener.swift
+++ b/Sources/Analytics/AnalyticsListener.swift
@@ -7,7 +7,7 @@
 import Combine
 import ComScore
 import Foundation
-import TCServerSide_noIDFA
+import TCServerSide
 
 /// A listener for analytics events.
 ///

--- a/Sources/Analytics/CommandersAct/CommandersActInterceptor.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActInterceptor.swift
@@ -6,7 +6,7 @@
 
 import Combine
 import Foundation
-import TCServerSide_noIDFA
+import TCServerSide
 
 /// A tool that intercepts Commanders Act requests and turns them into an event stream.
 enum CommandersActInterceptor {

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import TCCore
-import TCServerSide_noIDFA
+import TCServerSide
 
 final class CommandersActService {
     private var serverSide: ServerSide?


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR automatically links against AdSupport.framework. This does not impact user privacy negatively and does not require dedicated documentation, making analytics integration more straightforward.

# Changes made

- Update package manifest.
- Link against the IDFA-compatible version of TCServerSide.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
