### PR TITLE
Further improve seek user experience

### DIFF
--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -35,8 +35,6 @@ class QueuePlayer: AVQueuePlayer {
     private var pendingSeeks = Deque<Seek>()
     private var cancellables = Set<AnyCancellable>()
 
-    private var wasPaused = false
-
     private var targetSeek: Seek? {
         pendingSeeks.last
     }
@@ -78,11 +76,9 @@ class QueuePlayer: AVQueuePlayer {
             return
         }
 
-        pausePlaybackIfNeeded(smooth: smooth)
         enqueue(seek: seek) { [weak self] in
             guard let self else { return }
             notifySeekEnd()
-            resumePlaybackIfNeeded()
         }
     }
 
@@ -128,18 +124,6 @@ class QueuePlayer: AVQueuePlayer {
 
     private func notifySeekEnd() {
         Self.notificationCenter.post(name: .didSeek, object: self)
-    }
-
-    private func pausePlaybackIfNeeded(smooth: Bool) {
-        guard smooth && rate != 0 else { return }
-        wasPaused = true
-        rate = 0
-    }
-
-    private func resumePlaybackIfNeeded() {
-        guard wasPaused else { return }
-        rate = defaultRate
-        wasPaused = false
     }
 }
 

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -54,8 +54,7 @@ public extension Player {
     /// - Parameters:
     ///   - position: The position to seek to.
     ///   - smooth: Set to `true` to enable smooth seeking. This allows any currently pending seek to complete before
-    ///     any new seek is performed, preventing unnecessary cancellation. The player is also paused during the seek
-    ///     operation. Altogether both measures make it possible for the playhead position to be moved in a smoother way.
+    ///     any new seek is performed, preventing unnecessary cancellation and providing for a smoother experience.
     ///   - completion: A completion called when seeking ends. The provided Boolean informs whether the seek could
     ///     finish without being cancelled.
     func seek(
@@ -78,7 +77,9 @@ public extension Player {
         )
     }
 
-    /// Performs an optimal seek to a given time, providing the best possible user experience in all cases.
+    /// Performs an optimal seek to a given time, providing the best possible interactive user experience in all cases.
+    ///
+    /// For the best result the player should be paused during the whole interaction.
     ///
     /// - Parameters:
     ///   - time: The time to reach.

--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
@@ -6,7 +6,6 @@
 
 @testable import Player
 
-import Circumspect
 import Combine
 import CoreMedia
 import Nimble
@@ -22,12 +21,11 @@ final class ProgressTrackerPlaybackStateTests: TestCase {
         player.play()
         expect(player.playbackState).toEventually(equal(.playing))
 
-        expectAtLeastEqualPublished(values: [.playing, .paused], from: player.$playbackState) {
-            progressTracker.isInteracting = true
-        }
-        expectAtLeastEqualPublishedNext(values: [.playing], from: player.$playbackState) {
-            progressTracker.isInteracting = false
-        }
+        progressTracker.isInteracting = true
+        expect(player.playbackState).toEventually(equal(.paused))
+
+        progressTracker.isInteracting = false
+        expect(player.playbackState).toEventually(equal(.playing))
     }
 
     func testInteractionDoesUpdateAlreadyPausedPlayback() {
@@ -37,11 +35,10 @@ final class ProgressTrackerPlaybackStateTests: TestCase {
         progressTracker.player = player
         expect(player.playbackState).toEventually(equal(.paused))
 
-        expectNothingPublishedNext(from: player.$playbackState, during: .seconds(2)) {
-            progressTracker.isInteracting = true
-        }
-        expectNothingPublishedNext(from: player.$playbackState, during: .seconds(2)) {
-            progressTracker.isInteracting = false
-        }
+        progressTracker.isInteracting = true
+        expect(player.playbackState).toAlways(equal(.paused), until: .seconds(1))
+
+        progressTracker.isInteracting = false
+        expect(player.playbackState).toAlways(equal(.paused), until: .seconds(1))
     }
 }

--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
@@ -41,4 +41,27 @@ final class ProgressTrackerPlaybackStateTests: TestCase {
         progressTracker.isInteracting = false
         expect(player.playbackState).toAlways(equal(.paused), until: .seconds(1))
     }
+
+    func testTransferInteractionBetweenPlayers() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+
+        let item1 = PlayerItem.simple(url: Stream.onDemand.url)
+        let player1 = Player(item: item1)
+        progressTracker.player = player1
+        player1.play()
+        expect(player1.playbackState).toEventually(equal(.playing))
+
+        progressTracker.isInteracting = true
+        expect(player1.playbackState).toEventually(equal(.paused))
+
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
+        let player2 = Player(item: item2)
+        progressTracker.player = player2
+        player2.play()
+        expect(player2.playbackState).toEventually(equal(.playing))
+
+        progressTracker.player = player2
+        expect(player1.playbackState).toEventually(equal(.playing))
+        expect(player2.playbackState).toEventually(equal(.paused))
+    }
 }

--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerPlaybackStateTests.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import Circumspect
+import Combine
+import CoreMedia
+import Nimble
+import Streams
+import XCTest
+
+final class ProgressTrackerPlaybackStateTests: TestCase {
+    func testInteractionPausesPlayback() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        progressTracker.player = player
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        expectAtLeastEqualPublished(values: [.playing, .paused], from: player.$playbackState) {
+            progressTracker.isInteracting = true
+        }
+        expectAtLeastEqualPublishedNext(values: [.playing], from: player.$playbackState) {
+            progressTracker.isInteracting = false
+        }
+    }
+
+    func testInteractionDoesUpdateAlreadyPausedPlayback() {
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        progressTracker.player = player
+        expect(player.playbackState).toEventually(equal(.paused))
+
+        expectNothingPublishedNext(from: player.$playbackState, during: .seconds(2)) {
+            progressTracker.isInteracting = true
+        }
+        expectNothingPublishedNext(from: player.$playbackState, during: .seconds(2)) {
+            progressTracker.isInteracting = false
+        }
+    }
+}

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -270,17 +270,4 @@ final class QueuePlayerSeekTests: TestCase {
         }
         expect(player.seeks).to(equal(2))
     }
-
-    func testSeekDoesNotPausePlayback() {
-        let item = AVPlayerItem(url: Stream.onDemand.url)
-        let player = QueuePlayer(playerItem: item)
-        player.play()
-        expect(item.timeRange).toEventuallyNot(equal(.invalid))
-
-        expectEqualPublished(values: [1], from: player.publisher(for: \.rate), during: .seconds(2)) {
-            player.seek(to: CMTime(value: 30, timescale: 1), smooth: false) { finished in
-                expect(finished).to(beTrue())
-            }
-        }
-    }
 }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
@@ -171,43 +171,4 @@ final class QueuePlayerSmoothSeekTests: TestCase {
         player.seek(to: time2, smooth: true) { _ in }
         expect(player.targetSeekTime).to(equal(time2))
     }
-
-    func testSmoothSeekPausesPlayback() {
-        let item = AVPlayerItem(url: Stream.onDemand.url)
-        let player = QueuePlayer(playerItem: item)
-        player.play()
-        expect(item.timeRange).toEventuallyNot(equal(.invalid))
-
-        expectAtLeastEqualPublished(values: [1, 0, 1], from: player.publisher(for: \.rate)) {
-            player.seek(to: CMTime(value: 30, timescale: 1), smooth: true) { finished in
-                expect(finished).to(beTrue())
-            }
-        }
-    }
-
-    func testSmoothSeekPreservesPlaybackSpeed() {
-        let item = AVPlayerItem(url: Stream.onDemand.url)
-        let player = QueuePlayer(playerItem: item)
-        player.defaultRate = 0.5
-        player.play()
-        expect(item.timeRange).toEventuallyNot(equal(.invalid))
-
-        expectAtLeastEqualPublished(values: [0.5, 0, 0.5], from: player.publisher(for: \.rate)) {
-            player.seek(to: CMTime(value: 30, timescale: 1), smooth: true) { finished in
-                expect(finished).to(beTrue())
-            }
-        }
-    }
-
-    func testSmoothSeekDoesNotResumePausedPlayback() {
-        let item = AVPlayerItem(url: Stream.onDemand.url)
-        let player = QueuePlayer(playerItem: item)
-        expect(item.timeRange).toEventuallyNot(equal(.invalid))
-
-        expectEqualPublished(values: [0], from: player.publisher(for: \.rate), during: .seconds(2)) {
-            player.seek(to: CMTime(value: 30, timescale: 1), smooth: true) { finished in
-                expect(finished).to(beTrue())
-            }
-        }
-    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR further improves the seek user experience to have it on par with the one provided by the system player.

If running the code in its prior state one could namely observe that the experience was still lagging behind the standard system player user experience when seeking while playing (images were not moving as smoothly, e.g. with MP4 step-by-step seeking). But if playback was paused before seeking then both our player and the system player were providing the same experience.

The reason was that, even though we were pausing / resuming for each global seek group (current seek and pending seeks), we weren't pausing during the whole user interaction. Since an interaction leads to several seek groups being created, when each group completed playback was resumed, leading to a less smooth experience than if playback was kept paused the whole time.

This change also coincidentally mitigates issues reported in #473, though stream issues still have to be fixed.

# Changes made

- Implement pause during seeks in `ProgressTracker` to associate it with user interaction.
- Remove pause from `QueuePlayer` seeks.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
