### PR TITLE
Retrieve media composition specific to supported vectors

### DIFF
--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -20,6 +20,14 @@ final class DataProvider {
     let server: Server
     private let session: URLSession
 
+    private var vector: String {
+#if os(iOS)
+        return "appplay"
+#else
+        return "tvplay"
+#endif
+    }
+
     init(server: Server = .production) {
         self.server = server
         session = URLSession(configuration: .ephemeral)
@@ -43,7 +51,8 @@ final class DataProvider {
         let url = server.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
         components.queryItems = [
-            URLQueryItem(name: "onlyChapters", value: "true")
+            URLQueryItem(name: "onlyChapters", value: "true"),
+            URLQueryItem(name: "vector", value: vector)
         ]
         return components.url ?? url
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds vector support to media composition calls so that data can be adjusted for mobile and TV platforms.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
