### PR TITLE
Improve seek user experience

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -435,10 +435,8 @@ private struct TimeSlider: View {
         )
         .foregroundColor(.white)
         .tint(.white)
+        .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
         .opacity(isVisible ? 1 : 0)
-        .transaction { transaction in
-            transaction.animation = nil
-        }
         .padding()
         ._debugBodyCounter(color: .blue)
     }
@@ -459,6 +457,7 @@ private struct TimeSlider: View {
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundColor(.white)
+                .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
         }
     }
 }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -516,7 +516,7 @@ struct PlaybackView: View {
                     .ignoresSafeArea()
             }
 #else
-            VideoView(player: player)
+            SystemVideoView(player: player)
                 .ignoresSafeArea()
 #endif
         }

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -119,11 +119,19 @@ struct ShowcaseView: View {
     private func systemPlayerSection() -> some View {
         Section("System player (using Pillarbox)") {
             cell(
-                title: "Video URL",
-                destination: .systemPlayer(media: Media(from: URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS))
+                title: "Apple Advanced - fMP4",
+                destination: .systemPlayer(media: Media(from: URLTemplate.appleAdvanced_16_9_fMP4_HLS))
             )
             cell(
-                title: "Video URN",
+                title: "Trickplay",
+                destination: .systemPlayer(media: Media(from: URLTemplate.unifiedStreamingOnDemandTrickplay))
+            )
+            cell(
+                title: "VOD - MP4",
+                destination: .systemPlayer(media: Media(from: URLTemplate.onDemandVideoMP4))
+            )
+            cell(
+                title: "Video URN - Livestream with DRM",
                 destination: .systemPlayer(media: Media(from: URNTemplate.dvrVideo))
             )
             cell(
@@ -137,8 +145,16 @@ struct ShowcaseView: View {
     private func vanillaPlayerSection() -> some View {
         Section("System player (using AVPlayer)") {
             cell(
-                title: "Video URL",
-                destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_TS_HLS)!)
+                title: "Apple Advanced - fMP4",
+                destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.appleAdvanced_16_9_fMP4_HLS)!)
+            )
+            cell(
+                title: "Trickplay",
+                destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.unifiedStreamingOnDemandTrickplay)!)
+            )
+            cell(
+                title: "VOD - MP4",
+                destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.onDemandVideoMP4)!)
             )
             cell(
                 title: "Unknown",

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -63,7 +63,6 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
-        .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
         .animation(.easeInOut(duration: 0.4), value: progressTracker.isInteracting)
     }
 

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -63,6 +63,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
+        .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
         .animation(.easeInOut(duration: 0.4), value: progressTracker.isInteracting)
     }
 

--- a/Sources/Analytics/ComScore/ComScorePageView.swift
+++ b/Sources/Analytics/ComScore/ComScorePageView.swift
@@ -16,7 +16,7 @@ public struct ComScorePageView {
     /// Custom labels which might accidentally override official labels will be ignored.
     ///
     /// - Parameters:
-    ///   - name: The page view name.
+    ///   - name: The page name.
     ///   - labels: Additional information associated with the page view.
     public init(name: String, labels: [String: String] = [:]) {
         assert(!name.isBlank, "A name is required")

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -58,7 +58,7 @@ class QueuePlayer: AVQueuePlayer {
     }
 
     override func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {
-        seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: false, paused: false, completionHandler: completionHandler)
+        seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: false, completionHandler: completionHandler)
     }
 
     func seek(
@@ -66,7 +66,6 @@ class QueuePlayer: AVQueuePlayer {
         toleranceBefore: CMTime = .positiveInfinity,
         toleranceAfter: CMTime = .positiveInfinity,
         smooth: Bool,
-        paused: Bool,
         completionHandler: @escaping (Bool) -> Void
     ) {
         assert(time.isValid)
@@ -91,7 +90,7 @@ class QueuePlayer: AVQueuePlayer {
             return
         }
 
-        if paused && rate != 0 {
+        if rate != 0 {
             wasPaused = true
             rate = 0
         }

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -78,17 +78,11 @@ class QueuePlayer: AVQueuePlayer {
             return
         }
 
-        if smooth && rate != 0 {
-            wasPaused = true
-            rate = 0
-        }
+        pausePlaybackIfNeeded(smooth: smooth)
         enqueue(seek: seek) { [weak self] in
             guard let self else { return }
             notifySeekEnd()
-            if wasPaused {
-                rate = defaultRate
-                wasPaused = false
-            }
+            resumePlaybackIfNeeded()
         }
     }
 
@@ -134,6 +128,18 @@ class QueuePlayer: AVQueuePlayer {
 
     private func notifySeekEnd() {
         Self.notificationCenter.post(name: .didSeek, object: self)
+    }
+
+    private func pausePlaybackIfNeeded(smooth: Bool) {
+        guard smooth && rate != 0 else { return }
+        wasPaused = true
+        rate = 0
+    }
+
+    private func resumePlaybackIfNeeded() {
+        guard wasPaused else { return }
+        rate = defaultRate
+        wasPaused = false
     }
 }
 

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -45,18 +45,6 @@ class QueuePlayer: AVQueuePlayer {
         targetSeek?.time
     }
 
-    override var rate: Float {
-        get {
-            super.rate
-        }
-        set {
-            if wasPaused && newValue != 0 {
-                wasPaused = false
-            }
-            super.rate = newValue
-        }
-    }
-
     override func seek(to time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {
         seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, smooth: false, completionHandler: completionHandler)
     }

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -78,7 +78,7 @@ class QueuePlayer: AVQueuePlayer {
             return
         }
 
-        if rate != 0 {
+        if smooth && rate != 0 {
             wasPaused = true
             rate = 0
         }

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -102,7 +102,7 @@ private extension Player {
     func changePlaybackPositionRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.changePlaybackPositionCommand) { [weak self] event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
-            self?.seek(near(.init(seconds: positionEvent.positionTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC))))
+            self?.seek(near(.init(seconds: positionEvent.positionTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC))), smooth: false)
             return .success
         }
     }

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -22,12 +22,15 @@ public extension Player {
         guard let item else {
             return near(time)
         }
+        // If stepping supported we must use exact seeking to provide a frame-by-frame experience at rate 0.
         if item.canStepForward {
             return at(time)
         }
+        // If fast-forward is supported we must use one-sided tolerance to allow the player to rely on I-frames at rate 0.
         else if item.canPlayFastForward {
             return after(time)
         }
+        // In all other cases we apply efficient smooth seeking.
         else {
             return near(time)
         }

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -4,9 +4,35 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import CoreMedia
 
 public extension Player {
+    /// Returns the optimal position to reach a given time based on available item information.
+    ///
+    /// For perfect results the position should be reached with the player paused during the seek operation.
+    ///
+    /// - Parameters:
+    ///   - time: The time to reach.
+    ///   - item: The item to consider.
+    ///
+    /// - Returns: An optimal position to seek to.
+    private static func optimalPosition(reaching time: CMTime, for item: AVPlayerItem?) -> Position {
+        // Based on analysis of `AVPlayerViewController` behavior during seeks for a variety of content.
+        guard let item else {
+            return near(time)
+        }
+        if item.canStepForward {
+            return at(time)
+        }
+        else if item.canPlayFastForward {
+            return after(time)
+        }
+        else {
+            return near(time)
+        }
+    }
+
     /// Checks whether seeking to a specific time is possible.
     ///
     /// - Parameter time: The time to seek to.
@@ -23,11 +49,14 @@ public extension Player {
     ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before
     ///     any new seek is performed, preventing unnecessary cancellation. This makes it possible for the playhead
     ///     position to be moved in a smoother way.
+    ///   - paused: Set to `true` to pause playback during seeks. This in general allows the player to seek more
+    ///     efficiently.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs
     ///     whether the seek could finish without being cancelled.
     func seek(
         _ position: Position,
         smooth: Bool = true,
+        paused: Bool = true,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
         // Mitigates issues arising when seeking to the very end of the range by introducing a small offset.
@@ -41,7 +70,20 @@ public extension Player {
             toleranceBefore: position.toleranceBefore,
             toleranceAfter: position.toleranceAfter,
             smooth: smooth,
+            paused: paused,
             completionHandler: completion
         )
+    }
+
+    /// Performs an optimal seek to a given time, providing the smoothest possible experience depending on the type of
+    /// content.
+    ///
+    /// - Parameters:
+    ///   - time: The time to reach.
+    ///   - completion: A completion called when seeking ends. The provided Boolean informs
+    ///     whether the seek could finish without being cancelled.
+    func optimalSeek(to time: CMTime, completion: @escaping (Bool) -> Void = { _ in }) {
+        let position = Self.optimalPosition(reaching: time, for: queuePlayer.currentItem)
+        seek(position, smooth: true, paused: true, completion: completion)
     }
 }

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -82,7 +82,7 @@ public extension Player {
     ///   - time: The time to reach.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs
     ///     whether the seek could finish without being cancelled.
-    func optimalSeek(to time: CMTime, completion: @escaping (Bool) -> Void = { _ in }) {
+    func seek(to time: CMTime, completion: @escaping (Bool) -> Void = { _ in }) {
         let position = Self.optimalPosition(reaching: time, for: queuePlayer.currentItem)
         seek(position, smooth: true, paused: true, completion: completion)
     }

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -50,16 +50,13 @@ public extension Player {
     /// - Parameters:
     ///   - position: The position to seek to.
     ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before
-    ///     any new seek is performed, preventing unnecessary cancellation. This makes it possible for the playhead
-    ///     position to be moved in a smoother way.
-    ///   - paused: Set to `true` to pause playback during seeks. This in general allows the player to seek more
-    ///     efficiently.
+    ///     any new seek is performed, preventing unnecessary cancellation. The player is also paused during the seek
+    ///     operation. Altogether both measures make it possible for the playhead position to be moved in a smoother way.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs
     ///     whether the seek could finish without being cancelled.
     func seek(
         _ position: Position,
         smooth: Bool = true,
-        paused: Bool = true,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
         // Mitigates issues arising when seeking to the very end of the range by introducing a small offset.
@@ -73,7 +70,6 @@ public extension Player {
             toleranceBefore: position.toleranceBefore,
             toleranceAfter: position.toleranceAfter,
             smooth: smooth,
-            paused: paused,
             completionHandler: completion
         )
     }
@@ -87,6 +83,6 @@ public extension Player {
     ///     whether the seek could finish without being cancelled.
     func seek(to time: CMTime, completion: @escaping (Bool) -> Void = { _ in }) {
         let position = Self.optimalPosition(reaching: time, for: queuePlayer.currentItem)
-        seek(position, smooth: true, paused: true, completion: completion)
+        seek(position, smooth: true, completion: completion)
     }
 }

--- a/Sources/Player/Player+Skip.swift
+++ b/Sources/Player/Player+Skip.swift
@@ -30,16 +30,16 @@ public extension Player {
 
     /// Skips backward.
     ///
-    /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
-    ///   whether the skip could finish without being cancelled.
+    /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs whether the skip
+    ///   could finish without being cancelled.
     func skipBackward(completion: @escaping (Bool) -> Void = { _ in }) {
         skip(withInterval: backwardSkipTime, toleranceBefore: .positiveInfinity, toleranceAfter: .zero, completion: completion)
     }
 
     /// Skips forward.
     /// 
-    /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs
-    ///   whether the skip could finish without being cancelled.
+    /// - Parameter completion: A completion called when skipping ends. The provided Boolean informs whether the skip
+    ///   could finish without being cancelled.
     func skipForward(completion: @escaping (Bool) -> Void = { _ in }) {
         skip(withInterval: forwardSkipTime, toleranceBefore: .zero, toleranceAfter: .positiveInfinity, completion: completion)
     }
@@ -68,7 +68,7 @@ private extension Player {
         if interval < .zero || currentTime < timeRange.end - endTolerance {
             seek(
                 to(currentTime + interval, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter),
-                smooth: true,
+                smooth: false,
                 completion: completion
             )
         }

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -144,7 +144,7 @@ public final class ProgressTracker: ObservableObject {
     private func seek(to progress: Float, optimal: Bool) {
         guard let player, let time = time(forProgress: progress) else { return }
         if optimal {
-            player.optimalSeek(to: time)
+            player.seek(to: time)
         }
         else {
             player.seek(near(time), smooth: false)

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -23,7 +23,7 @@ public final class ProgressTracker: ObservableObject {
     @Published public var isInteracting = false {
         willSet {
             guard !newValue else { return }
-            seek(to: progress, smooth: false)
+            seek(to: progress, optimal: false)
         }
     }
 
@@ -52,7 +52,7 @@ public final class ProgressTracker: ObservableObject {
             guard _progress != nil else { return }
             _progress = newValue.clamped(to: range)
             guard seekBehavior == .immediate else { return }
-            seek(to: newValue, smooth: true)
+            seek(to: newValue, optimal: true)
         }
     }
 
@@ -141,9 +141,14 @@ public final class ProgressTracker: ObservableObject {
         return Float((time - timeRange.start).seconds / timeRange.duration.seconds).clamped(to: 0...1)
     }
 
-    private func seek(to progress: Float, smooth: Bool) {
+    private func seek(to progress: Float, optimal: Bool) {
         guard let player, let time = time(forProgress: progress) else { return }
-        player.seek(near(time), smooth: smooth)
+        if optimal {
+            player.optimalSeek(to: time)
+        }
+        else {
+            player.seek(near(time), smooth: false)
+        }
     }
 
     private func time(forProgress progress: Float?) -> CMTime? {

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -103,7 +103,7 @@ final class QueuePlayerSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true, paused: false) { finished in
+            player.seek(to: time1, smooth: true) { finished in
                 expect(finished).to(beFalse())
             }
             player.seek(to: time2) { finished in
@@ -163,9 +163,9 @@ final class QueuePlayerSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: true, paused: false, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: true, paused: false, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: false, paused: false, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: true, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: true, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: false, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: false,
@@ -260,11 +260,11 @@ final class QueuePlayerSeekTests: TestCase {
         let player = QueuePlayerMock(playerItem: item)
         expect(player.timeRange).toEventuallyNot(equal(.invalid))
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true, paused: false) { _ in }
-            player.seek(to: CMTime(value: 2, timescale: 1), smooth: true, paused: false) { _ in }
-            player.seek(to: CMTime(value: 3, timescale: 1), smooth: true, paused: false) { _ in }
-            player.seek(to: CMTime(value: 4, timescale: 1), smooth: true, paused: false) { _ in }
-            player.seek(to: CMTime(value: 5, timescale: 1), smooth: true, paused: false) { _ in
+            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true) { _ in }
+            player.seek(to: CMTime(value: 2, timescale: 1), smooth: true) { _ in }
+            player.seek(to: CMTime(value: 3, timescale: 1), smooth: true) { _ in }
+            player.seek(to: CMTime(value: 4, timescale: 1), smooth: true) { _ in }
+            player.seek(to: CMTime(value: 5, timescale: 1), smooth: true) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -270,4 +270,17 @@ final class QueuePlayerSeekTests: TestCase {
         }
         expect(player.seeks).to(equal(2))
     }
+
+    func testSeekDoesNotPausePlayback() {
+        let item = AVPlayerItem(url: Stream.onDemand.url)
+        let player = QueuePlayer(playerItem: item)
+        player.play()
+        expect(item.timeRange).toEventuallyNot(equal(.invalid))
+
+        expectEqualPublished(values: [1], from: player.publisher(for: \.rate), during: .seconds(2)) {
+            player.seek(to: CMTime(value: 30, timescale: 1), smooth: false) { finished in
+                expect(finished).to(beTrue())
+            }
+        }
+    }
 }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -103,7 +103,7 @@ final class QueuePlayerSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true) { finished in
+            player.seek(to: time1, smooth: true, paused: false) { finished in
                 expect(finished).to(beFalse())
             }
             player.seek(to: time2) { finished in
@@ -163,9 +163,9 @@ final class QueuePlayerSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: true, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: true, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: false, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: true, paused: false, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: true, paused: false, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: false, paused: false, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: false,
@@ -260,11 +260,11 @@ final class QueuePlayerSeekTests: TestCase {
         let player = QueuePlayerMock(playerItem: item)
         expect(player.timeRange).toEventuallyNot(equal(.invalid))
         waitUntil { done in
-            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true) { _ in }
-            player.seek(to: CMTime(value: 2, timescale: 1), smooth: true) { _ in }
-            player.seek(to: CMTime(value: 3, timescale: 1), smooth: true) { _ in }
-            player.seek(to: CMTime(value: 4, timescale: 1), smooth: true) { _ in }
-            player.seek(to: CMTime(value: 5, timescale: 1), smooth: true) { _ in
+            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true, paused: false) { _ in }
+            player.seek(to: CMTime(value: 2, timescale: 1), smooth: true, paused: false) { _ in }
+            player.seek(to: CMTime(value: 3, timescale: 1), smooth: true, paused: false) { _ in }
+            player.seek(to: CMTime(value: 4, timescale: 1), smooth: true, paused: false) { _ in }
+            player.seek(to: CMTime(value: 5, timescale: 1), smooth: true, paused: false) { _ in
                 done()
             }
         }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
@@ -17,7 +17,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
     func testNotificationsForSeekWithEmptyPlayer() {
         let player = QueuePlayer()
         expect {
-            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true, paused: false) { finished in
+            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([]), from: QueuePlayer.notificationCenter))
@@ -28,7 +28,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let player = QueuePlayer(playerItem: item)
         let time = CMTime(value: 1, timescale: 1)
         expect {
-            player.seek(to: time, smooth: true, paused: false) { finished in
+            player.seek(to: time, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
@@ -43,10 +43,10 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true, paused: false) { finished in
+            player.seek(to: time1, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true, paused: false) { finished in
+            player.seek(to: time2, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
@@ -66,10 +66,10 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true, paused: false) { finished in
+            player.seek(to: time1, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true, paused: false) { finished in
+            player.seek(to: time2, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
@@ -90,7 +90,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             player.seek(to: time1) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true, paused: false) { finished in
+            player.seek(to: time2, smooth: true) { finished in
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
@@ -118,9 +118,9 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: true, paused: false, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: true, paused: false, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: true, paused: false, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: true, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: true, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: true, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: true,
@@ -147,9 +147,9 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: false, paused: false, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: false, paused: false, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: true, paused: false, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: false, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: false, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: true, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: false,
@@ -164,11 +164,11 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         expect(player.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
-        player.seek(to: time1, smooth: true, paused: false) { _ in }
+        player.seek(to: time1, smooth: true) { _ in }
         expect(player.targetSeekTime).to(equal(time1))
 
         let time2 = CMTime(value: 2, timescale: 1)
-        player.seek(to: time2, smooth: true, paused: false) { _ in }
+        player.seek(to: time2, smooth: true) { _ in }
         expect(player.targetSeekTime).to(equal(time2))
     }
 }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
@@ -17,7 +17,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
     func testNotificationsForSeekWithEmptyPlayer() {
         let player = QueuePlayer()
         expect {
-            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true) { finished in
+            player.seek(to: CMTime(value: 1, timescale: 1), smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([]), from: QueuePlayer.notificationCenter))
@@ -28,7 +28,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let player = QueuePlayer(playerItem: item)
         let time = CMTime(value: 1, timescale: 1)
         expect {
-            player.seek(to: time, smooth: true) { finished in
+            player.seek(to: time, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
@@ -43,10 +43,10 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true) { finished in
+            player.seek(to: time1, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true) { finished in
+            player.seek(to: time2, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
@@ -66,10 +66,10 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         let time1 = CMTime(value: 1, timescale: 1)
         let time2 = CMTime(value: 2, timescale: 1)
         expect {
-            player.seek(to: time1, smooth: true) { finished in
+            player.seek(to: time1, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true) { finished in
+            player.seek(to: time2, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
@@ -90,7 +90,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             player.seek(to: time1) { finished in
                 expect(finished).to(beTrue())
             }
-            player.seek(to: time2, smooth: true) { finished in
+            player.seek(to: time2, smooth: true, paused: false) { finished in
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
@@ -118,9 +118,9 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: true, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: true, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: true, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: true, paused: false, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: true, paused: false, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: true, paused: false, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: true,
@@ -147,9 +147,9 @@ final class QueuePlayerSmoothSeekTests: TestCase {
             }
         }
 
-        player.seek(to: time1, smooth: false, completionHandler: completion(index: 1))
-        player.seek(to: time2, smooth: false, completionHandler: completion(index: 2))
-        player.seek(to: time3, smooth: true, completionHandler: completion(index: 3))
+        player.seek(to: time1, smooth: false, paused: false, completionHandler: completion(index: 1))
+        player.seek(to: time2, smooth: false, paused: false, completionHandler: completion(index: 2))
+        player.seek(to: time3, smooth: true, paused: false, completionHandler: completion(index: 3))
 
         expect(results).toEventually(equalDiff([
             1: false,
@@ -164,11 +164,11 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         expect(player.timeRange).toEventuallyNot(equal(.invalid))
 
         let time1 = CMTime(value: 1, timescale: 1)
-        player.seek(to: time1, smooth: true) { _ in }
+        player.seek(to: time1, smooth: true, paused: false) { _ in }
         expect(player.targetSeekTime).to(equal(time1))
 
         let time2 = CMTime(value: 2, timescale: 1)
-        player.seek(to: time2, smooth: true) { _ in }
+        player.seek(to: time2, smooth: true, paused: false) { _ in }
         expect(player.targetSeekTime).to(equal(time2))
     }
 }

--- a/Tests/PlayerTests/Skips/SkipBackwardTests.swift
+++ b/Tests/PlayerTests/Skips/SkipBackwardTests.swift
@@ -43,7 +43,7 @@ final class SkipBackwardTests: TestCase {
 
         waitUntil { done in
             player.skipBackward { finished in
-                expect(finished).to(beTrue())
+                expect(finished).to(beFalse())
             }
 
             player.skipBackward { finished in

--- a/Tests/PlayerTests/Skips/SkipForwardTests.swift
+++ b/Tests/PlayerTests/Skips/SkipForwardTests.swift
@@ -43,7 +43,7 @@ final class SkipForwardTests: TestCase {
 
         waitUntil { done in
             player.skipForward { finished in
-                expect(finished).to(beTrue())
+                expect(finished).to(beFalse())
             }
 
             player.skipForward { finished in


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves the seek experience to compete with `AVPlayerViewController`:

- Support frame-by-frame seeking in buffered content.
- Support trick mode for streams including I-frame playlists.

# Changes made

- Improve smooth seeking by pausing the player during playback and using an optimal seek position. There is little interest in pausing the playback during non-smooth seeks, therefore the existing smooth seeking implementation has been improved.
- Improve iOS demo slider readability.
- Use standard system player UI on tvOS.
- Use standard seek in Control Center (avoids pausing playback unnecessarily since the progress bar in the Control Center has deferred behavior anyway). This avoids the playback button toggling between play and paused states unnecessarily.
- Make skips sharp. Same idea as above. I considered making the seeks optionally smooth but the end result is almost identical from a user experience perspective (even if tapping fast). So for the moment I propose that we remove smooth seeking from skips.

Note that unit tests have been written for the new paused behavior during smooth seeking. Optimal seek positions cannot be unit tested easily as they lead to a better perceived experience which is difficult to express in an automated test.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
