### PR TITLE
Separate buffer tracking from progress tracking

### DIFF
--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -10,6 +10,7 @@ import SwiftUI
 #if os(iOS)
 struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
+    @StateObject var bufferTracker = BufferTracker()
 
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
@@ -54,16 +55,17 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             ZStack(alignment: .leading) {
                 rectangle(opacity: 0.1)
                     .background(.ultraThinMaterial)
-                rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(progressTracker.buffer))
+                rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(bufferTracker.buffer))
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
             }
-            .animation(.linear(duration: 0.5), value: progressTracker.buffer)
+            .animation(.linear(duration: 0.5), value: bufferTracker.buffer)
             .gesture(dragGesture(in: geometry))
             .busy(isBusy && !progressTracker.isInteracting)
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
         .animation(.easeInOut(duration: 0.4), value: progressTracker.isInteracting)
+        .bind(bufferTracker, to: progressTracker.player)
     }
 
     private func dragGesture(in geometry: GeometryProxy) -> some Gesture {

--- a/Sources/Player/UserInterface/BufferTracker.swift
+++ b/Sources/Player/UserInterface/BufferTracker.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Core
+import CoreMedia
+import SwiftUI
+
+/// An observable object which tracks buffering.
+public final class BufferTracker: ObservableObject {
+    /// The player to attach.
+    ///
+    /// Use `View.bind(_:to:)` in SwiftUI code.
+    @Published public var player: Player?
+
+    /// The buffer position.
+    ///
+    /// Returns a value between 0 and 1 indicating up to where content has been loaded and is available for
+    /// playback.
+    @Published public private(set) var buffer: Float = .zero
+
+    /// Creates a buffer tracker.
+    public init() {
+        $player
+            .map { player -> AnyPublisher<Float, Never> in
+                guard let player else { return Just(0).eraseToAnyPublisher() }
+                return player.queuePlayer
+                    .currentItemBufferPublisher()
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .removeDuplicates()
+            .receiveOnMainThread()
+            .assign(to: &$buffer)
+    }
+}
+
+public extension View {
+    /// Binds a buffer tracker to a player.
+    ///
+    /// - Parameters:
+    ///   - buffer: The buffer tracker to bind.
+    ///   - player: The player to observe.
+    func bind(_ bufferTracker: BufferTracker, to player: Player?) -> some View {
+        onAppear {
+            bufferTracker.player = player
+        }
+        .onChange(of: player) { newValue in
+            bufferTracker.player = newValue
+        }
+    }
+}

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -5,6 +5,7 @@
 //
 
 import Combine
+import Core
 import CoreMedia
 import SwiftUI
 
@@ -26,12 +27,6 @@ public final class ProgressTracker: ObservableObject {
             seek(to: progress, smooth: false)
         }
     }
-
-    /// The buffer position.
-    ///
-    /// Returns a value between 0 and 1 indicating up to where content has been loaded and is available for
-    /// playback.
-    @Published public var buffer: Float = .zero
 
     @Published private var _progress: Float?
 
@@ -107,18 +102,6 @@ public final class ProgressTracker: ObservableObject {
             .removeDuplicates()
             .receiveOnMainThread()
             .assign(to: &$_progress)
-
-        $player
-            .map { player -> AnyPublisher<Float, Never> in
-                guard let player else { return Just(0).eraseToAnyPublisher() }
-                return player.queuePlayer
-                    .currentItemBufferPublisher()
-                    .eraseToAnyPublisher()
-            }
-            .switchToLatest()
-            .removeDuplicates()
-            .receiveOnMainThread()
-            .assign(to: &$buffer)
     }
 
     private static func currentTimePublisher(

--- a/Tests/PlayerTests/BufferTracker/BufferTrackerTests.swift
+++ b/Tests/PlayerTests/BufferTracker/BufferTrackerTests.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Circumspect
+import Combine
+import Nimble
+import Streams
+import XCTest
+
+final class BufferTrackerTests: TestCase {
+    func testUnbound() {
+        let bufferTracker = BufferTracker()
+        expectAtLeastEqualPublished(
+            values: [0],
+            from: bufferTracker.changePublisher(at: \.buffer)
+                .removeDuplicates()
+        )
+    }
+
+    func testEmptyPlayer() {
+        let bufferTracker = BufferTracker()
+        expectAtLeastEqualPublished(
+            values: [0],
+            from: bufferTracker.changePublisher(at: \.buffer)
+                .removeDuplicates()
+        ) {
+            bufferTracker.player = Player()
+        }
+    }
+
+    func testPlayerChange() {
+        let bufferTracker = BufferTracker()
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        bufferTracker.player = player
+        player.play()
+        expect(bufferTracker.buffer).toEventuallyNot(equal(0))
+
+        let buffer = bufferTracker.buffer
+        expectAtLeastEqualPublished(
+            values: [buffer, 0],
+            from: bufferTracker.changePublisher(at: \.buffer)
+                .removeDuplicates()
+        ) {
+            bufferTracker.player = Player()
+        }
+    }
+
+    func testPlayerSetToNil() {
+        let bufferTracker = BufferTracker()
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        bufferTracker.player = player
+        player.play()
+        expect(bufferTracker.buffer).toEventuallyNot(equal(0))
+
+        let buffer = bufferTracker.buffer
+        expectAtLeastEqualPublished(
+            values: [buffer, 0],
+            from: bufferTracker.changePublisher(at: \.buffer)
+                .removeDuplicates()
+        ) {
+            bufferTracker.player = nil
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR separates progress tracking from buffer tracking. This avoids updates related to buffering to be propagating to view hierarchies only interested in time updates. Since buffer tracking is really a corner case having it impact all progress trackers is superfluous, thus its extraction as a separate object.

# Changes made

- Extract progress tracking from `ProgressTracker` and move it a new `BufferTracker`.
- Update the demo.

The documentation has not been updated. A dedicated small article would likely be helpful but talking about buffer tracking in the current getting started guide was a bit too much IMHO.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
