### PR TITLE
Fix slider label contrast issues

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -415,8 +415,12 @@ private struct TimeSlider: View {
     var body: some View {
         PlaybackSlider(
             progressTracker: progressTracker,
-            minimumValueLabel: { Text(formattedElapsedTime ?? "") },
-            maximumValueLabel: { Text(formattedTotalTime ?? "") }
+            minimumValueLabel: {
+                label(withText: formattedElapsedTime)
+            },
+            maximumValueLabel: {
+                label(withText: formattedTotalTime)
+            }
         )
         .foregroundColor(.white)
         .tint(.white)
@@ -441,7 +445,9 @@ private struct TimeSlider: View {
     private func label(withText text: String?) -> some View {
         if let text {
             Text(text)
+                .font(.caption)
                 .monospacedDigit()
+                .foregroundColor(.white)
         }
     }
 }

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -8,7 +8,7 @@ import Player
 import SwiftUI
 
 #if os(iOS)
-struct PlaybackSlider<ValueLabel: View>: View {
+struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
 
     let minimumValueLabel: () -> ValueLabel
@@ -41,7 +41,7 @@ struct PlaybackSlider<ValueLabel: View>: View {
         label()
             .font(.caption)
             .monospacedDigit()
-            .foregroundColor(.gray)
+            .foregroundColor(.white)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -18,9 +18,9 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
     var body: some View {
         HStack {
-            format(minimumValueLabel)
+            minimumValueLabel()
             progressBar()
-            format(maximumValueLabel)
+            maximumValueLabel()
         }
         .frame(height: 8)
         .frame(maxWidth: .infinity)
@@ -34,14 +34,6 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         self.progressTracker = progressTracker
         self.minimumValueLabel = minimumValueLabel
         self.maximumValueLabel = maximumValueLabel
-    }
-
-    @ViewBuilder
-    private func format(_ label: () -> ValueLabel) -> some View {
-        label()
-            .font(.caption)
-            .monospacedDigit()
-            .foregroundColor(.white)
     }
 
     @ViewBuilder


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes slider labels contrast issues on our custom player layout, mostly visible when holding a phone in landscape orientation.

# Changes made

- Display labels in white for better readability.
- Slightly refactor the implementation to display slider labels as they are provided.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
