### PR TITLE
Remove media bandwidth from CommandersAct analytics

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -8,7 +8,6 @@ import Foundation
 
 /// The labels associated with a Commanders Act event.
 public struct CommandersActLabels: Decodable {
-    private let _media_bandwidth: String?
     private let _media_playback_rate: String?
     private let _media_position: String?
     private let _media_timeshift: String?
@@ -104,11 +103,6 @@ public struct CommandersActLabels: Decodable {
     /// The value of `media_player_version`.
     public let media_player_version: String?
 
-    /// The value of `media_bandwidth`.
-    public var media_bandwidth: Double? {
-        extract(\._media_bandwidth)
-    }
-
     /// The value of `media_playback_rate`.
     public var media_playback_rate: Float? {
         extract(\._media_playback_rate)
@@ -166,7 +160,6 @@ private extension CommandersActLabels {
         case event_value_5
         case media_player_display
         case media_player_version
-        case _media_bandwidth = "media_bandwidth"
         case _media_playback_rate = "media_playback_rate"
         case _media_position = "media_position"
         case _media_timeshift = "media_timeshift"

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -105,8 +105,7 @@ private extension CommandersActTracker {
             "media_player_display": "Pillarbox",
             "media_player_version": PackageInfo.version,
             "media_volume": "\(volume(for: player))",
-            "media_playback_rate": "\(player.effectivePlaybackSpeed)",
-            "media_bandwidth": "\(bitrate(for: player))"
+            "media_playback_rate": "\(player.effectivePlaybackSpeed)"
         ]) { _, new in new }
     }
 }

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -21,7 +21,6 @@ public struct TrackerAdapter<M: AssetMetadata> {
     ///   - configuration: The tracker configuration.
     ///   - mapper: The metadata mapper.
     public init<T>(trackerType: T.Type, configuration: T.Configuration, mapper: ((M) -> T.Metadata)?) where T: PlayerItemTracker {
-        // swiftlint:disable:next private_subject
         let metadataSubject = CurrentValueSubject<T.Metadata?, Never>(nil)
         let metadataPublisher = metadataSubject.compactMap { $0 }.eraseToAnyPublisher()
         let tracker = trackerType.init(configuration: configuration, metadataPublisher: metadataPublisher)

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -21,7 +21,6 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_playback_rate).to(equal(0.5))
-                expect(labels.media_bandwidth).to(equal(0))
                 expect(labels.media_title).to(equal("title"))
             }
         ) {
@@ -59,7 +58,6 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_playback_rate).to(equal(1))
-                expect(labels.media_bandwidth).to(equal(0))
                 expect(labels.media_title).to(equal("title"))
             }
         ) {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to remove useless `bandwidth` sent to `CommandersAct`. 

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
