### PR TITLE
Show user interface when playback is paused

### DIFF
--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -75,23 +75,24 @@ public final class VisibilityTracker: ObservableObject {
     private func updatePublisher(for playbackState: PlaybackState) -> AnyPublisher<Bool, Never> {
         switch playbackState {
         case .playing:
-            return interactivePublisher()
+            return togglePublisher
+                .prepend(isUserInterfaceHidden)
                 .compactMap { [weak self] isHidden -> AnyPublisher<Bool, Never>? in
                     guard let self else { return nil }
-                    return Just(isHidden).append(autohidePublisher(delay: delay), if: !isHidden)
+                    return Just(isHidden)
+                        .append(autoHidePublisher(delay: delay), if: !isHidden)
                 }
                 .switchToLatest()
                 .eraseToAnyPublisher()
+        case .paused:
+            return Publishers.Merge(togglePublisher, foregroundPublisher())
+                .prepend(false)
+                .eraseToAnyPublisher()
         default:
-            return Publishers.Merge(interactivePublisher(), foregroundPublisher())
+            return Publishers.Merge(togglePublisher, foregroundPublisher())
+                .prepend(isUserInterfaceHidden)
                 .eraseToAnyPublisher()
         }
-    }
-
-    private func interactivePublisher() -> AnyPublisher<Bool, Never> {
-        togglePublisher
-            .prepend(isUserInterfaceHidden)
-            .eraseToAnyPublisher()
     }
 
     private func foregroundPublisher() -> AnyPublisher<Bool, Never> {
@@ -100,7 +101,7 @@ public final class VisibilityTracker: ObservableObject {
             .eraseToAnyPublisher()
     }
 
-    private func autohidePublisher(delay: TimeInterval) -> AnyPublisher<Bool, Never> {
+    private func autoHidePublisher(delay: TimeInterval) -> AnyPublisher<Bool, Never> {
         Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: TriggerId.reset)) {
             Timer.publish(every: delay, on: .main, in: .common)
                 .autoconnect()

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -13,7 +13,7 @@ import UIKit
 /// An observable object tracking user interface visibility.
 ///
 /// The tracker automatically turns off visibility after a delay while playing content. It also automatically turns
-/// on visibility when the application returns to the foreground, provided the player is not currently playing.
+/// on visibility when playback is paused externally (e.g. by another app or through the control center).
 @available(tvOS, unavailable)
 public final class VisibilityTracker: ObservableObject {
     private enum TriggerId {

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -36,6 +36,23 @@ final class VisibilityTrackerTests: TestCase {
         expect(visibilityTracker.isUserInterfaceHidden).to(beTrue())
     }
 
+    func testInitiallyVisibleIfPaused() {
+        let visibilityTracker = VisibilityTracker(delay: 0.5, isUserInterfaceHidden: true)
+        visibilityTracker.player = Player(item: PlayerItem.simple(url: Stream.onDemand.url))
+        expect(visibilityTracker.isUserInterfaceHidden).toEventually(beFalse())
+    }
+
+    func testVisibleWhenPaused() {
+        let visibilityTracker = VisibilityTracker(delay: 0.5, isUserInterfaceHidden: true)
+        let player = Player(item: PlayerItem.simple(url: Stream.onDemand.url))
+        visibilityTracker.player = player
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+        expect(visibilityTracker.isUserInterfaceHidden).to(beTrue())
+        player.pause()
+        expect(visibilityTracker.isUserInterfaceHidden).toEventually(beFalse())
+    }
+
     func testNoAutoHideWhileIdle() {
         let visibilityTracker = VisibilityTracker(delay: 0.5)
         visibilityTracker.player = Player()

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -65,7 +65,7 @@ A player usually responds to user interaction in a standard way:
 
 - Controls are toggled on or off when the user taps the player area.
 - Controls are automatically hidden after some delay during playback. Auto hide must only occur as long as the user is not actively interacting with the player, though, for example if controls contain a slider or buttons.
-- When not playing controls are automatically toggled on when returning from background, inviting the user to resume playback.
+- Controls are shown when playback is paused externally (e.g. by another app or through the control center), inviting the user to resume playback.
 
 Pillarbox provides `VisibilityTracker` to make implementing this standard behavior as straightforward as possible. This observable object exposes a `isUserInterfaceHidden` read-only property which advises whether a player user interface should be hidden or not.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves #526 by also showing the user interface when playback is paused. This improves the default user experience in the following cases:

- On an iPad used in split screen, playback is paused by another app which steals the main audio session.
- Playback is paused from the control center.

The work done is #526 is still relevant since the user interface can still be hidden when the player is paused. This therefore covers the following use case:

- Playback is paused.
- The user interface is hidden.
- The application is sent to the background.
- The application is resumed.

This behavior is applied only to the paused state so that transitions between items, e.g., do not show the user interface. This use case is already covered by a test returning the player to idle.

# Changes made

- Implement the above behavior.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
