### PR TITLE
Avoid sound playing for a short while after system player UI dismissal on tvOS

### DIFF
--- a/Demo/Sources/Players/SystemPlayerView.swift
+++ b/Demo/Sources/Players/SystemPlayerView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 // Behavior: h-exp, v-exp
 struct SystemPlayerView: View {
     let media: Media
-
     @StateObject private var player = Player()
 
     var body: some View {

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -135,6 +135,10 @@ struct ShowcaseView: View {
                 destination: .systemPlayer(media: Media(from: URLTemplate.onDemandVideoMP4))
             )
             cell(
+                title: "Video URN - On-demand",
+                destination: .systemPlayer(media: Media(from: URNTemplate.onDemandVideo))
+            )
+            cell(
                 title: "Video URN - Livestream with DRM",
                 destination: .systemPlayer(media: Media(from: URNTemplate.dvrVideo))
             )

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -21,6 +21,12 @@ public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
         VideoPlayer(player: player.queuePlayer) {
             videoOverlay
         }
+#if os(tvOS)
+        .onDisappear {
+            // Avoid sound continuing in background on tvOS, see https://github.com/SRGSSR/pillarbox-apple/issues/520.
+            player.pause()
+        }
+#endif
     }
 
     /// Creates the view.


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes an issue encountered when using Pillarbox with the system player UI on tvOS.

# Changes made

See related issue. This PR implements idea 7 which was the less intrusive. Other ideas are still possible if this pragmatic fix proves insufficient in the long term.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
