### PR TITLE
Fix YouTube identifier parsing

### DIFF
--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -39,8 +39,8 @@ private struct MediaEntryView: View {
         if trimmedText.hasPrefix("urn") {
             return .init(title: "URN", type: .urn(trimmedText))
         }
-        else if let videoId = trimmedText.split(separator: "yt:").first {
-            return .init(title: "YouTube", type: .youTube(String(videoId)))
+        else if let videoId = trimmedText.firstMatch(of: /yt:(.*)/) {
+            return .init(title: "YouTube", type: .youTube(String(videoId.1)))
         }
         else if let url = URL(string: trimmedText) {
             return .init(title: "URL", type: .url(url))

--- a/Demo/Sources/YouTube/PlayerItem.swift
+++ b/Demo/Sources/YouTube/PlayerItem.swift
@@ -11,19 +11,17 @@ import YouTubeKit
 
 extension PlayerItem {
     static func youTube(videoId: String) -> Self {
-        let youTubePublisher =
-        Publishers.CombineLatest(
-            urlPublisher(videoId: videoId),
-            imagePublisher(videoId: videoId)
-                .prepend(UIImage())
-                .setFailureType(to: YouTubeError.self)
+        self.init(
+            publisher: Publishers.CombineLatest(
+                urlPublisher(videoId: videoId),
+                imagePublisher(videoId: videoId)
+                    .prepend(UIImage())
+                    .setFailureType(to: YouTubeError.self)
+            )
+            .map { url, image in
+                Asset.simple(url: url, metadata: YouTubeMetadata(videoId: videoId, url: url, image: image))
+            }
         )
-        .map { url, image in
-            Asset.simple(url: url, metadata: YouTubeMetadata(videoId: videoId, url: url, image: image))
-        }
-        .eraseToAnyPublisher()
-
-        return self.init(publisher: youTubePublisher)
     }
 
     private static func urlPublisher(videoId: String) -> AnyPublisher<URL, YouTubeError> {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes a minor issue preventing YouTube identifier parsing from working correctly.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
