### PR TITLE
Add a player version

### DIFF
--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -6,6 +6,7 @@
 
 import Analytics
 import AVFoundation
+import Player
 import SwiftUI
 
 struct SettingsView: View {
@@ -115,7 +116,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func debuggingFooter() -> some View {
         VStack {
-            Text("Version \(version) Build \(buildVersion)")
+            Text("Version \(version) Build \(buildVersion), Player \(Player.version)")
             HStack(spacing: 0) {
                 Text("Made with ")
                 Image(systemName: "heart.fill")

--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,9 @@ let package = Package(
                 .target(name: "Core"),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "TimelaneCombine", package: "TimelaneCombine")
+            ],
+            plugins: [
+                .plugin(name: "PackageInfoPlugin")
             ]
         ),
         .target(

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -44,6 +44,11 @@ public class Analytics {
     /// The singleton instance.
     public static var shared = Analytics()
 
+    /// The analytics version.
+    public static var version: String {
+        PackageInfo.version
+    }
+
     private var configuration: Configuration?
 
     private let comScoreService = ComScoreService()

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -28,7 +28,7 @@ public final class ComScoreTracker: PlayerItemTracker {
     public func enable(for player: Player) {
         streamingAnalytics.createPlaybackSession()
         streamingAnalytics.setMediaPlayerName("Pillarbox")
-        streamingAnalytics.setMediaPlayerVersion(PackageInfo.version)
+        streamingAnalytics.setMediaPlayerVersion(Player.version)
 
         $metadata.sink { [weak self] metadata in
             self?.updateMetadata(with: metadata)

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -27,7 +27,7 @@ final class CommandersActService {
     func start(with configuration: Analytics.Configuration) {
         vendor = configuration.vendor
         guard let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) else { return }
-        serverSide.addPermanentData("app_library_version", withValue: PackageInfo.version)
+        serverSide.addPermanentData("app_library_version", withValue: Analytics.version)
         serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
         serverSide.addPermanentData("navigation_device", withValue: Self.device())
         serverSide.enableRunningInBackground()

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -103,7 +103,7 @@ private extension CommandersActTracker {
     func labels(for player: Player) -> [String: String] {
         metadata.labels.merging([
             "media_player_display": "Pillarbox",
-            "media_player_version": PackageInfo.version,
+            "media_player_version": Player.version,
             "media_volume": "\(volume(for: player))"
         ]) { _, new in new }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -15,6 +15,11 @@ import TimelaneCombine
 public final class Player: ObservableObject, Equatable {
     private static weak var currentPlayer: Player?
 
+    /// The player version.
+    public static var version: String {
+        PackageInfo.version
+    }
+
     /// The current playback state.
     @Published public private(set) var playbackState: PlaybackState = .idle
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -27,7 +27,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(labels.navigation_level_8).to(equal("level_8"))
                 expect(labels.navigation_level_9).to(beNil())
                 expect(["phone", "tablet", "tvbox", "phone"]).to(contain([labels.navigation_device]))
-                expect(labels.app_library_version).to(equal(PackageInfo.version))
+                expect(labels.app_library_version).to(equal(Analytics.version))
                 expect(labels.navigation_app_site_name).to(equal("site"))
                 expect(labels.navigation_property_type).to(equal("app"))
                 expect(labels.navigation_bu_distributer).to(equal("SRG"))


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to add a player version.

<img width="306" alt="version" src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/72117a88-4ae1-47e0-ab8e-a89a5a076df5">

# Changes made

- The `PackgeInfoPlugin` has been added as player dependency.
- A version property has been added to the player.
- The player version is displayed in the settings in the demo app.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
