### PR TITLE
Fix conflict with standard Commanders Act event

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -46,6 +46,7 @@ public struct CommandersActEvent {
 
         /// Creates an event from a raw string.
         public init?(rawValue: String?) {
+            // swiftlint:disable:previous cyclomatic_complexity
             guard let rawValue else { return nil }
             switch rawValue {
             case "play":

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -9,7 +9,7 @@ import Foundation
 /// An event sent by the Commanders Act SDK.
 public struct CommandersActEvent {
     /// A name describing a Commanders Act event.
-    public enum Name: String {
+    public enum Name: Equatable {
         case play
         case pause
         case seek
@@ -18,7 +18,56 @@ public struct CommandersActEvent {
         case pos
         case uptime
         case page_view
-        case hidden_event
+        case custom(String)
+
+        /// Returns the event raw representation.
+        public var rawValue: String {
+            switch self {
+            case .play:
+                return "play"
+            case .pause:
+                return "pause"
+            case .seek:
+                return "seek"
+            case .stop:
+                return "stop"
+            case .eof:
+                return "eof"
+            case .pos:
+                return "pos"
+            case .uptime:
+                return "uptime"
+            case .page_view:
+                return "page_view"
+            case let .custom(name):
+                return name
+            }
+        }
+
+        /// Creates an event from a raw string.
+        public init?(rawValue: String?) {
+            guard let rawValue else { return nil }
+            switch rawValue {
+            case "play":
+                self = .play
+            case "pause":
+                self = .pause
+            case "seek":
+                self = .seek
+            case "stop":
+                self = .stop
+            case "eof":
+                self = .eof
+            case "pos":
+                self = .pos
+            case "uptime":
+                self = .uptime
+            case "page_view":
+                self = .page_view
+            default:
+                self = .custom(rawValue)
+            }
+        }
     }
 
     /// The event name.

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -72,10 +72,6 @@ public struct CommandersActLabels: Decodable {
 
     // MARK: Event labels
 
-    /// The value of `event_title`.
-    /// FIXME: This field was introduced to avoid clashes with `event_name` but still needs to be discussed.
-    public let event_title: String?
-
     /// The value of `event_type`.
     public let event_type: String?
 
@@ -160,7 +156,6 @@ private extension CommandersActLabels {
         case navigation_level_8
         case navigation_level_9
         case page_type
-        case event_title
         case event_type
         case event_value
         case event_source

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -49,10 +49,9 @@ final class CommandersActService {
     }
 
     func sendEvent(_ event: Event) {
-        guard let serverSide, let customEvent = TCCustomEvent(name: "hidden_event") else { return }
+        guard let serverSide, let customEvent = TCCustomEvent(name: event.name) else { return }
 
         let eventProperties = [
-            "event_title": event.name,
             "event_type": event.type,
             "event_value": event.value,
             "event_source": event.source,

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventExpectation.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventExpectation.swift
@@ -58,9 +58,9 @@ struct CommandersActEventExpectation {
         .init(name: .page_view, evaluate: evaluate)
     }
 
-    /// Hidden event
-    static func hidden_event(evaluate: @escaping (CommandersActLabels) -> Void = { _ in }) -> Self {
-        .init(name: .hidden_event, evaluate: evaluate)
+    /// Custom event.
+    static func custom(name: String, evaluate: @escaping (CommandersActLabels) -> Void = { _ in }) -> Self {
+        .init(name: .custom(name), evaluate: evaluate)
     }
 }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -13,8 +13,7 @@ import XCTest
 final class CommandersActEventTests: CommandersActTestCase {
     func testLabels() {
         expectAtLeastEvents(
-            .hidden_event { labels in
-                expect(labels.event_title).to(equal("name"))
+            .custom(name: "name") { labels in
                 expect(labels.event_type).to(equal("type"))
                 expect(labels.event_value).to(equal("value"))
                 expect(labels.event_source).to(equal("source"))
@@ -39,10 +38,10 @@ final class CommandersActEventTests: CommandersActTestCase {
         }
     }
 
-    func testEmptyLabels() {
+    func testBlankLabels() {
         expectAtLeastEvents(
-            .hidden_event { labels in
-                expect(labels.event_title).to(equal("name"))
+            .custom(name: "name") { labels in
+                expect(labels.event_name).to(equal("name"))
                 expect(labels.event_type).to(beNil())
                 expect(labels.event_value).to(beNil())
                 expect(labels.event_source).to(beNil())


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes a conflict with a standard Commanders Act field, affecting events.

# Changes made

- Update test helpers to parse events with custom names.
- Update tests according to decisions (see related issue).
- Update code to pass tests again.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
