### PR TITLE
Rename site by appSiteName for the analytics configuration

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -47,7 +47,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         let configuration = Analytics.Configuration(
             vendor: .SRG,
             sourceKey: "39ae8f94-595c-4ca4-81f7-fb7748bd3f04",
-            site: "pillarbox-demo-apple"
+            appSiteName: "pillarbox-demo-apple"
         )
         try? Analytics.shared.start(with: configuration)
     }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -24,18 +24,20 @@ public class Analytics {
     public struct Configuration {
         let vendor: Vendor
         let sourceKey: String
-        let site: String
+        let appSiteName: String
 
         /// Creates an analytics configuration.
+        ///
+        /// Contact the ADI team to get configuration parameters for your app.
         ///
         /// - Parameters:
         ///   - vendor: The vendor which the application belongs to.
         ///   - sourceKey: The source key.
-        ///   - site: The site name.
-        public init(vendor: Vendor, sourceKey: String, site: String) {
+        ///   - appSiteName: The app/site name.
+        public init(vendor: Vendor, sourceKey: String, appSiteName: String) {
             self.vendor = vendor
             self.sourceKey = sourceKey
-            self.site = site
+            self.appSiteName = appSiteName
         }
     }
 

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -30,7 +30,7 @@ final class CommandersActService {
         TCDebug.setDebugLevel(TCLogLevel_None)
         guard let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) else { return }
         serverSide.addPermanentData("app_library_version", withValue: PackageInfo.version)
-        serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.site)
+        serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
         serverSide.addPermanentData("navigation_device", withValue: Self.device())
         serverSide.enableRunningInBackground()
         self.serverSide = serverSide

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -14,7 +14,7 @@ import XCTest
 class TestCase: XCTestCase {
     override class func setUp() {
         PollingDefaults.timeout = .seconds(20)
-        try? Analytics.shared.start(with: .init(vendor: .SRG, sourceKey: "source", site: "site"))
+        try? Analytics.shared.start(with: .init(vendor: .SRG, sourceKey: "source", appSiteName: "site"))
     }
 
     override class func tearDown() {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to rename the `site` parameter of the analytics configuration by `appSiteName`.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
