### PR TITLE
Avoid PhaseAnimator usage

### DIFF
--- a/Demo/Sources/Players/BasicPlaybackView.swift
+++ b/Demo/Sources/Players/BasicPlaybackView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 // Behavior: h-exp, v-hug
 private struct TimeSlider: View {
     @ObservedObject var player: Player
-    @StateObject var progressTracker = ProgressTracker(
+    @StateObject private var progressTracker = ProgressTracker(
         interval: CMTime(value: 1, timescale: 10),
         seekBehavior: UserDefaults.standard.seekBehavior
     )

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -145,7 +145,7 @@ private struct MainView: View {
 
 private struct ControlsView: View {
     @ObservedObject var player: Player
-    @StateObject var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 1))
+    @StateObject private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 1))
 
     var body: some View {
         ZStack {

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -60,7 +60,6 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             }
             .animation(.linear(duration: 0.5), value: bufferTracker.buffer)
             .gesture(dragGesture(in: geometry))
-            .busy(isBusy && !progressTracker.isInteracting)
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
@@ -88,27 +87,6 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 extension PlaybackSlider where ValueLabel == EmptyView {
     init(progressTracker: ProgressTracker) {
         self.init(progressTracker: progressTracker, minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() })
-    }
-}
-
-private extension View {
-    @ViewBuilder
-    func busy(_ isBusy: Bool) -> some View {
-        // TODO: Remove when Xcode 15 has been released
-#if compiler(>=5.9)
-        if #available(iOS 17.0, *), isBusy {
-            phaseAnimator([true, false]) { content, phase in
-                content
-                    .opacity(phase ? 0.5 : 1)
-                    .animation(.easeInOut(duration: 0.7), value: phase)
-            }
-        }
-        else {
-            self
-        }
-#else
-        self
-#endif
     }
 }
 

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -10,7 +10,7 @@ import SwiftUI
 #if os(iOS)
 struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
-    @StateObject var bufferTracker = BufferTracker()
+    @StateObject private var bufferTracker = BufferTracker()
 
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to remove a buggy `PhaseAnimator` API.

# Changes made

- The `isBusy` method has been removed and `PhaseAnimator` is not used anymore.
- Some `@StateObject` and `@State` have been made private.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
