### PR TITLE
Use view modifiers where appropriate

### DIFF
--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -121,7 +121,7 @@ struct SettingsView: View {
                 Text("Made with ")
                 Image(systemName: "heart.fill")
                     .foregroundColor(.red)
-                    .pulseEffect()
+                    .symbolPulseEffect()
                 Text(" in Switzerland")
             }
         }

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -7,6 +7,23 @@
 import Analytics
 import SwiftUI
 
+private struct SymbolPulseEffect: ViewModifier {
+    func body(content: Content) -> some View {
+        // TODO: Remove when Xcode 15 has been released
+#if compiler(>=5.9)
+        if #available(iOS 17.0, tvOS 17.0, *) {
+            content
+                .symbolEffect(.pulse)
+        }
+        else {
+            content
+        }
+#else
+        content
+#endif
+    }
+}
+
 extension View {
     /// Prevents touch propagation to views located below the receiver.
     func preventsTouchPropagation() -> some View {
@@ -24,21 +41,8 @@ extension View {
             commandersAct: .init(name: name, type: "content", levels: levels)
         )
     }
-}
 
-extension View {
-    @ViewBuilder
-    func pulseEffect() -> some View {
-        // TODO: Remove when Xcode 15 has been released
-#if compiler(>=5.9)
-        if #available(iOS 17.0, tvOS 17.0, *) {
-            symbolEffect(.pulse)
-        }
-        else {
-            self
-        }
-#else
-        self
-#endif
+    func symbolPulseEffect() -> some View {
+        modifier(SymbolPulseEffect())
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR slightly rewrites modifiers using the `ViewModifier` protocol.

# Changes made

- Update symbol pulse effect modifier and rename it for more expressiveness.
- Update modal modifier implementation.

The `_debugBodyCounter(color:)` modifier was not rewritten to avoid losing body refresh counting.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
