### PR TITLE
Add a pulse animation on the slider

### DIFF
--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -105,7 +105,7 @@ struct ContentListsView: View {
 
     @ViewBuilder
     private func serverSettingsMenu() -> some View {
-        if #available(iOS 17, tvOS 17.0, *) {
+        if #available(iOS 17.0, tvOS 17.0, *) {
             Menu {
                 Picker("Server", selection: $selectedServerSetting) {
                     ForEach(ServerSetting.allCases, id: \.self) { service in

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -63,7 +63,7 @@ private struct MainView: View {
             controls()
             loadingIndicator()
         }
-        .animation(.defaultLinear, value: isUserInterfaceHidden)
+        .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
         .readLayout(into: $layoutInfo)
         .accessibilityAddTraits(.isButton)
         .onTapGesture(perform: visibilityTracker.toggle)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -19,6 +19,7 @@ private struct MainView: View {
 
     @State private var layoutInfo: LayoutInfo = .none
     @State private var selectedGravity: AVLayerVideoGravity = .resizeAspect
+    @State private var isInteracting = false
 
     private var areControlsAlwaysVisible: Bool {
         player.isExternalPlaybackActive || player.mediaType == .audio
@@ -75,7 +76,7 @@ private struct MainView: View {
 
     @ViewBuilder
     private func timeBar() -> some View {
-        TimeBar(player: player, visibilityTracker: visibilityTracker, layout: $layout)
+        TimeBar(player: player, visibilityTracker: visibilityTracker, layout: $layout, isInteracting: $isInteracting)
             .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
@@ -107,13 +108,14 @@ private struct MainView: View {
     private func controls() -> some View {
         ControlsView(player: player)
             .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
+            .opacity(isInteracting ? 0 : 1)
     }
 
     @ViewBuilder
     private func loadingIndicator() -> some View {
         ProgressView()
             .tint(.white)
-            .opacity(player.isBusy ? 1 : 0)
+            .opacity(player.isBusy && !isInteracting ? 1 : 0)
             .controlSize(.large)
     }
 
@@ -347,6 +349,7 @@ private struct TimeBar: View {
     @ObservedObject var player: Player
     @ObservedObject var visibilityTracker: VisibilityTracker
     @Binding var layout: PlaybackView.Layout
+    @Binding var isInteracting: Bool
 
     @StateObject private var progressTracker = ProgressTracker(
         interval: CMTime(value: 1, timescale: 10),
@@ -371,6 +374,7 @@ private struct TimeBar: View {
         }
         .preventsTouchPropagation()
         .padding(.horizontal, 6)
+        .onChange(of: progressTracker.isInteracting) { isInteracting = $0 }
         .bind(progressTracker, to: player)
     }
 

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -141,7 +141,7 @@ private extension View {
     func pulseEffect() -> some View {
         // TODO: Remove when Xcode 15 has been released
 #if compiler(>=5.9)
-        if #available(iOS 17, tvOS 17, *) {
+        if #available(iOS 17.0, tvOS 17.0, *) {
             symbolEffect(.pulse)
         }
         else {

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -54,7 +54,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             }
             .animation(.linear(duration: 0.5), value: progressTracker.buffer)
             .gesture(dragGesture(in: geometry))
-            .busy(progressTracker.player?.isBusy ?? false)
+            .busy((progressTracker.player?.isBusy ?? false) && !progressTracker.isInteracting)
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -54,6 +54,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             }
             .animation(.linear(duration: 0.5), value: progressTracker.buffer)
             .gesture(dragGesture(in: geometry))
+            .busy(progressTracker.player?.isBusy ?? false)
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
@@ -80,6 +81,20 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 extension PlaybackSlider where ValueLabel == EmptyView {
     init(progressTracker: ProgressTracker) {
         self.init(progressTracker: progressTracker, minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() })
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func busy(_ isBusy: Bool) -> some View {
+        if #available(iOS 17.0, *) {
+            self.phaseAnimator([isBusy, false]) { content, phase in
+                content.opacity(phase ? 0.5 : 1)
+                    .animation(.easeInOut(duration: 0.7), value: phase)
+            }
+        } else {
+            self
+        }
     }
 }
 

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -88,8 +88,8 @@ extension PlaybackSlider where ValueLabel == EmptyView {
 private extension View {
     @ViewBuilder
     func busy(_ isBusy: Bool) -> some View {
-        if #available(iOS 17.0, *) {
-            phaseAnimator([isBusy, false]) { content, phase in
+        if #available(iOS 17.0, *), isBusy {
+            phaseAnimator([true, false]) { content, phase in
                 content
                     .opacity(phase ? 0.5 : 1)
                     .animation(.easeInOut(duration: 0.7), value: phase)

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -89,8 +89,9 @@ private extension View {
     @ViewBuilder
     func busy(_ isBusy: Bool) -> some View {
         if #available(iOS 17.0, *) {
-            self.phaseAnimator([isBusy, false]) { content, phase in
-                content.opacity(phase ? 0.5 : 1)
+            phaseAnimator([isBusy, false]) { content, phase in
+                content
+                    .opacity(phase ? 0.5 : 1)
                     .animation(.easeInOut(duration: 0.7), value: phase)
             }
         } else {

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -16,6 +16,10 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
     @State private var initialProgress: Float = 0
 
+    private var isBusy: Bool {
+        progressTracker.player?.isBusy ?? false
+    }
+
     var body: some View {
         HStack {
             minimumValueLabel()
@@ -55,7 +59,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             }
             .animation(.linear(duration: 0.5), value: progressTracker.buffer)
             .gesture(dragGesture(in: geometry))
-            .busy((progressTracker.player?.isBusy ?? false) && !progressTracker.isInteracting)
+            .busy(isBusy && !progressTracker.isInteracting)
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -49,6 +49,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 rectangle(opacity: 0.1)
+                    .background(.ultraThinMaterial)
                 rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(progressTracker.buffer))
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
             }

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -88,15 +88,21 @@ extension PlaybackSlider where ValueLabel == EmptyView {
 private extension View {
     @ViewBuilder
     func busy(_ isBusy: Bool) -> some View {
+        // TODO: Remove when Xcode 15 has been released
+#if compiler(>=5.9)
         if #available(iOS 17.0, *), isBusy {
             phaseAnimator([true, false]) { content, phase in
                 content
                     .opacity(phase ? 0.5 : 1)
                     .animation(.easeInOut(duration: 0.7), value: phase)
             }
-        } else {
+        }
+        else {
             self
         }
+#else
+        self
+#endif
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to add an animation on the slider when the player is busy.

# Changes made

- Controls and loading indicator are masked when the user is interacting with the slider.
- An pulse animation has been added using the `phaseAnimator` API.

# Illustration

![pulse](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/73b23d07-7bdc-4e25-99f7-4c3d314c1184)

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
