### PR TITLE
Add YouTube auto paste

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0E310FE32A6E504700054319 /* YouTubeIdentifier in Frameworks */ = {isa = PBXBuildFile; productRef = 0E310FE22A6E504700054319 /* YouTubeIdentifier */; };
 		0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B995B29D43E4200D0276D /* OptInView.swift */; };
 		0E84D6162A12753100EB48C5 /* SettingsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E84D6152A12753100EB48C5 /* SettingsMenu.swift */; };
+		0EA6D2AA2A6F8FF300CC78BE /* YouTube+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA6D2A92A6F8FF300CC78BE /* YouTube+View.swift */; };
 		0EA8A9A72A6A7F940077E3E4 /* YouTubeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0EA8A9A62A6A7F940077E3E4 /* YouTubeKit */; };
 		0EA8A9AA2A6A80430077E3E4 /* PlayerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA8A9A92A6A80430077E3E4 /* PlayerItem.swift */; };
 		0EA8A9AE2A6AF0AF0077E3E4 /* YouTubeMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA8A9AD2A6AF0AF0077E3E4 /* YouTubeMetadata.swift */; };
@@ -79,6 +80,7 @@
 		0E2A3C392A6E431000645CA2 /* YouTubeIdentifier */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = YouTubeIdentifier; sourceTree = "<group>"; };
 		0E6B995B29D43E4200D0276D /* OptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInView.swift; sourceTree = "<group>"; };
 		0E84D6152A12753100EB48C5 /* SettingsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMenu.swift; sourceTree = "<group>"; };
+		0EA6D2A92A6F8FF300CC78BE /* YouTube+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "YouTube+View.swift"; sourceTree = "<group>"; };
 		0EA8A9A92A6A80430077E3E4 /* PlayerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerItem.swift; sourceTree = "<group>"; };
 		0EA8A9AD2A6AF0AF0077E3E4 /* YouTubeMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeMetadata.swift; sourceTree = "<group>"; };
 		0EA8E5D42A6D9AC700AB33BB /* YouTubeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeError.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				0EA8A9A92A6A80430077E3E4 /* PlayerItem.swift */,
+				0EA6D2A92A6F8FF300CC78BE /* YouTube+View.swift */,
 				0EA8E5D42A6D9AC700AB33BB /* YouTubeError.swift */,
 				0E2A3C392A6E431000645CA2 /* YouTubeIdentifier */,
 				0EA8A9AD2A6AF0AF0077E3E4 /* YouTubeMetadata.swift */,
@@ -585,6 +588,7 @@
 				6F8459F22A38543400A7B5F2 /* Signal.swift in Sources */,
 				6FDB51CB2A4042B2001F430F /* Router.swift in Sources */,
 				0E84D6162A12753100EB48C5 /* SettingsMenu.swift in Sources */,
+				0EA6D2AA2A6F8FF300CC78BE /* YouTube+View.swift in Sources */,
 				6F59E88B29CF31E20093E6FB /* PlaylistViewModel.swift in Sources */,
 				0EA8A9AA2A6A80430077E3E4 /* PlayerItem.swift in Sources */,
 				6F59E87F29CF31E10093E6FB /* Template.swift in Sources */,

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -22,6 +22,7 @@ private struct TextFieldView: View {
             }
             .tint(.white)
             .opacity(text.isEmpty ? 0 : 1)
+            .youTubePaste($text)
         }
     }
 

--- a/Demo/Sources/YouTube/YouTube+View.swift
+++ b/Demo/Sources/YouTube/YouTube+View.swift
@@ -8,11 +8,18 @@ import SwiftUI
 import YouTubeIdentifier
 
 extension View {
+    private static func paste(_ text: Binding<String>) {
+        guard let paste = UIPasteboard.general.string,
+              YouTubeIdentifier.extract(from: URL(string: paste)!) != nil else { return }
+        text.wrappedValue = paste
+    }
+
     func youTubePaste(_ text: Binding<String>) -> some View {
         onAppear {
-            guard let paste = UIPasteboard.general.string,
-                  YouTubeIdentifier.extract(from: URL(string: paste)!) != nil else { return }
-            text.wrappedValue = paste
+            Self.paste(text)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Self.paste(text)
         }
     }
 }

--- a/Demo/Sources/YouTube/YouTube+View.swift
+++ b/Demo/Sources/YouTube/YouTube+View.swift
@@ -33,8 +33,8 @@ extension View {
 #if os(iOS)
 private extension UIPasteboard {
     var hasYouTubeUrl: Bool {
-        guard let string else { return false }
-        return YouTubeIdentifier.extract(from: URL(string: string)!) != nil
+        guard let string, let url = URL(string: string) else { return false }
+        return YouTubeIdentifier.extract(from: url) != nil
     }
 }
 #endif

--- a/Demo/Sources/YouTube/YouTube+View.swift
+++ b/Demo/Sources/YouTube/YouTube+View.swift
@@ -9,8 +9,8 @@ import YouTubeIdentifier
 
 extension View {
     private static func paste(_ text: Binding<String>) {
-        guard let paste = UIPasteboard.general.string,
-              YouTubeIdentifier.extract(from: URL(string: paste)!) != nil else { return }
+        guard UIPasteboard.general.hasYouTubeUrl,
+              let paste = UIPasteboard.general.string else { return }
         text.wrappedValue = paste
     }
 
@@ -21,5 +21,12 @@ extension View {
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             Self.paste(text)
         }
+    }
+}
+
+private extension UIPasteboard {
+    var hasYouTubeUrl: Bool {
+        guard let string else { return false }
+        return YouTubeIdentifier.extract(from: URL(string: string)!) != nil
     }
 }

--- a/Demo/Sources/YouTube/YouTube+View.swift
+++ b/Demo/Sources/YouTube/YouTube+View.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+import YouTubeIdentifier
+
+extension View {
+    func youTubePaste(_ text: Binding<String>) -> some View {
+        onAppear {
+            guard let paste = UIPasteboard.general.string,
+                  YouTubeIdentifier.extract(from: URL(string: paste)!) != nil else { return }
+            text.wrappedValue = paste
+        }
+    }
+}

--- a/Demo/Sources/YouTube/YouTube+View.swift
+++ b/Demo/Sources/YouTube/YouTube+View.swift
@@ -8,25 +8,33 @@ import SwiftUI
 import YouTubeIdentifier
 
 extension View {
+#if os(iOS)
     private static func paste(_ text: Binding<String>) {
         guard UIPasteboard.general.hasYouTubeUrl,
               let paste = UIPasteboard.general.string else { return }
         text.wrappedValue = paste
     }
+#endif
 
     func youTubePaste(_ text: Binding<String>) -> some View {
+#if os(iOS)
         onAppear {
             Self.paste(text)
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             Self.paste(text)
         }
+#else
+        self
+#endif
     }
 }
 
+#if os(iOS)
 private extension UIPasteboard {
     var hasYouTubeUrl: Bool {
         guard let string else { return false }
         return YouTubeIdentifier.extract(from: URL(string: string)!) != nil
     }
 }
+#endif


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows to auto paste YouTube URLs in the `TextField`, if any detected.

# Changes made

- A `youTubePaste` method has been added as `View` extension.

# Improvement ideas

- Use `UIPasteControl` to avoid raising an alert.
- Try to use continuity to copy/paste from Apple devices.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
