### PR TITLE
Fix tests running unnecessarily for 20 seconds

### DIFF
--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerProgressTests.swift
@@ -128,7 +128,7 @@ final class ProgressTrackerProgressTests: TestCase {
         }
 
         let progress = Float(20.0 / Stream.onDemand.duration.seconds)
-        expectPublished(
+        expectAtLeastPublished(
             values: [0, progress],
             from: progressTracker.changePublisher(at: \.progress)
                 .removeDuplicates(),

--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerTimeTests.swift
@@ -142,7 +142,7 @@ final class ProgressTrackerTimeTests: TestCase {
             }
         }
 
-        expectPublished(
+        expectAtLeastPublished(
             values: [nil, time],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR optimizes two tests which were running unnecessarily for 20 seconds, the default timeout. These tests were revealed thanks to the new Xcode 15 Insights feature.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
