### PR TITLE
Add WWDC Keynote stream to examples

### DIFF
--- a/Demo/Sources/Examples/ExamplesViewModel.swift
+++ b/Demo/Sources/Examples/ExamplesViewModel.swift
@@ -44,7 +44,8 @@ final class ExamplesViewModel: ObservableObject {
         URLTemplate.appleBasic_16_9_TS_HLS,
         URLTemplate.appleAdvanced_16_9_TS_HLS,
         URLTemplate.appleAdvanced_16_9_fMP4_HLS,
-        URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS
+        URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS,
+        URLTemplate.appleWWDCKeynote2023
     ])
 
     let thirdPartyMedias = Template.medias(from: [

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -81,6 +81,10 @@ enum URLTemplate {
         description: "16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz",
         type: .url("https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8")
     )
+    static let appleWWDCKeynote2023 = Template(
+        title: "Apple WWDC Keynote 2023",
+        type: .url("https://events-delivery.apple.com/0105cftwpxxsfrpdwklppzjhjocakrsk/m3u8/vod_index-PQsoJoECcKHTYzphNkXohHsQWACugmET.m3u8")
+    )
     static let uhdVideoHLS = Template(
         title: "Brain Farm Skate Phantom Flex",
         description: "4K video",

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -30,6 +30,7 @@ final class PlaylistViewModel: ObservableObject {
         URLTemplate.appleAdvanced_16_9_TS_HLS,
         URLTemplate.appleAdvanced_16_9_fMP4_HLS,
         URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS,
+        URLTemplate.appleWWDCKeynote2023,
         URLTemplate.uhdVideoHLS,
         URNTemplate.expired,
         URNTemplate.unknown


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds WWDC 2023 Keynote stream to the examples. This stream is especially intersting since it supports:

- A lot of different variants.
- Many subtitles.
- AD.
- I-frame playlists.

And it brings a bit of Vision Pro to Pillarbox 😉

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
