### PR TITLE
Fix neverending custom slider interactions

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -373,11 +373,10 @@ private struct TimeBar: View {
         HStack(spacing: 8) {
             routePickerView()
             HStack(spacing: 20) {
-                TimeSlider(player: player, progressTracker: progressTracker)
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { _ in visibilityTracker.reset() }
-                    )
+                TimeSlider(player: player, progressTracker: progressTracker) { isEditing in
+                    guard isEditing else { return }
+                    visibilityTracker.reset()
+                }
                 LiveLabel(player: player, progressTracker: progressTracker)
                 SettingsMenu(player: player)
                     .padding(.vertical, 12)
@@ -420,6 +419,7 @@ private struct TimeSlider: View {
 
     @ObservedObject var player: Player
     @ObservedObject var progressTracker: ProgressTracker
+    let onEditingChanged: (Bool) -> Void
 
     private var formattedElapsedTime: String? {
         guard player.streamType == .onDemand, let time = progressTracker.time, let timeRange = progressTracker.timeRange else {
@@ -445,7 +445,8 @@ private struct TimeSlider: View {
             },
             maximumValueLabel: {
                 label(withText: formattedTotalTime)
-            }
+            },
+            onEditingChanged: onEditingChanged
         )
         .foregroundColor(.white)
         .tint(.white)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -373,10 +373,7 @@ private struct TimeBar: View {
         HStack(spacing: 8) {
             routePickerView()
             HStack(spacing: 20) {
-                TimeSlider(player: player, progressTracker: progressTracker) { isEditing in
-                    guard isEditing else { return }
-                    visibilityTracker.reset()
-                }
+                TimeSlider(player: player, progressTracker: progressTracker)
                 LiveLabel(player: player, progressTracker: progressTracker)
                 SettingsMenu(player: player)
                     .padding(.vertical, 12)
@@ -419,7 +416,6 @@ private struct TimeSlider: View {
 
     @ObservedObject var player: Player
     @ObservedObject var progressTracker: ProgressTracker
-    let onEditingChanged: (Bool) -> Void
 
     private var formattedElapsedTime: String? {
         guard player.streamType == .onDemand, let time = progressTracker.time, let timeRange = progressTracker.timeRange else {
@@ -445,8 +441,7 @@ private struct TimeSlider: View {
             },
             maximumValueLabel: {
                 label(withText: formattedTotalTime)
-            },
-            onEditingChanged: onEditingChanged
+            }
         )
         .foregroundColor(.white)
         .tint(.white)

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
     @StateObject private var bufferTracker = BufferTracker()
+    @GestureState private var gestureValue: DragGesture.Value?
 
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
@@ -59,7 +60,15 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
             }
             .animation(.linear(duration: 0.5), value: bufferTracker.buffer)
-            .gesture(dragGesture(in: geometry))
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .updating($gestureValue) { value, state, _ in
+                        state = value
+                    }
+            )
+            .onChange(of: gestureValue) { value in
+                updateProgress(for: value, in: geometry)
+            }
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .cornerRadius(progressTracker.isInteracting ? 8 : 4)
@@ -67,20 +76,19 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         .bind(bufferTracker, to: progressTracker.player)
     }
 
-    private func dragGesture(in geometry: GeometryProxy) -> some Gesture {
-        DragGesture(minimumDistance: 1)
-            .onChanged { value in
-                if !progressTracker.isInteracting {
-                    progressTracker.isInteracting = true
-                    initialProgress = progressTracker.progress
-                }
-                let delta = (geometry.size.width != 0) ? Float(value.translation.width / geometry.size.width) : 0
-                progressTracker.progress = initialProgress + delta
+    private func updateProgress(for value: DragGesture.Value?, in geometry: GeometryProxy) {
+        if let value {
+            if !progressTracker.isInteracting {
+                progressTracker.isInteracting = true
+                initialProgress = progressTracker.progress
             }
-            .onEnded { _ in
-                initialProgress = 0
-                progressTracker.isInteracting = false
-            }
+            let delta = (geometry.size.width != 0) ? Float(value.translation.width / geometry.size.width) : 0
+            progressTracker.progress = initialProgress + delta
+        }
+        else {
+            initialProgress = 0
+            progressTracker.isInteracting = false
+        }
     }
 }
 

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -10,12 +10,12 @@ import SwiftUI
 #if os(iOS)
 struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
-    @StateObject private var bufferTracker = BufferTracker()
-    @GestureState private var gestureValue: DragGesture.Value?
-
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
+    let onEditingChanged: (Bool) -> Void
 
+    @StateObject private var bufferTracker = BufferTracker()
+    @GestureState private var gestureValue: DragGesture.Value?
     @State private var initialProgress: Float = 0
 
     private var isBusy: Bool {
@@ -35,11 +35,13 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     init(
         progressTracker: ProgressTracker,
         @ViewBuilder minimumValueLabel: @escaping () -> ValueLabel,
-        @ViewBuilder maximumValueLabel: @escaping () -> ValueLabel
+        @ViewBuilder maximumValueLabel: @escaping () -> ValueLabel,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
     ) {
         self.progressTracker = progressTracker
         self.minimumValueLabel = minimumValueLabel
         self.maximumValueLabel = maximumValueLabel
+        self.onEditingChanged = onEditingChanged
     }
 
     @ViewBuilder
@@ -81,6 +83,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             if !progressTracker.isInteracting {
                 progressTracker.isInteracting = true
                 initialProgress = progressTracker.progress
+                onEditingChanged(true)
             }
             let delta = (geometry.size.width != 0) ? Float(value.translation.width / geometry.size.width) : 0
             progressTracker.progress = initialProgress + delta
@@ -88,6 +91,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         else {
             initialProgress = 0
             progressTracker.isInteracting = false
+            onEditingChanged(false)
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes an annoying issue affecting our custom slider. When dragging our custom slider, and since it is close to the home indicator in landscape orientation on an iPhone, we namely might grab the slider and trigger app switching at the same time. In such cases `isInteracting` was never correctly reset, leading to controls never reappearing:

https://github.com/SRGSSR/pillarbox-apple/assets/170201/d3787d97-d8dc-4a78-a58e-9a9728ec28a4

As can be seen in this video a workaround was to seek again, but this was ugly at best.

# Changes made

- Fix the drag gesture so that the `isInteracting` flag is properly reset when the gesture is cancelled. There is namely a [known limitation](https://stackoverflow.com/questions/58807357/detect-draggesture-cancelation-in-swiftui) with the `onEnded` modifier we were using, but fortunately we can use the [`updating` modifier](https://developer.apple.com/documentation/swiftui/gesturestate) instead. This modifier namely takes care of resetting the associated state to its original value when cancelled, which can be used to properly reset the interaction flag.
- Improve our slider implementation to avoid using a drag gesture to reset visibility. This is not needed anymore since we are now pausing playback during seeks anyway, which disables autohide.
- Update slider API to add an `onEditingChanged` parameter so that its API mimics the one of `Slider`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
