### PR TITLE
Rename page view properties from title to name

### DIFF
--- a/Demo/Sources/ContentLists/ContentList.swift
+++ b/Demo/Sources/ContentLists/ContentList.swift
@@ -55,7 +55,7 @@ enum ContentList: Hashable {
         }
     }
 
-    var pageTitle: String {
+    var pageName: String {
         switch self {
         case .tvTopics:
              return "tv-topics"

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -115,7 +115,7 @@ struct ContentListView: View {
         .animation(.defaultLinear, value: model.state)
         .onAppear { model.configuration = configuration }
         .navigationTitle(configuration.list.name)
-        .tracked(title: configuration.list.pageTitle, levels: configuration.list.pageLevels)
+        .tracked(name: configuration.list.pageName, levels: configuration.list.pageLevels)
     }
 }
 

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -27,7 +27,7 @@ struct ContentListsView: View {
             Self.radioShows(image: "waveform")
             Self.latestAudiosSection(image: "music.note.list")
         }
-        .tracked(title: "lists")
+        .tracked(name: "lists")
         .navigationTitle("Lists (\(selectedServerSetting.title))")
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -77,7 +77,7 @@ struct ExamplesView: View {
         .scrollDismissesKeyboard(.immediately)
         .animation(.defaultLinear, value: model.protectedMedias)
         .navigationTitle("Examples")
-        .tracked(title: "examples")
+        .tracked(name: "examples")
         .refreshable { await model.refresh() }
     }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -18,7 +18,7 @@ struct PlayerView: View {
     var body: some View {
         PlaybackView(player: player)
             .onAppear(perform: load)
-            .tracked(title: "player")
+            .tracked(name: "player")
     }
 
     private func load() {

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -22,7 +22,7 @@ struct SimplePlayerView: View {
             playbackButton()
         }
         .onAppear(perform: play)
-        .tracked(title: "simple-player")
+        .tracked(name: "simple-player")
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/SystemPlayerView.swift
+++ b/Demo/Sources/Players/SystemPlayerView.swift
@@ -19,7 +19,7 @@ struct SystemPlayerView: View {
         SystemVideoView(player: player)
             .ignoresSafeArea()
             .onAppear(perform: play)
-            .tracked(title: "system-player")
+            .tracked(name: "system-player")
     }
 
     private func play() {

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -27,7 +27,7 @@ struct SearchView: View {
         }
         .animation(.defaultLinear, value: model.state)
         .navigationTitle("Search")
-        .tracked(title: "search")
+        .tracked(name: "search")
         .searchable(text: $model.text)
 #if os(iOS)
         .searchScopes($model.vendor) {

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -44,7 +44,7 @@ struct SettingsView: View {
             debuggingSection()
         }
         .navigationTitle("Settings")
-        .tracked(title: "settings")
+        .tracked(name: "settings")
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -27,7 +27,7 @@ struct BlurredView: View {
         .background(.black)
         .onAppear(perform: play)
         .onForeground(perform: player.play)
-        .tracked(title: "blurred")
+        .tracked(name: "blurred")
     }
 
     private func play() {

--- a/Demo/Sources/Showcase/LinkView.swift
+++ b/Demo/Sources/Showcase/LinkView.swift
@@ -27,7 +27,7 @@ struct LinkView: View {
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)
-        .tracked(title: "link")
+        .tracked(name: "link")
     }
 
     private func play() {

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -85,7 +85,7 @@ struct MultiView: View {
             Self.play(media: media2, in: bottomPlayer)
             setActive(position: activePosition)
         }
-        .tracked(title: "multi")
+        .tracked(name: "multi")
     }
 
     private static func play(media: Media, in player: Player) {

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -39,7 +39,7 @@ struct OptInView: View {
             }
         }
         .onAppear(perform: load)
-        .tracked(title: "tracking")
+        .tracked(name: "tracking")
     }
 
     private func load() {

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -58,7 +58,7 @@ private struct PlaylistSelectionView: View {
                 }
             }
         }
-        .tracked(title: "selection", levels: ["playlist"])
+        .tracked(name: "selection", levels: ["playlist"])
     }
 
     @ViewBuilder
@@ -167,7 +167,7 @@ struct PlaylistView: View {
         .onChange(of: templates) { newValue in
             model.templates = newValue
         }
-        .tracked(title: "playlist")
+        .tracked(name: "playlist")
     }
 }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -21,7 +21,7 @@ struct ShowcaseView: View {
             trackingSection()
         }
         .navigationTitle("Showcase")
-        .tracked(title: "showcase")
+        .tracked(name: "showcase")
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/Stories/StoriesView.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesView.swift
@@ -54,7 +54,7 @@ struct StoriesView: View {
         .background(.black)
         .tabViewStyle(.page)
         .ignoresSafeArea()
-        .tracked(title: "stories")
+        .tracked(name: "stories")
     }
 }
 

--- a/Demo/Sources/Showcase/TwinsView.swift
+++ b/Demo/Sources/Showcase/TwinsView.swift
@@ -41,7 +41,7 @@ struct TwinsView: View {
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)
-        .tracked(title: "twins")
+        .tracked(name: "twins")
     }
 
     private func play() {

--- a/Demo/Sources/Showcase/Wrapped/WrappedView.swift
+++ b/Demo/Sources/Showcase/Wrapped/WrappedView.swift
@@ -30,7 +30,7 @@ struct WrappedView: View {
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)
-        .tracked(title: "wrapped")
+        .tracked(name: "wrapped")
     }
 
     private func play() {

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -18,10 +18,10 @@ extension View {
             .animation(animation, value: v2)
     }
 
-    func tracked(title: String, levels: [String] = []) -> some View {
+    func tracked(name: String, levels: [String] = []) -> some View {
         tracked(
-            comScore: .init(title: title),
-            commandersAct: .init(title: title, type: "content", levels: levels)
+            comScore: .init(name: name),
+            commandersAct: .init(name: name, type: "content", levels: levels)
         )
     }
 }

--- a/Sources/Analytics/ComScore/ComScorePageView.swift
+++ b/Sources/Analytics/ComScore/ComScorePageView.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A comScore page view.
 public struct ComScorePageView {
-    let title: String
+    let name: String
     let labels: [String: String]
 
     /// Creates a comScore page view.
@@ -16,11 +16,11 @@ public struct ComScorePageView {
     /// Custom labels which might accidentally override official labels will be ignored.
     ///
     /// - Parameters:
-    ///   - title: The page view title.
+    ///   - name: The page view name.
     ///   - labels: Additional information associated with the page view.
-    public init(title: String, labels: [String: String] = [:]) {
-        assert(!title.isBlank, "A title is required")
-        self.title = title
+    public init(name: String, labels: [String: String] = [:]) {
+        assert(!name.isBlank, "A name is required")
+        self.name = name
         self.labels = labels
     }
 }

--- a/Sources/Analytics/ComScore/ComScoreService.swift
+++ b/Sources/Analytics/ComScore/ComScoreService.swift
@@ -36,7 +36,7 @@ struct ComScoreService {
     }
 
     func trackPageView(_ pageView: ComScorePageView) {
-        var labels = pageView.labels.merging(["c8": pageView.title]) { _, new in new }
+        var labels = pageView.labels.merging(["c8": pageView.name]) { _, new in new }
         AnalyticsListener.capture(&labels)
         SCORAnalytics.notifyViewEvent(withLabels: labels)
     }

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A Commanders Act page view.
 public struct CommandersActPageView {
-    let title: String
+    let name: String
     let type: String
     let levels: [String]
     let labels: [String: String]
@@ -18,14 +18,14 @@ public struct CommandersActPageView {
     /// Custom labels which might accidentally override official labels will be ignored.
     /// 
     /// - Parameters:
-    ///   - title: The page title.
+    ///   - name: The page name.
     ///   - type: The page type (e.g. Article).
     ///   - labels: Additional information associated with the page view.
     ///   - levels: The page levels.
-    public init(title: String, type: String, levels: [String] = [], labels: [String: String] = [:]) {
-        assert(!title.isBlank, "A title is required")
+    public init(name: String, type: String, levels: [String] = [], labels: [String: String] = [:]) {
+        assert(!name.isBlank, "A name is required")
         assert(!type.isBlank, "A type is required")
-        self.title = title
+        self.name = name
         self.type = type
         self.levels = levels
         self.labels = labels

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -41,7 +41,7 @@ final class CommandersActService {
         pageView.labels.forEach { key, value in
             event.addAdditionalProperty(key, withStringValue: value)
         }
-        event.addNonBlankAdditionalProperty("content_title", withStringValue: pageView.title)
+        event.addNonBlankAdditionalProperty("content_title", withStringValue: pageView.name)
         event.addNonBlankAdditionalProperty("navigation_property_type", withStringValue: "app")
         event.addNonBlankAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
         pageView.levels.enumerated().forEach { index, level in

--- a/Sources/Analytics/UserInterface/PageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/PageViewTracking.swift
@@ -9,10 +9,7 @@ import UIKit
 /// A protocol that view controller containers can implement to declare how they are tracked.
 ///
 /// View controllers whose usage must be measured should conform to the `PageViewTracking` protocol, which describes
-/// the associated measurement data:
-/// 
-/// - Page title.
-/// - Page levels.
+/// the associated measurement data.
 ///
 /// The protocol also provides a `isTrackedAutomatically` property, set to `true` by default, which lets you choose
 /// between automatic and manual tracking.

--- a/Sources/Analytics/UserInterface/View.swift
+++ b/Sources/Analytics/UserInterface/View.swift
@@ -52,8 +52,8 @@ struct TrackedView_Previews: PreviewProvider {
         Color.red
             .frame(width: 40, height: 40)
             .tracked(
-                comScore: .init(title: "title"),
-                commandersAct: .init(title: "title", type: "home")
+                comScore: .init(name: "name"),
+                commandersAct: .init(name: "name", type: "home")
             )
             .border(Color.blue)
     }

--- a/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
@@ -12,16 +12,16 @@ import UIKit
 import XCTest
 
 private class AutomaticMockViewController: UIViewController, PageViewTracking {
-    private var pageTitle: String {
+    private var pageName: String {
         title ?? "automatic"
     }
 
     var comScorePageView: ComScorePageView {
-        .init(title: pageTitle)
+        .init(name: pageName)
     }
 
     var commandersActPageView: CommandersActPageView {
-        .init(title: pageTitle, type: "type")
+        .init(name: pageName, type: "type")
     }
 
     init(title: String? = nil) {
@@ -36,30 +36,30 @@ private class AutomaticMockViewController: UIViewController, PageViewTracking {
 }
 
 private class AutomaticWithLevelsMockViewController: UIViewController, PageViewTracking {
-    private var pageTitle: String {
+    private var pageName: String {
         "automatic_with_levels"
     }
 
     var comScorePageView: ComScorePageView {
-        .init(title: pageTitle)
+        .init(name: pageName)
     }
 
     var commandersActPageView: CommandersActPageView {
-        .init(title: pageTitle, type: "type", levels: ["level1", "level2"])
+        .init(name: pageName, type: "type", levels: ["level1", "level2"])
     }
 }
 
 private class ManualMockViewController: UIViewController, PageViewTracking {
-    private var pageTitle: String {
+    private var pageName: String {
         "manual"
     }
 
     var comScorePageView: ComScorePageView {
-        .init(title: pageTitle)
+        .init(name: pageName)
     }
 
     var commandersActPageView: CommandersActPageView {
-        .init(title: pageTitle, type: "type")
+        .init(name: pageName, type: "type")
     }
 
     var isTrackedAutomatically: Bool {
@@ -73,7 +73,7 @@ final class ComScorePageViewTests: ComScoreTestCase {
             .view { labels in
                 expect(labels.c2).to(equal("6036016"))
                 expect(labels.ns_ap_an).to(equal("xctest"))
-                expect(labels.c8).to(equal("title"))
+                expect(labels.c8).to(equal("name"))
                 expect(labels.ns_st_mp).to(beNil())
                 expect(labels.ns_st_mv).to(beNil())
                 expect(labels.mp_brand).to(equal("SRG"))
@@ -81,8 +81,8 @@ final class ComScorePageViewTests: ComScoreTestCase {
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title"),
-                commandersAct: .init(title: "title", type: "type")
+                comScore: .init(name: "name"),
+                commandersAct: .init(name: "name", type: "type")
             )
         }
     }
@@ -90,8 +90,8 @@ final class ComScorePageViewTests: ComScoreTestCase {
     func testBlankTitle() {
         guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.trackPageView(
-            comScore: .init(title: " "),
-            commandersAct: .init(title: "title", type: "type")
+            comScore: .init(name: " "),
+            commandersAct: .init(name: "name", type: "type")
         )).to(throwAssertion())
     }
 
@@ -102,8 +102,8 @@ final class ComScorePageViewTests: ComScoreTestCase {
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title", labels: ["key": "value"]),
-                commandersAct: .init(title: "title", type: "type")
+                comScore: .init(name: "name", labels: ["key": "value"]),
+                commandersAct: .init(name: "name", type: "type")
             )
         }
     }
@@ -111,12 +111,12 @@ final class ComScorePageViewTests: ComScoreTestCase {
     func testCustomLabelsForbiddenOverrides() {
         expectAtLeastHits(
             .view { labels in
-                expect(labels.c8).to(equal("title"))
+                expect(labels.c8).to(equal("name"))
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title", labels: ["c8": "overridden_title"]),
-                commandersAct: .init(title: "title", type: "type")
+                comScore: .init(name: "name", labels: ["c8": "overridden_title"]),
+                commandersAct: .init(name: "name", type: "type")
             )
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -15,7 +15,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         expectAtLeastHits(
             .page_view { labels in
                 expect(labels.page_type).to(equal("type"))
-                expect(labels.content_title).to(equal("title"))
+                expect(labels.content_title).to(equal("name"))
                 expect(labels.navigation_level_0).to(beNil())
                 expect(labels.navigation_level_1).to(equal("level_1"))
                 expect(labels.navigation_level_2).to(equal("level_2"))
@@ -34,9 +34,9 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title"),
+                comScore: .init(name: "name"),
                 commandersAct: .init(
-                    title: "title",
+                    name: "name",
                     type: "type",
                     levels: [
                         "level_1",
@@ -56,16 +56,16 @@ final class CommandersActPageViewTests: CommandersActTestCase {
     func testBlankTitle() {
         guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.trackPageView(
-            comScore: .init(title: "title"),
-            commandersAct: .init(title: " ", type: "type")
+            comScore: .init(name: "name"),
+            commandersAct: .init(name: " ", type: "type")
         )).to(throwAssertion())
     }
 
     func testBlankType() {
         guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.trackPageView(
-            comScore: .init(title: "title"),
-            commandersAct: .init(title: "title", type: " ")
+            comScore: .init(name: "name"),
+            commandersAct: .init(name: "name", type: " ")
         )).to(throwAssertion())
     }
 
@@ -73,7 +73,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         expectAtLeastHits(
             .page_view { labels in
                 expect(labels.page_type).to(equal("type"))
-                expect(labels.content_title).to(equal("title"))
+                expect(labels.content_title).to(equal("name"))
                 expect(labels.navigation_level_1).to(beNil())
                 expect(labels.navigation_level_2).to(beNil())
                 expect(labels.navigation_level_3).to(beNil())
@@ -85,9 +85,9 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title"),
+                comScore: .init(name: "name"),
                 commandersAct: .init(
-                    title: "title",
+                    name: "name",
                     type: "type",
                     levels: [
                         " ",
@@ -112,9 +112,9 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title"),
+                comScore: .init(name: "name"),
                 commandersAct: .init(
-                    title: "title",
+                    name: "name",
                     type: "type",
                     labels: ["media_player_display": "value"]
                 )
@@ -125,13 +125,13 @@ final class CommandersActPageViewTests: CommandersActTestCase {
     func testLabelsForbiddenOverrides() {
         expectAtLeastHits(
             .page_view { labels in
-                expect(labels.content_title).to(equal("title"))
+                expect(labels.content_title).to(equal("name"))
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(title: "title"),
+                comScore: .init(name: "name"),
                 commandersAct: .init(
-                    title: "title",
+                    name: "name",
                     type: "type",
                     labels: ["content_title": "overridden_title"]
                 )

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActStreamingAnalyticsMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActStreamingAnalyticsMetadataTests.swift
@@ -15,25 +15,25 @@ final class CommandersActStreamingAnalyticsMetadataTests: CommandersActTestCase 
     func testPlay() {
         expectAtLeastHits(
             .play { labels in
-                expect(labels.media_title).to(equal("title"))
+                expect(labels.media_title).to(equal("name"))
             }
         ) {
             _ = CommandersActStreamingAnalytics(streamType: .onDemand) {
-                .init(labels: ["media_title": "title"], time: CMTime(value: 2, timescale: 1), range: .zero)
+                .init(labels: ["media_title": "name"], time: CMTime(value: 2, timescale: 1), range: .zero)
             }
         }
     }
 
     func testStopWhenDestroyed() {
         var analytics: CommandersActStreamingAnalytics? = .init(streamType: .live) {
-            .init(labels: ["media_title": "title"], time: .zero, range: .zero)
+            .init(labels: ["media_title": "name"], time: .zero, range: .zero)
         }
         _ = analytics
         wait(for: .seconds(1))
 
         expectAtLeastHits(
             .stop { labels in
-                expect(labels.media_title).to(equal("title"))
+                expect(labels.media_title).to(equal("name"))
             }
         ) {
             analytics = nil

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTracker.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTracker.swift
@@ -13,6 +13,6 @@ extension CommandersActTracker.Metadata {
     }
 
     static func test(streamType: StreamType) -> Self {
-        .init(labels: ["media_title": "title"], streamType: streamType)
+        .init(labels: ["media_title": "name"], streamType: streamType)
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -20,7 +20,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
-                expect(labels.media_title).to(equal("title"))
+                expect(labels.media_title).to(equal("name"))
             }
         ) {
              player = Player(item: .simple(
@@ -56,7 +56,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_display).to(equal("Pillarbox"))
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
-                expect(labels.media_title).to(equal("title"))
+                expect(labels.media_title).to(equal("name"))
             }
         ) {
             player = nil


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to change properties `title` to `name` for **ComScore** and **CommandersAct**.

# Changes made

- Updates the `CommandersActPageView` struct by renaming the `title` property to `name`.
- Updates the `ComScorePageView` struct by renaming the `title` property to `name`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
