### PR TITLE
Fix control centering

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -190,11 +190,11 @@ private struct PlaybackButton: View {
             Image(systemName: imageName)
                 .resizable()
                 .tint(.white)
-                .opacity(player.isBusy ? 0 : 1)
-                .animation(.defaultLinear, values: player.playbackState, player.canRestart())
         }
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
+        .opacity(player.isBusy ? 0 : 1)
+        .animation(.defaultLinear, values: player.playbackState, player.canRestart())
     }
 
     private func play() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -96,7 +96,7 @@ private struct MainView: View {
             image(name: "music.note.tv.fill")
         default:
             if player.isExternalPlaybackActive {
-                image(name: "airplayvideo")
+                image(name: "tv")
             }
             else {
                 VideoView(player: player, gravity: gravity)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -59,10 +59,10 @@ private struct MainView: View {
     private func main() -> some View {
         ZStack {
             video()
-                .ignoresSafeArea()
             controls()
             loadingIndicator()
         }
+        .ignoresSafeArea()
         .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
         .readLayout(into: $layoutInfo)
         .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes control centering in the custom player layout.

# Changes made

- Fixes centering.
- Update AirPlay icon to match the system player UI.
- Fix incorrect interaction still available while the playback button is supposed to be hidden.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
