### PR TITLE
Show user interface when returning to the foreground while not playing

### DIFF
--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -41,7 +41,23 @@ public final class VisibilityTracker: ObservableObject {
     public init(delay: TimeInterval = 3, isUserInterfaceHidden: Bool = false) {
         assert(delay > 0)
         self.isUserInterfaceHidden = isUserInterfaceHidden
+        autohidePublisher(delay: delay)
+            .receiveOnMainThread()
+            .assign(to: &$isUserInterfaceHidden)
+    }
 
+    /// Toggles user interface visibility.
+    public func toggle() {
+        isUserInterfaceHidden.toggle()
+    }
+
+    /// Resets user interface auto hide delay.
+    public func reset() {
+        guard !isUserInterfaceHidden else { return }
+        trigger.activate(for: TriggerId.reset)
+    }
+
+    private func autohidePublisher(delay: TimeInterval) -> AnyPublisher<Bool, Never> {
         $player
             .removeDuplicates()
             .map { player -> AnyPublisher<PlaybackState, Never> in
@@ -64,19 +80,7 @@ public final class VisibilityTracker: ObservableObject {
                 .eraseToAnyPublisher()
             }
             .switchToLatest()
-            .receiveOnMainThread()
-            .assign(to: &$isUserInterfaceHidden)
-    }
-
-    /// Toggles user interface visibility.
-    public func toggle() {
-        isUserInterfaceHidden.toggle()
-    }
-
-    /// Resets user interface auto hide delay.
-    public func reset() {
-        guard !isUserInterfaceHidden else { return }
-        trigger.activate(for: TriggerId.reset)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -8,14 +8,15 @@ import Combine
 import Core
 import Foundation
 import SwiftUI
+import UIKit
 
 /// An observable object tracking user interface visibility.
 ///
-/// The tracker automatically turns off visibility after a delay while playing content.
+/// The tracker automatically turns off visibility after a delay while playing content. It also automatically turns
+/// on visibility when the application returns to the foreground, provided the player is not currently playing.
 @available(tvOS, unavailable)
 public final class VisibilityTracker: ObservableObject {
     private enum TriggerId {
-        case toggle
         case reset
     }
 
@@ -25,14 +26,11 @@ public final class VisibilityTracker: ObservableObject {
     @Published public var player: Player?
 
     /// Returns whether the user interface should be hidden.
-    @Published public private(set) var isUserInterfaceHidden: Bool {
-        didSet {
-            guard !isUserInterfaceHidden else { return }
-            trigger.activate(for: TriggerId.reset)
-        }
-    }
+    @Published public private(set) var isUserInterfaceHidden: Bool
 
+    private let delay: TimeInterval
     private let trigger = Trigger()
+    private let togglePublisher = PassthroughSubject<Bool, Never>()
 
     /// Creates a tracker managing user interface visibility.
     /// 
@@ -41,35 +39,10 @@ public final class VisibilityTracker: ObservableObject {
     ///   - isUserInterfaceHidden: The initial value for `isUserInterfaceHidden`.
     public init(delay: TimeInterval = 3, isUserInterfaceHidden: Bool = false) {
         assert(delay > 0)
+
+        self.delay = delay
         self.isUserInterfaceHidden = isUserInterfaceHidden
 
-        Publishers.Merge(
-            togglePublisher(),
-            autohidePublisher(delay: delay)
-        )
-        .receiveOnMainThread()
-        .assign(to: &$isUserInterfaceHidden)
-    }
-
-    /// Toggles user interface visibility.
-    public func toggle() {
-        trigger.activate(for: TriggerId.toggle)
-    }
-
-    /// Resets user interface auto hide delay.
-    public func reset() {
-        guard !isUserInterfaceHidden else { return }
-        trigger.activate(for: TriggerId.reset)
-    }
-
-    private func togglePublisher() -> AnyPublisher<Bool, Never> {
-        trigger.signal(activatedBy: TriggerId.toggle)
-            .weakCapture(self, at: \.isUserInterfaceHidden)
-            .map { !$1 }
-            .eraseToAnyPublisher()
-    }
-
-    private func autohidePublisher(delay: TimeInterval) -> AnyPublisher<Bool, Never> {
         $player
             .removeDuplicates()
             .map { player -> AnyPublisher<PlaybackState, Never> in
@@ -79,20 +52,62 @@ public final class VisibilityTracker: ObservableObject {
                 return player.$playbackState.eraseToAnyPublisher()
             }
             .switchToLatest()
-            .map { [trigger] playbackState -> AnyPublisher<Bool, Never> in
-                guard playbackState == .playing else {
-                    return Empty().eraseToAnyPublisher()
-                }
-                return Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: TriggerId.reset)) {
-                    Timer.publish(every: delay, on: .main, in: .common)
-                        .autoconnect()
-                        .first()
-                }
-                .map { _ in true }
-                .eraseToAnyPublisher()
+            .compactMap { [weak self] playbackState in
+                self?.updatePublisher(for: playbackState)
             }
             .switchToLatest()
+            .removeDuplicates()
+            .receiveOnMainThread()
+            .assign(to: &$isUserInterfaceHidden)
+    }
+
+    /// Toggles user interface visibility.
+    public func toggle() {
+        togglePublisher.send(!isUserInterfaceHidden)
+    }
+
+    /// Resets user interface auto hide delay.
+    public func reset() {
+        guard !isUserInterfaceHidden else { return }
+        trigger.activate(for: TriggerId.reset)
+    }
+
+    private func updatePublisher(for playbackState: PlaybackState) -> AnyPublisher<Bool, Never> {
+        switch playbackState {
+        case .playing:
+            return interactivePublisher()
+                .compactMap { [weak self] isHidden -> AnyPublisher<Bool, Never>? in
+                    guard let self else { return nil }
+                    return Just(isHidden).append(autohidePublisher(delay: delay), if: !isHidden)
+                }
+                .switchToLatest()
+                .eraseToAnyPublisher()
+        default:
+            return Publishers.Merge(interactivePublisher(), foregroundPublisher())
+                .eraseToAnyPublisher()
+        }
+    }
+
+    private func interactivePublisher() -> AnyPublisher<Bool, Never> {
+        togglePublisher
+            .prepend(isUserInterfaceHidden)
             .eraseToAnyPublisher()
+    }
+
+    private func foregroundPublisher() -> AnyPublisher<Bool, Never> {
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .map { _ in false }
+            .eraseToAnyPublisher()
+    }
+
+    private func autohidePublisher(delay: TimeInterval) -> AnyPublisher<Bool, Never> {
+        Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: TriggerId.reset)) {
+            Timer.publish(every: delay, on: .main, in: .common)
+                .autoconnect()
+                .first()
+        }
+        .map { _ in true }
+        .eraseToAnyPublisher()
     }
 }
 
@@ -109,6 +124,17 @@ public extension View {
         }
         .onChange(of: player) { newValue in
             visibilityTracker.player = newValue
+        }
+    }
+}
+
+private extension Publisher {
+    func append<P>(_ publisher: P, if condition: Bool) -> AnyPublisher<Output, Failure> where P: Publisher, Failure == P.Failure, Output == P.Output {
+        if condition {
+            return self.append(publisher).eraseToAnyPublisher()
+        }
+        else {
+            return self.eraseToAnyPublisher()
         }
     }
 }

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -129,7 +129,10 @@ public extension View {
 }
 
 private extension Publisher {
-    func append<P>(_ publisher: P, if condition: Bool) -> AnyPublisher<Output, Failure> where P: Publisher, Failure == P.Failure, Output == P.Output {
+    func append<P>(
+        _ publisher: P,
+        if condition: Bool
+    ) -> AnyPublisher<Output, Failure> where P: Publisher, Failure == P.Failure, Output == P.Output {
         if condition {
             return self.append(publisher).eraseToAnyPublisher()
         }

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -95,7 +95,7 @@ public final class VisibilityTracker: ObservableObject {
     }
 
     private func foregroundPublisher() -> AnyPublisher<Bool, Never> {
-        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .map { _ in false }
             .eraseToAnyPublisher()
     }

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -23,8 +23,15 @@ final class VisibilityTrackerTests: TestCase {
         expect(visibilityTracker.isUserInterfaceHidden).to(beTrue())
     }
 
+    func testNoToggleWithoutPlayer() {
+        let visibilityTracker = VisibilityTracker()
+        visibilityTracker.toggle()
+        expect(visibilityTracker.isUserInterfaceHidden).to(beFalse())
+    }
+
     func testToggle() {
         let visibilityTracker = VisibilityTracker()
+        visibilityTracker.player = Player()
         visibilityTracker.toggle()
         expect(visibilityTracker.isUserInterfaceHidden).to(beTrue())
     }
@@ -132,6 +139,29 @@ final class VisibilityTrackerTests: TestCase {
 
         visibilityTracker.player = player2
         expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(400))
+    }
+
+    func testDeallocation() {
+        var visibilityTracker: VisibilityTracker? = VisibilityTracker()
+        weak var weakVisibilityTracker = visibilityTracker
+        autoreleasepool {
+            visibilityTracker = nil
+        }
+        expect(weakVisibilityTracker).to(beNil())
+    }
+
+    func testDeallocationWhilePlaying() {
+        var visibilityTracker: VisibilityTracker? = VisibilityTracker()
+        let player = Player(item: PlayerItem.simple(url: Stream.onDemand.url))
+        player.play()
+        visibilityTracker?.player = player
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        weak var weakVisibilityTracker = visibilityTracker
+        autoreleasepool {
+            visibilityTracker = nil
+        }
+        expect(weakVisibilityTracker).to(beNil())
     }
 }
 #endif

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -65,6 +65,7 @@ A player usually responds to user interaction in a standard way:
 
 - Controls are toggled on or off when the user taps the player area.
 - Controls are automatically hidden after some delay during playback. Auto hide must only occur as long as the user is not actively interacting with the player, though, for example if controls contain a slider or buttons.
+- When not playing controls are automatically toggled on when returning from background, inviting the user to resume playback.
 
 Pillarbox provides `VisibilityTracker` to make implementing this standard behavior as straightforward as possible. This observable object exposes a `isUserInterfaceHidden` read-only property which advises whether a player user interface should be hidden or not.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves the standard user experience provided by `VisibilityTracker` in the following way:

- If the player is not playing controls are automatically displayed again when returning to the foreground. This makes controls discoverable, ensures that the state is clear and invites the user to resume playback.
- If the player is playing control visibility is not altered (for video this requires the corresponding opt-in). In general controls will resume hidden, ensuring that the playback experience is not interrupted, especially when returning from PiP.

# Changes made

- Refactor implementation to have a single reducer for `isUserInterfaceHidden`, which was previously not the case.
- Implement behavior described above.
- Disable toggling when no player has been attached. The visibility remains the one provided at construction time until a player is attached.

No unit tests were written for the new behavior since it relies on application notifications. The behavior must be manually tested on device.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
