### PR TITLE
Update correctly subtitle selection

### DIFF
--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -7,6 +7,7 @@
 import AVFoundation
 import Combine
 import Core
+import MediaAccessibility
 
 extension AVPlayerItem {
     func itemStatePublisher() -> AnyPublisher<ItemState, Never> {
@@ -94,11 +95,16 @@ extension AVPlayerItem {
     }
 
     func mediaSelectionContextPublisher() -> AnyPublisher<MediaSelectionContext, Never> {
-        Publishers.CombineLatest(
+        Publishers.CombineLatest3(
             asset.mediaSelectionGroupsPublisher(),
-            mediaSelectionPublisher()
+            mediaSelectionPublisher(),
+            NotificationCenter.default.publisher(for: kMACaptionAppearanceSettingsChangedNotification as Notification.Name)
+                .map { _ in }
+                .prepend(())
         )
-        .map { MediaSelectionContext(groups: $0, selection: $1) }
+        .map { groups, selection, _ in
+            MediaSelectionContext(groups: groups, selection: selection)
+        }
         .prepend(.empty)
         .eraseToAnyPublisher()
     }

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -250,6 +250,17 @@ final class MediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toAlways(equal(.off), until: .seconds(2))
         expect(player.currentMediaOption(for: .legible)).to(equal(.off))
     }
+
+    func testLegibleOptionSwitchFromOffToAutomatic() {
+        setupAccessibilityDisplayType(.forcedOnly)
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+        player.select(mediaOption: .automatic, for: .legible)
+
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
+        expect(player.currentMediaOption(for: .legible)).to(equal(.off))
+    }
 }
 
 private extension Player {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to fix the subtitle selection when toggling from `Off` to `Automatic`.

# Changes made

- The notification `kMACaptionAppearanceSettingsChangedNotification` is observed to update the `mediaSelectionContextPublisher`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
