### PR TITLE
Make the project compile again with Xcode 14

### DIFF
--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -136,15 +136,20 @@ struct SettingsView: View {
     }
 }
 
-fileprivate extension View {
+private extension View {
     @ViewBuilder
     func pulseEffect() -> some View {
+        // TODO: Remove when Xcode 15 has been released
+#if compiler(>=5.9)
         if #available(iOS 17, tvOS 17, *) {
             symbolEffect(.pulse)
         }
         else {
             self
         }
+#else
+        self
+#endif
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR ensures the project can still be compiled with Xcode 14, though we are readily working primarily with Xcode 15.

# Changes made

- Use preprocessor macro to avoid compiling code referencing iOS 17 APIs ([cannot](https://forums.swift.org/t/do-we-need-something-like-if-available/40349/27) use `__IPHONE_17_0` in Swift, though).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
