### PR TITLE
Add feedback report reference to known audio duration issue for iPad apps running on macOS

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -70,7 +70,7 @@ The media type can be `.unknown` if an AirPlay session was established before pl
 
 No workaround is available yet.
 
-## Audio duration is zero in Mac applications "Designed for iPad"
+## Audio duration is zero in Mac applications "Designed for iPad" (FB12765347)
 
 Pillarbox can be used in iPad applications run on Silicon Macs (_Designed for iPad_ destination) but audios played will have a reported duration of zero. As a result progress reported by `ProgressTracker` also remains stuck at zero.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds a feedback number for a known issue affecting audio duration in iPad apps run on macOS.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
