### PR TITLE
Improve full screen support on iPad

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		6F9B5BC928CF8C530074B9E0 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9B5BC828CF8C530074B9E0 /* OrderedCollections */; };
 		6F9DDB44288FE90E0069B687 /* Player in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9DDB43288FE90E0069B687 /* Player */; };
 		6FBEFCEB289132DB004BE625 /* UserInterface in Frameworks */ = {isa = PBXBuildFile; productRef = 6FBEFCEA289132DB004BE625 /* UserInterface */; };
+		6FC5D6A22A6FA8D20012BC89 /* Modal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC5D6A12A6FA8D20012BC89 /* Modal.swift */; };
 		6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6FCA4746292CBEC7008C2812 /* ShowTime */; };
 		6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCB9DDD29E024E900961B69 /* BlurredView.swift */; };
 		6FDB51CB2A4042B2001F430F /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB51CA2A4042B2001F430F /* Router.swift */; };
@@ -141,6 +142,7 @@
 		6F917C082887EA8E004113BA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6F917C0D2887EA8E004113BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6F9DDB40288FE8F80069B687 /* pillarbox-apple */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "pillarbox-apple"; path = ..; sourceTree = "<group>"; };
+		6FC5D6A12A6FA8D20012BC89 /* Modal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modal.swift; sourceTree = "<group>"; };
 		6FCB9DDD29E024E900961B69 /* BlurredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredView.swift; sourceTree = "<group>"; };
 		6FDB51CA2A4042B2001F430F /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		6FE324B229E4657D007501CF /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -354,9 +356,10 @@
 				6F59E86729CF31E10093E6FB /* Cell.swift */,
 				6F59E86629CF31E10093E6FB /* CopyButton.swift */,
 				6F59E86829CF31E10093E6FB /* MessageViews.swift */,
+				6FC5D6A12A6FA8D20012BC89 /* Modal.swift */,
+				0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */,
 				0E84D6152A12753100EB48C5 /* SettingsMenu.swift */,
 				6FE324B229E4657D007501CF /* View.swift */,
-				0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -593,6 +596,7 @@
 				6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */,
 				6F59E89129CF31E20093E6FB /* WrappedView.swift in Sources */,
 				6F59E88629CF31E20093E6FB /* ContentListView.swift in Sources */,
+				6FC5D6A22A6FA8D20012BC89 /* Modal.swift in Sources */,
 				6F59E89B29CF31E20093E6FB /* SystemPlayerView.swift in Sources */,
 				6F59E87B29CF31E10093E6FB /* DemoApp.swift in Sources */,
 				6F59E89029CF31E20093E6FB /* Story.swift in Sources */,

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		6F9DDB44288FE90E0069B687 /* Player in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9DDB43288FE90E0069B687 /* Player */; };
 		6FBEFCEB289132DB004BE625 /* UserInterface in Frameworks */ = {isa = PBXBuildFile; productRef = 6FBEFCEA289132DB004BE625 /* UserInterface */; };
 		6FC5D6A22A6FA8D20012BC89 /* Modal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC5D6A12A6FA8D20012BC89 /* Modal.swift */; };
+		6FC5D6A42A6FACB20012BC89 /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC5D6A32A6FACB20012BC89 /* CloseButton.swift */; };
 		6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6FCA4746292CBEC7008C2812 /* ShowTime */; };
 		6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCB9DDD29E024E900961B69 /* BlurredView.swift */; };
 		6FDB51CB2A4042B2001F430F /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB51CA2A4042B2001F430F /* Router.swift */; };
@@ -143,6 +144,7 @@
 		6F917C0D2887EA8E004113BA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6F9DDB40288FE8F80069B687 /* pillarbox-apple */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "pillarbox-apple"; path = ..; sourceTree = "<group>"; };
 		6FC5D6A12A6FA8D20012BC89 /* Modal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modal.swift; sourceTree = "<group>"; };
+		6FC5D6A32A6FACB20012BC89 /* CloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
 		6FCB9DDD29E024E900961B69 /* BlurredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredView.swift; sourceTree = "<group>"; };
 		6FDB51CA2A4042B2001F430F /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		6FE324B229E4657D007501CF /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				6F59E86729CF31E10093E6FB /* Cell.swift */,
+				6FC5D6A32A6FACB20012BC89 /* CloseButton.swift */,
 				6F59E86629CF31E10093E6FB /* CopyButton.swift */,
 				6F59E86829CF31E10093E6FB /* MessageViews.swift */,
 				6FC5D6A12A6FA8D20012BC89 /* Modal.swift */,
@@ -549,6 +552,7 @@
 				6F59E88E29CF31E20093E6FB /* StoriesViewModel.swift in Sources */,
 				6F59E89729CF31E20093E6FB /* MessageViews.swift in Sources */,
 				6F59E88C29CF31E20093E6FB /* TwinsView.swift in Sources */,
+				6FC5D6A42A6FACB20012BC89 /* CloseButton.swift in Sources */,
 				6F59E88529CF31E20093E6FB /* ContentListsView.swift in Sources */,
 				6F59E8A329CF31E20093E6FB /* ExamplesView.swift in Sources */,
 				0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */,

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -29,7 +29,7 @@ private struct MainView: View {
         ZStack {
             main()
             timeBar()
-            volumeButton()
+            topBar()
         }
         .animation(.defaultLinear, values: player.isBusy, isUserInterfaceHidden)
         .bind(visibilityTracker, to: player)
@@ -82,11 +82,15 @@ private struct MainView: View {
     }
 
     @ViewBuilder
-    private func volumeButton() -> some View {
-        VolumeButton(player: player)
-            .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
-            .preventsTouchPropagation()
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+    private func topBar() -> some View {
+        HStack {
+            CloseButton()
+            Spacer()
+            VolumeButton(player: player)
+        }
+        .opacity(isUserInterfaceHidden && !areControlsAlwaysVisible ? 0 : 1)
+        .preventsTouchPropagation()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
     }
 
     @ViewBuilder
@@ -260,9 +264,9 @@ private struct FullScreenButton: View {
             Button(action: toggleFullScreen) {
                 Image(systemName: imageName)
                     .tint(.white)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 45, height: 45)
             }
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 45, height: 45)
         }
     }
 
@@ -297,8 +301,8 @@ private struct VolumeButton: View {
         Button(action: toggleMuted) {
             Image(systemName: imageName)
                 .tint(.white)
+                .frame(width: 45, height: 45)
         }
-        .frame(width: 45, height: 45)
     }
 
     private var imageName: String {
@@ -482,6 +486,9 @@ struct PlaybackView: View {
                 switch player.playbackState {
                 case let .failed(error: error):
                     PlaybackMessageView(message: error.localizedDescription)
+                        .overlay(alignment: .topLeading) {
+                            CloseButton()
+                        }
                 default:
                     videoView()
                         .persistentSystemOverlays(.hidden)
@@ -489,6 +496,9 @@ struct PlaybackView: View {
             }
             else {
                 PlaybackMessageView(message: "No content")
+                    .overlay(alignment: .topLeading) {
+                        CloseButton()
+                    }
             }
         }
         .background(.black)
@@ -512,6 +522,9 @@ struct PlaybackView: View {
                 MainView(player: player, layout: $layout)
             case .system:
                 SystemVideoView(player: player)
+                    .overlay(alignment: .topLeading) {
+                        CloseButton()
+                    }
                     .ignoresSafeArea()
             }
 #else

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -21,6 +21,9 @@ struct SimplePlayerView: View {
             progressView()
             playbackButton()
         }
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onAppear(perform: play)
         .tracked(name: "simple-player")
     }

--- a/Demo/Sources/Players/SystemPlayerView.swift
+++ b/Demo/Sources/Players/SystemPlayerView.swift
@@ -18,6 +18,9 @@ struct SystemPlayerView: View {
     var body: some View {
         SystemVideoView(player: player)
             .ignoresSafeArea()
+            .overlay(alignment: .topLeading) {
+                CloseButton()
+            }
             .onAppear(perform: play)
             .tracked(name: "system-player")
     }

--- a/Demo/Sources/Players/VanillaPlayerView.swift
+++ b/Demo/Sources/Players/VanillaPlayerView.swift
@@ -16,6 +16,9 @@ struct VanillaPlayerView: View {
     var body: some View {
         VideoPlayer(player: player)
             .ignoresSafeArea()
+            .overlay(alignment: .topLeading) {
+                CloseButton()
+            }
             .onAppear(perform: play)
     }
 

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -16,7 +16,7 @@ struct RoutedNavigationStack<Root>: View where Root: View {
     var body: some View {
         NavigationStack(path: $router.path) {
             root()
-                .sheet(item: $router.presented) { presented in
+                .modal(item: $router.presented) { presented in
                     view(for: presented)
                 }
                 .navigationDestination(for: RouterDestination.self) { destination in

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -25,6 +25,9 @@ struct BlurredView: View {
                 .opacity(player.isBusy ? 1 : 0)
         }
         .background(.black)
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onAppear(perform: play)
         .onForeground(perform: player.play)
         .tracked(name: "blurred")

--- a/Demo/Sources/Showcase/LinkView.swift
+++ b/Demo/Sources/Showcase/LinkView.swift
@@ -25,6 +25,9 @@ struct LinkView: View {
             Toggle("Content displayed", isOn: $isDisplayed)
                 .padding()
         }
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onAppear(perform: play)
         .onForeground(perform: resume)
         .tracked(name: "link")

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -77,6 +77,9 @@ struct MultiView: View {
             }
             .background(.black)
         }
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onChange(of: activePosition) { position in
             setActive(position: position)
         }

--- a/Demo/Sources/Showcase/Stories/StoriesView.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesView.swift
@@ -54,6 +54,10 @@ struct StoriesView: View {
         .background(.black)
         .tabViewStyle(.page)
         .ignoresSafeArea()
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+                .offset(y: 20)
+        }
         .tracked(name: "stories")
     }
 }

--- a/Demo/Sources/Showcase/TwinsView.swift
+++ b/Demo/Sources/Showcase/TwinsView.swift
@@ -39,6 +39,9 @@ struct TwinsView: View {
             .pickerStyle(.segmented)
             .padding()
         }
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onAppear(perform: play)
         .onForeground(perform: resume)
         .tracked(name: "twins")

--- a/Demo/Sources/Showcase/Wrapped/WrappedView.swift
+++ b/Demo/Sources/Showcase/Wrapped/WrappedView.swift
@@ -28,6 +28,9 @@ struct WrappedView: View {
             }
             .padding()
         }
+        .overlay(alignment: .topLeading) {
+            CloseButton()
+        }
         .onAppear(perform: play)
         .onForeground(perform: resume)
         .tracked(name: "wrapped")

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -5,15 +5,21 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct CloseButton: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        Button(action: dismiss.callAsFunction) {
-            Image(systemName: "chevron.down")
-                .tint(.white)
-                .frame(width: 45, height: 45)
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            Button(action: dismiss.callAsFunction) {
+                Image(systemName: "chevron.down")
+                    .tint(.white)
+                    .frame(width: 45, height: 45)
+            }
+        default:
+            EmptyView()
         }
     }
 }

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+struct CloseButton: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Button(action: dismiss.callAsFunction) {
+            Image(systemName: "chevron.down")
+                .tint(.white)
+                .frame(width: 45, height: 45)
+        }
+    }
+}

--- a/Demo/Sources/Views/Modal.swift
+++ b/Demo/Sources/Views/Modal.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+private struct PresentedView<Content>: View where Content: View {
+    @ViewBuilder var content: () -> Content
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        content()
+            .gesture(
+                DragGesture(minimumDistance: 100)
+                    .onEnded { value in
+                        guard value.translation.height > 0 else { return }
+                        dismiss()
+                    }
+            )
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func modal<Item, Content>(item: Binding<Item?>, @ViewBuilder content: @escaping (Item) -> Content) -> some View where Item: Identifiable, Content: View {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            fullScreenCover(item: item) { item in
+                PresentedView {
+                    content(item)
+                }
+            }
+        default:
+            sheet(item: item, content: content)
+        }
+    }
+}

--- a/Demo/Sources/Views/Modal.swift
+++ b/Demo/Sources/Views/Modal.swift
@@ -6,6 +6,7 @@
 
 import SwiftUI
 
+@available(tvOS, unavailable)
 private struct PresentedView<Content>: View where Content: View {
     @ViewBuilder var content: () -> Content
     @Environment(\.dismiss) private var dismiss
@@ -25,6 +26,7 @@ private struct PresentedView<Content>: View where Content: View {
 extension View {
     @ViewBuilder
     func modal<Item, Content>(item: Binding<Item?>, @ViewBuilder content: @escaping (Item) -> Content) -> some View where Item: Identifiable, Content: View {
+#if os(iOS)
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
             fullScreenCover(item: item) { item in
@@ -35,5 +37,8 @@ extension View {
         default:
             sheet(item: item, content: content)
         }
+#else
+        fullScreenCover(item: item, content: content)
+#endif
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves full screen support on iPad, displaying modal on the full screen with a close button displayed in this case.

# Changes made

 The implementation suffers from current SwiftUI limitations:

- Full screen cover has no built-in gesture.
- We cannot transition between full screen cover and sheet presentations, either with `presentationCompactAdaptation(_:)` or by branching between two view hierarchies.

Until SwiftUI is improved or until we implement better modal presentation (which requires quite an amount of work), the following compromise was implemented:

- Always use cover on iPad and sheet on iPhone, no matter the size class.
- Add a raw drag gesture (with non-interactive dismissal).

Moreover, due to current `Router` limitations, the playlist view accessible from content lists displays as a modal sheet instead of a full screen cover.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
