### PR TITLE
Reduce auto-hide standard delay

### DIFF
--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -38,7 +38,7 @@ public final class VisibilityTracker: ObservableObject {
     /// - Parameters:
     ///   - delay: The delay after which `isUserInterfaceHidden` is automatically reset to `true`.
     ///   - isUserInterfaceHidden: The initial value for `isUserInterfaceHidden`.
-    public init(delay: TimeInterval = 4, isUserInterfaceHidden: Bool = false) {
+    public init(delay: TimeInterval = 3, isUserInterfaceHidden: Bool = false) {
         assert(delay > 0)
         self.isUserInterfaceHidden = isUserInterfaceHidden
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adjusts the default auto-hide delay, in agreement with @svenduvoisin and @StaehliJ.

# Changes made

- Reduce the auto-hide delay from 4 to 3 seconds.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
