### PR TITLE
Use default Commanders Act logging

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import TCCore
 import TCServerSide
 
 final class CommandersActService {
@@ -27,7 +26,6 @@ final class CommandersActService {
 
     func start(with configuration: Analytics.Configuration) {
         vendor = configuration.vendor
-        TCDebug.setDebugLevel(TCLogLevel_None)
         guard let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) else { return }
         serverSide.addPermanentData("app_library_version", withValue: PackageInfo.version)
         serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR removes Commanders Act logging level setup now superfluous following an SDK update merged in #487.

# Changes made

- Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
