### PR TITLE
Enhancing the media selection options

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCB9DDD29E024E900961B69 /* BlurredView.swift */; };
 		6FDB51CB2A4042B2001F430F /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB51CA2A4042B2001F430F /* Router.swift */; };
 		6FE324B329E4657D007501CF /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE324B229E4657D007501CF /* View.swift */; };
+		6FED426B2A96F4D3004D7724 /* TransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FED426A2A96F4D3004D7724 /* TransitionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -144,6 +145,7 @@
 		6FCB9DDD29E024E900961B69 /* BlurredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredView.swift; sourceTree = "<group>"; };
 		6FDB51CA2A4042B2001F430F /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		6FE324B229E4657D007501CF /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		6FED426A2A96F4D3004D7724 /* TransitionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -298,13 +300,14 @@
 			children = (
 				6F59E85629CF31E10093E6FB /* Playlist */,
 				6F59E85B29CF31E10093E6FB /* Stories */,
-				6F59E85F29CF31E10093E6FB /* Wrapped */,
 				6FCB9DDD29E024E900961B69 /* BlurredView.swift */,
 				6F59E86229CF31E10093E6FB /* LinkView.swift */,
 				6F59E85529CF31E10093E6FB /* MultiView.swift */,
-				6F59E85A29CF31E10093E6FB /* ShowcaseView.swift */,
 				0E6B995B29D43E4200D0276D /* OptInView.swift */,
+				6F59E85A29CF31E10093E6FB /* ShowcaseView.swift */,
+				6FED426A2A96F4D3004D7724 /* TransitionView.swift */,
 				6F59E85929CF31E10093E6FB /* TwinsView.swift */,
+				6F59E85F29CF31E10093E6FB /* Wrapped */,
 			);
 			path = Showcase;
 			sourceTree = "<group>";
@@ -551,6 +554,7 @@
 				6F59E87A29CF31E10093E6FB /* SearchViewModel.swift in Sources */,
 				6F59E88829CF31E20093E6FB /* UserDefaults.swift in Sources */,
 				0EA8A9AE2A6AF0AF0077E3E4 /* YouTubeMetadata.swift in Sources */,
+				6FED426B2A96F4D3004D7724 /* TransitionView.swift in Sources */,
 				6F59E88D29CF31E20093E6FB /* ShowcaseView.swift in Sources */,
 				6F59E88929CF31E20093E6FB /* MultiView.swift in Sources */,
 				6F59E89F29CF31E20093E6FB /* PlayerLayout.swift in Sources */,

--- a/Demo/Sources/Examples/ExamplesViewModel.swift
+++ b/Demo/Sources/Examples/ExamplesViewModel.swift
@@ -46,7 +46,9 @@ final class ExamplesViewModel: ObservableObject {
         URLTemplate.appleAdvanced_16_9_fMP4_HLS,
         URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS,
         URLTemplate.appleWWDCKeynote2023,
-        URLTemplate.appleDolbyAtmos
+        URLTemplate.appleDolbyAtmos,
+        URLTemplate.appleTvMorningShowSeason1Trailer,
+        URLTemplate.appleTvMorningShowSeason2Trailer
     ])
 
     let thirdPartyMedias = Template.medias(from: [

--- a/Demo/Sources/Model/Playlist.swift
+++ b/Demo/Sources/Model/Playlist.swift
@@ -155,6 +155,11 @@ enum URNTemplates {
         )
     ]
 
+    static let videosWithMediaSelections: [Template] = [
+        URLTemplate.appleTvMorningShowSeason1Trailer,
+        URLTemplate.appleTvMorningShowSeason2Trailer
+    ]
+
     static let videosWithOneError: [Template] = [
         URLTemplate.shortOnDemandVideoHLS,
         URNTemplate.unknown,

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -89,6 +89,16 @@ enum URLTemplate {
         title: "Apple Dolby Atmos",
         type: .url("https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8")
     )
+    static let appleTvMorningShowSeason1Trailer = Template(
+        title: "The Morning Show - My Way: Season 1",
+        // swiftlint:disable:next line_length
+        type: .url("https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1522121579&isExternal=true&brandId=tvs.sbd.4000&id=518077009&l=en-GB&aec=UHD")
+    )
+    static let appleTvMorningShowSeason2Trailer = Template(
+        title: "The Morning Show - Change: Season 2",
+        // swiftlint:disable:next line_length
+        type: .url("https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD")
+    )
     static let uhdVideoHLS = Template(
         title: "Brain Farm Skate Phantom Flex",
         description: "4K video",

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -77,18 +77,6 @@ private struct MainView: View {
             TapGesture()
                 .onEnded { _ in visibilityTracker.reset() }
         )
-        .overlay(alignment: .top) {
-            VStack {
-                Text("Audible, selected: \(player.selectedMediaOption(for: .audible).displayName)")
-                    .foregroundStyle(.green)
-                Text("Audible, current: \(player.currentMediaOption(for: .audible).displayName)")
-                    .foregroundStyle(.green)
-                Text("Legible, selected: \(player.selectedMediaOption(for: .legible).displayName)")
-                    .foregroundStyle(.red)
-                Text("Legible, current: \(player.currentMediaOption(for: .legible).displayName)")
-                    .foregroundStyle(.red)
-            }
-        }
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -77,6 +77,18 @@ private struct MainView: View {
             TapGesture()
                 .onEnded { _ in visibilityTracker.reset() }
         )
+        .overlay(alignment: .top) {
+            VStack {
+                Text("Audible, selected: \(player.selectedMediaOption(for: .audible).displayName)")
+                    .foregroundStyle(.green)
+                Text("Audible, current: \(player.currentMediaOption(for: .audible).displayName)")
+                    .foregroundStyle(.green)
+                Text("Legible, selected: \(player.selectedMediaOption(for: .legible).displayName)")
+                    .foregroundStyle(.red)
+                Text("Legible, current: \(player.currentMediaOption(for: .legible).displayName)")
+                    .foregroundStyle(.red)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -50,6 +50,8 @@ struct RoutedNavigationStack<Root>: View where Root: View {
             LinkView(media: media)
         case let .wrapped(media: media):
             WrappedView(media: media)
+        case let .transition(media: media):
+            TransitionView(media: media)
         case .stories:
             StoriesView()
         case let .playlist(templates: templates):

--- a/Demo/Sources/Router/RouterDestination.swift
+++ b/Demo/Sources/Router/RouterDestination.swift
@@ -21,6 +21,7 @@ enum RouterDestination: Identifiable, Hashable {
     case multi(media1: Media, media2: Media)
     case link(media: Media)
     case wrapped(media: Media)
+    case transition(media: Media)
 
     case stories
     case playlist(templates: [Template])
@@ -49,6 +50,8 @@ enum RouterDestination: Identifiable, Hashable {
             return "link_\(media.id)"
         case let .wrapped(media: media):
             return "wrapped_\(media.id)"
+        case let .transition(media: media):
+            return "transition_\(media.id)"
         case .stories:
             return "stories"
         case .playlist:

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -32,6 +32,8 @@ final class PlaylistViewModel: ObservableObject {
         URLTemplate.appleAdvanced_16_9_HEVC_h264_HLS,
         URLTemplate.appleWWDCKeynote2023,
         URLTemplate.appleDolbyAtmos,
+        URLTemplate.appleTvMorningShowSeason1Trailer,
+        URLTemplate.appleTvMorningShowSeason2Trailer,
         URLTemplate.uhdVideoHLS,
         URNTemplate.expired,
         URNTemplate.unknown

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -112,6 +112,11 @@ struct ShowcaseView: View {
                 subtitle: "A view whose player can be removed",
                 destination: .wrapped(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS))
             )
+            cell(
+                title: "Transition",
+                subtitle: "A transition between two layouts sharing the same player",
+                destination: .transition(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS))
+            )
         }
     }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -54,6 +54,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func playlistsSection() -> some View {
+        // swiftlint:disable:next closure_body_length
         Section("Playlists") {
             cell(
                 title: "Video URLs",
@@ -66,6 +67,10 @@ struct ShowcaseView: View {
             cell(
                 title: "Long video URNs",
                 destination: .playlist(templates: URNTemplates.longVideos)
+            )
+            cell(
+                title: "Videos with media selections",
+                destination: .playlist(templates: URNTemplates.videosWithMediaSelections)
             )
             cell(
                 title: "Audios",

--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -13,12 +13,10 @@ private struct FullScreenView: View {
     var body: some View {
         PlaybackView(player: player)
             .onAppear {
-                player.setMediaSelection(preferredLanguages: [], for: .legible)
-                player.isMuted = false
+                player.disableSilentPlayback()
             }
             .onDisappear {
-                player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-                player.isMuted = true
+                player.enableSilentPlayback(withLanguage: "fr")
             }
     }
 }
@@ -42,10 +40,21 @@ struct TransitionView: View {
     }
 
     private func play() {
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        player.isMuted = true
+        player.enableSilentPlayback(withLanguage: "fr")
         player.append(media.playerItem())
         player.play()
+    }
+}
+
+private extension Player {
+    func enableSilentPlayback(withLanguage language: String) {
+        setMediaSelection(preferredLanguages: [language], for: .legible)
+        isMuted = true
+    }
+
+    func disableSilentPlayback() {
+        setMediaSelection(preferredLanguages: [], for: .legible)
+        isMuted = false
     }
 }
 

--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -13,11 +13,11 @@ private struct FullScreenView: View {
     var body: some View {
         PlaybackView(player: player)
             .onAppear {
-                player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+                player.setMediaSelection(preferredLanguages: [], for: .legible)
                 player.isMuted = false
             }
             .onDisappear {
-                player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+                player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
                 player.isMuted = true
             }
     }
@@ -42,7 +42,7 @@ struct TransitionView: View {
     }
 
     private func play() {
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         player.isMuted = true
         player.append(media.playerItem())
         player.play()

--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Player
+import SwiftUI
+
+private struct FullScreenView: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        PlaybackView(player: player)
+            .onAppear {
+                player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+                player.isMuted = false
+            }
+            .onDisappear {
+                player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+                player.isMuted = true
+            }
+    }
+}
+
+struct TransitionView: View {
+    let media: Media
+
+    @StateObject private var player = Player(configuration: .externalPlaybackDisabled)
+    @State private var isPresented = false
+
+    var body: some View {
+        VideoView(player: player)
+            .accessibilityAddTraits(.isButton)
+            .onTapGesture {
+                isPresented.toggle()
+            }
+            .onAppear(perform: play)
+            .sheet(isPresented: $isPresented) {
+                FullScreenView(player: player)
+            }
+    }
+
+    private func play() {
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.isMuted = true
+        player.append(media.playerItem())
+        player.play()
+    }
+}
+
+struct TransitionView_Previews: PreviewProvider {
+    static var previews: some View {
+        TransitionView(media: Media(from: URLTemplate.onDemandVideoLocalHLS))
+    }
+}

--- a/Sources/Player/Extensions/AVMediaSelectionOption.swift
+++ b/Sources/Player/Extensions/AVMediaSelectionOption.swift
@@ -8,6 +8,6 @@ import AVFoundation
 
 extension AVMediaSelectionOption {
     var languageCode: String? {
-        locale?.language.languageCode?.identifier
+        locale?.identifier
     }
 }

--- a/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
+++ b/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+// TODO: Remove duplicates
+
+extension AVPlayerMediaSelectionCriteria {
+    func adding(preferredLanguages languages: [String]) -> Self {
+        let preferredLanguages = self.preferredLanguages ?? []
+        return Self(
+            preferredLanguages: languages + preferredLanguages,
+            preferredMediaCharacteristics: self.preferredMediaCharacteristics
+        )
+    }
+}

--- a/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
+++ b/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
@@ -5,14 +5,13 @@
 //
 
 import AVFoundation
-
-// TODO: Remove duplicates
+import Core
 
 extension AVPlayerMediaSelectionCriteria {
     func adding(preferredLanguages languages: [String]) -> Self {
         let existingPreferredLanguages = preferredLanguages ?? []
         return Self(
-            preferredLanguages: languages + existingPreferredLanguages,
+            preferredLanguages: (languages + existingPreferredLanguages).removeDuplicates(),
             preferredMediaCharacteristics: preferredMediaCharacteristics
         )
     }

--- a/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
+++ b/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
@@ -10,10 +10,10 @@ import AVFoundation
 
 extension AVPlayerMediaSelectionCriteria {
     func adding(preferredLanguages languages: [String]) -> Self {
-        let preferredLanguages = self.preferredLanguages ?? []
+        let existingPreferredLanguages = preferredLanguages ?? []
         return Self(
-            preferredLanguages: languages + preferredLanguages,
-            preferredMediaCharacteristics: self.preferredMediaCharacteristics
+            preferredLanguages: languages + existingPreferredLanguages,
+            preferredMediaCharacteristics: preferredMediaCharacteristics
         )
     }
 }

--- a/Sources/Player/Interfaces/MediaSelector.swift
+++ b/Sources/Player/Interfaces/MediaSelector.swift
@@ -18,10 +18,30 @@ protocol MediaSelector {
     func mediaSelectionOptions() -> [MediaSelectionOption]
 
     /// The selected media option matching the provided selection.
-    func selectedMediaOption(in selection: AVMediaSelection, of player: AVPlayer) -> MediaSelectionOption
+    ///
+    /// - Parameters:
+    ///   - selection: The current selection information.
+    ///   - selectionCriteria: The current selection criteria.
+    /// - Returns: The selected media option.
+    ///
+    /// Use available information to refine the choice of the selected media option to return.
+    func selectedMediaOption(in selection: AVMediaSelection, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption
 
     /// Selects the provided option, applying it on the specified item.
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, of player: AVPlayer)
+    ///
+    /// - Parameters:
+    ///   - mediaOption: The media option to select.
+    ///   - item: The item on which the option must be selected.
+    ///   - selectionCriteria: The current selection criteria.
+    /// - Returns: Updated media selection to apply on return. Return `nil` if no update is required.
+    ///
+    /// If selection should alter media selection criteria your implementation should update the received value
+    /// and return the corresponding result.
+    func select(
+        mediaOption: MediaSelectionOption,
+        on item: AVPlayerItem,
+        with selectionCriteria: AVPlayerMediaSelectionCriteria?
+    ) -> AVPlayerMediaSelectionCriteria?
 }
 
 extension MediaSelector {

--- a/Sources/Player/Interfaces/MediaSelector.swift
+++ b/Sources/Player/Interfaces/MediaSelector.swift
@@ -17,28 +17,15 @@ protocol MediaSelector {
     /// The available options.
     func mediaSelectionOptions() -> [MediaSelectionOption]
 
-    /// The selected persisted media option matching the provided selection.
-    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption
+    /// The selected media option matching the provided selection.
+    func selectedMediaOption(in selection: AVMediaSelection, of player: AVPlayer) -> MediaSelectionOption
 
     /// Selects the provided option, applying it on the specified item.
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer)
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, of player: AVPlayer)
 }
 
 extension MediaSelector {
     func supports(mediaSelectionOption: MediaSelectionOption) -> Bool {
         mediaSelectionOptions().contains(mediaSelectionOption)
-    }
-
-    func selectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
-        if let option = selection.selectedMediaOption(in: group) {
-            return .on(option)
-        }
-        else {
-            return .off
-        }
-    }
-
-    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
-        selectedMediaOption(in: selection)
     }
 }

--- a/Sources/Player/Interfaces/MediaSelector.swift
+++ b/Sources/Player/Interfaces/MediaSelector.swift
@@ -17,15 +17,28 @@ protocol MediaSelector {
     /// The available options.
     func mediaSelectionOptions() -> [MediaSelectionOption]
 
-    /// The available media option matching the provided selection.
-    func selectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption
+    /// The selected persisted media option matching the provided selection.
+    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption
 
     /// Selects the provided option, applying it on the specified item.
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem)
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer)
 }
 
 extension MediaSelector {
     func supports(mediaSelectionOption: MediaSelectionOption) -> Bool {
         mediaSelectionOptions().contains(mediaSelectionOption)
+    }
+
+    func selectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
+        if let option = selection.selectedMediaOption(in: group) {
+            return .on(option)
+        }
+        else {
+            return .off
+        }
+    }
+
+    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
+        selectedMediaOption(in: selection)
     }
 }

--- a/Sources/Player/MediaSelection/AudibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/AudibleMediaSelector.swift
@@ -5,6 +5,7 @@
 //
 
 import AVFoundation
+import MediaAccessibility
 
 /// The default selector for audible options.
 struct AudibleMediaSelector: MediaSelector {
@@ -28,7 +29,10 @@ struct AudibleMediaSelector: MediaSelector {
                     )
                 }
                 else {
-                    let selectionCriteria = AVPlayerMediaSelectionCriteria(preferredLanguages: [languageCode], preferredMediaCharacteristics: nil)
+                    let selectionCriteria = AVPlayerMediaSelectionCriteria(
+                        preferredLanguages: [languageCode],
+                        preferredMediaCharacteristics: MAAudibleMediaCopyPreferredCharacteristics().takeRetainedValue() as? [AVMediaCharacteristic]
+                    )
                     player.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: .audible)
                 }
             }

--- a/Sources/Player/MediaSelection/AudibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/AudibleMediaSelector.swift
@@ -15,18 +15,23 @@ struct AudibleMediaSelector: MediaSelector {
         return options.count > 1 ? options.map { .on($0) } : []
     }
 
-    func selectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
-        if let option = selection.selectedMediaOption(in: group) {
-            return .on(option)
-        }
-        else {
-            return .off
-        }
-    }
+    // Question: Can this be moved for all characteristics to Player+MediaOption? What about persisted vs non-persisted then?
 
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem) {
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer) {
         switch mediaOption {
         case let .on(option):
+            if let languageCode = option.languageCode {
+                if let selectionCriteria = player.mediaSelectionCriteria(forMediaCharacteristic: .audible) {
+                    player.setMediaSelectionCriteria(
+                        selectionCriteria.adding(preferredLanguages: [languageCode]),
+                        forMediaCharacteristic: .audible
+                    )
+                }
+                else {
+                    let selectionCriteria = AVPlayerMediaSelectionCriteria(preferredLanguages: [languageCode], preferredMediaCharacteristics: nil)
+                    player.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: .audible)
+                }
+            }
             item.select(option, in: group)
         default:
             break

--- a/Sources/Player/MediaSelection/AudibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/AudibleMediaSelector.swift
@@ -16,12 +16,20 @@ struct AudibleMediaSelector: MediaSelector {
         return options.count > 1 ? options.map { .on($0) } : []
     }
 
-    // Question: Can this be moved for all characteristics to Player+MediaOption? What about persisted vs non-persisted then?
+    func selectedMediaOption(in selection: AVMediaSelection, of player: AVPlayer) -> MediaSelectionOption {
+        if let option = selection.selectedMediaOption(in: group) {
+            return .on(option)
+        }
+        else {
+            return .off
+        }
+    }
 
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer) {
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, of player: AVPlayer) {
         switch mediaOption {
         case let .on(option):
             if let languageCode = option.languageCode {
+                // TODO: In a private method
                 if let selectionCriteria = player.mediaSelectionCriteria(forMediaCharacteristic: .audible) {
                     player.setMediaSelectionCriteria(
                         selectionCriteria.adding(preferredLanguages: [languageCode]),

--- a/Sources/Player/MediaSelection/LegibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/LegibleMediaSelector.swift
@@ -21,7 +21,7 @@ struct LegibleMediaSelector: MediaSelector {
         return options
     }
 
-    func selectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
+    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
         switch MACaptionAppearanceGetDisplayType(.user) {
         case .alwaysOn:
             if let option = selection.selectedMediaOption(in: group) {
@@ -37,7 +37,7 @@ struct LegibleMediaSelector: MediaSelector {
         }
     }
 
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem) {
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer) {
         switch mediaOption {
         case .automatic:
             MACaptionAppearanceSetDisplayType(.user, .automatic)

--- a/Sources/Player/MediaSelection/LegibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/LegibleMediaSelector.swift
@@ -21,22 +21,9 @@ struct LegibleMediaSelector: MediaSelector {
         return options
     }
 
-    func selectedMediaOption(in selection: AVMediaSelection, of player: AVPlayer) -> MediaSelectionOption {
-        // TODO: Factor code
-        if player.mediaSelectionCriteria(forMediaCharacteristic: .legible) == nil {
-            switch MACaptionAppearanceGetDisplayType(.user) {
-            case .alwaysOn:
-                if let option = selection.selectedMediaOption(in: group) {
-                    return .on(option)
-                }
-                else {
-                    return .off
-                }
-            case .automatic:
-                return .automatic
-            default:
-                return .off
-            }
+    func selectedMediaOption(in selection: AVMediaSelection, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption {
+        if selectionCriteria == nil {
+            return persistedMediaOption(in: selection)
         }
         else if let option = selection.selectedMediaOption(in: group) {
             return .on(option)
@@ -46,7 +33,27 @@ struct LegibleMediaSelector: MediaSelector {
         }
     }
 
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, of player: AVPlayer) {
+    private func persistedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
+        switch MACaptionAppearanceGetDisplayType(.user) {
+        case .alwaysOn:
+            if let option = selection.selectedMediaOption(in: group) {
+                return .on(option)
+            }
+            else {
+                return .off
+            }
+        case .automatic:
+            return .automatic
+        default:
+            return .off
+        }
+    }
+
+    func select(
+        mediaOption: MediaSelectionOption,
+        on item: AVPlayerItem,
+        with selectionCriteria: AVPlayerMediaSelectionCriteria?
+    ) -> AVPlayerMediaSelectionCriteria? {
         switch mediaOption {
         case .automatic:
             MACaptionAppearanceSetDisplayType(.user, .automatic)
@@ -61,6 +68,7 @@ struct LegibleMediaSelector: MediaSelector {
             }
             item.select(option, in: group)
         }
+        return nil
     }
 
     /// Returns the preferred captioning options from a list of options.

--- a/Sources/Player/MediaSelection/LegibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/LegibleMediaSelector.swift
@@ -21,23 +21,32 @@ struct LegibleMediaSelector: MediaSelector {
         return options
     }
 
-    func persistedSelectedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
-        switch MACaptionAppearanceGetDisplayType(.user) {
-        case .alwaysOn:
-            if let option = selection.selectedMediaOption(in: group) {
-                return .on(option)
-            }
-            else {
+    func selectedMediaOption(in selection: AVMediaSelection, of player: AVPlayer) -> MediaSelectionOption {
+        // TODO: Factor code
+        if player.mediaSelectionCriteria(forMediaCharacteristic: .legible) == nil {
+            switch MACaptionAppearanceGetDisplayType(.user) {
+            case .alwaysOn:
+                if let option = selection.selectedMediaOption(in: group) {
+                    return .on(option)
+                }
+                else {
+                    return .off
+                }
+            case .automatic:
+                return .automatic
+            default:
                 return .off
             }
-        case .automatic:
-            return .automatic
-        default:
+        }
+        else if let option = selection.selectedMediaOption(in: group) {
+            return .on(option)
+        }
+        else {
             return .off
         }
     }
 
-    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, in player: AVPlayer) {
+    func select(mediaOption: MediaSelectionOption, on item: AVPlayerItem, of player: AVPlayer) {
         switch mediaOption {
         case .automatic:
             MACaptionAppearanceSetDisplayType(.user, .automatic)

--- a/Sources/Player/MediaSelection/MediaSelectionContext.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionContext.swift
@@ -5,7 +5,6 @@
 //
 
 import AVFoundation
-import MediaAccessibility
 
 struct MediaSelectionContext {
     static var empty: Self {

--- a/Sources/Player/MediaSelection/MediaSelectionContext.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionContext.swift
@@ -31,4 +31,9 @@ struct MediaSelectionContext {
         guard let selection, let group = groups[characteristic] else { return nil }
         return selection.selectedMediaOption(in: group)
     }
+
+    func reset(for characteristic: AVMediaCharacteristic, in item: AVPlayerItem) {
+        guard let group = groups[characteristic] else { return }
+        item.selectMediaOptionAutomatically(in: group)
+    }
 }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -75,9 +75,8 @@ public extension Player {
             return
         }
         let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic)
-        if let updatedSelectionCriteria = selector.select(mediaOption: mediaOption, on: item, with: selectionCriteria) {
-            queuePlayer.setMediaSelectionCriteria(updatedSelectionCriteria, forMediaCharacteristic: characteristic)
-        }
+        let updatedSelectionCriteria = selector.select(mediaOption: mediaOption, on: item, with: selectionCriteria)
+        queuePlayer.setMediaSelectionCriteria(updatedSelectionCriteria, forMediaCharacteristic: characteristic)
     }
 
     /// A binding to read and write the current media selection for a characteristic.

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -51,12 +51,11 @@ public extension Player {
     /// - Parameter characteristic: The characteristic.
     /// - Returns: The selected option.
     ///
-    /// You can use `mediaCharacteristics` to retrieve available characteristics.
+    /// You can use `mediaSelectionCharacteristics` to retrieve available characteristics.
     func selectedMediaOption(for characteristic: AVMediaCharacteristic) -> MediaSelectionOption {
         guard let selection = mediaSelectionContext.selection, let selector = mediaSelector(for: characteristic) else {
             return .off
         }
-
         let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic)
         let option = selector.selectedMediaOption(in: selection, with: selectionCriteria)
         return selector.supports(mediaSelectionOption: option) ? option : .off
@@ -68,8 +67,8 @@ public extension Player {
     ///   - mediaOption: The option to select.
     ///   - characteristic: The characteristic.
     ///
-    /// You can use `mediaCharacteristics` to retrieve available characteristics. This method does nothing if attempting
-    /// to set an option that is not supported.
+    /// You can use `mediaSelectionCharacteristics` to retrieve available characteristics. This method does nothing when
+    /// attempting to set an option that is not supported.
     func select(mediaOption: MediaSelectionOption, for characteristic: AVMediaCharacteristic) {
         guard let item = queuePlayer.currentItem, let selector = mediaSelector(for: characteristic),
               selector.supports(mediaSelectionOption: mediaOption) else {
@@ -96,11 +95,11 @@ public extension Player {
     /// The current media option for a characteristic.
     ///
     /// - Parameter characteristic: The characteristic.
-    /// - Returns: The current option or `nil` if none.
+    /// - Returns: The current option.
     ///
     /// Unlike `selectedMediaOption(for:)` this method provides the currently applied option. This method can
     /// be useful if you need to access the actual selection made by `select(mediaOption:for:)` for `.automatic`
-    /// and `.off` options. Forced options might be returned where applicable.
+    /// and `.off` options (forced options might be returned where applicable).
     func currentMediaOption(for characteristic: AVMediaCharacteristic) -> MediaSelectionOption {
         guard let option = mediaSelectionContext.selectedOption(for: characteristic) else { return .off }
         return .on(option)
@@ -112,15 +111,15 @@ public extension Player {
     ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are 
     ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T 
     ///     language codes.
-    ///   - characteristic: The media characteristic for which the selection criteria are to be applied.
-    ///     Supported values include `.audible`, `.legible`, and `.visual`.
+    ///   - characteristic: The media characteristic for which the selection criteria are to be applied. Supported values
+    ///     include `.audible`, `.legible`, and `.visual`.
     ///
-    /// Criteria will be applied to an `AVPlayerItem` instance when is ready to play.
+    /// This method can be used to override the default media option selection for some characteristic, e.g. to start
+    /// playback with a predefined language for audio and / or subtitles.
     func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
         if let item = queuePlayer.currentItem {
             mediaSelectionContext.reset(for: characteristic, in: item)
         }
-
         if !languages.isEmpty {
             let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
                 preferredLanguages: Self.preferredLanguages(for: characteristic),

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -128,7 +128,7 @@ public extension Player {
 
         if !languages.isEmpty {
             let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
-                preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
+                preferredLanguages: Self.preferredLanguages(for: characteristic),
                 preferredMediaCharacteristics: nil
             )
             queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -92,15 +92,15 @@ public extension Player {
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied. 
     ///   Supported values include .audible, .legible, and .visual.
     func setMediaSelectionCriteria(preferredLanguages: [String], for characteristic: AVMediaCharacteristic) {
-        if let group = mediaSelectionContext.group(for: characteristic), group.options.contains(where: { option in
-                guard let code = option.languageCode else { return false }
-                return preferredLanguages.contains(code)
-        }) {
+        if let group = mediaSelectionContext.group(for: characteristic) {
             queuePlayer.currentItem?.selectMediaOptionAutomatically(in: group)
         }
-
-        let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages, preferredMediaCharacteristics: nil)
-        queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
+        if preferredLanguages.isEmpty {
+            queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
+        } else {
+            let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages, preferredMediaCharacteristics: nil)
+            queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
+        }
     }
 
     private func mediaSelector(for characteristic: AVMediaCharacteristic) -> MediaSelector? {

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -5,6 +5,7 @@
 //
 
 import AVFoundation
+import MediaAccessibility
 import SwiftUI
 
 public extension Player {
@@ -98,7 +99,8 @@ public extension Player {
         if preferredLanguages.isEmpty {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
         } else {
-            let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages, preferredMediaCharacteristics: nil)
+            let languages = MACaptionAppearanceCopySelectedLanguages(.user).takeUnretainedValue() as? [String] ?? []
+            let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages + languages, preferredMediaCharacteristics: nil)
             queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
         }
     }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -81,6 +81,7 @@ public extension Player {
               selector.supports(mediaSelectionOption: mediaOption) else {
             return
         }
+        // TODO: Likely clear for legible options but append for audible options
         queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
         selector.select(mediaOption: mediaOption, on: item, in: queuePlayer)
     }
@@ -110,8 +111,8 @@ public extension Player {
         return .on(option)
     }
 
-    /// Applies automatic selection criteria for media that has the specified media characteristic.
-    /// 
+    /// Sets media selection preferred languages for the specified media characteristic.
+    ///
     /// - Parameters:
     ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are 
     ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T language
@@ -121,21 +122,31 @@ public extension Player {
     ///
     /// Criteria will be applied to an `AVPlayerItem` instance when is ready to play. They are cleared when a selection
     /// is made using `select(mediaOption:for`).
-    func setMediaSelectionCriteria(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
+    func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
         if let item = queuePlayer.currentItem {
             mediaSelectionContext.reset(for: characteristic, in: item)
         }
 
         if !languages.isEmpty {
-            let criteria = AVPlayerMediaSelectionCriteria(
+            let selectionCriteria = AVPlayerMediaSelectionCriteria(
                 preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
                 preferredMediaCharacteristics: nil
             )
-            queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
+            queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
         }
         else {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
         }
+    }
+    
+    /// Returns media selection preferred languages for the specified media characteristic.
+    ///
+    /// - Parameter characteristic: The characteristic.
+    func mediaSelectionPreferredLanguages(for characteristic: AVMediaCharacteristic) -> [String] {
+        guard let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) else {
+            return []
+        }
+        return selectionCriteria.preferredLanguages ?? []
     }
 
     private func mediaSelector(for characteristic: AVMediaCharacteristic) -> MediaSelector? {

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -60,7 +60,8 @@ public extension Player {
             return .off
         }
 
-        let option = selector.selectedMediaOption(in: selection, of: queuePlayer)
+        let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic)
+        let option = selector.selectedMediaOption(in: selection, with: selectionCriteria)
         return selector.supports(mediaSelectionOption: option) ? option : .off
     }
 
@@ -80,7 +81,10 @@ public extension Player {
               selector.supports(mediaSelectionOption: mediaOption) else {
             return
         }
-        selector.select(mediaOption: mediaOption, on: item, of: queuePlayer)
+        let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic)
+        if let updatedSelectionCriteria = selector.select(mediaOption: mediaOption, on: item, with: selectionCriteria) {
+            queuePlayer.setMediaSelectionCriteria(updatedSelectionCriteria, forMediaCharacteristic: characteristic)
+        }
     }
 
     /// A binding to read and write the current media selection for a characteristic.
@@ -124,11 +128,11 @@ public extension Player {
         }
 
         if !languages.isEmpty {
-            let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
+            let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
                 preferredLanguages: Self.preferredLanguages(for: characteristic),
                 preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
             )
-            queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
+            queuePlayer.setMediaSelectionCriteria(selectionCriteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
         }
         else {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -30,7 +30,8 @@ public extension Player {
     ///
     /// Use `mediaCharacteristics` to retrieve available characteristics.
     func mediaSelectionOptions(for characteristic: AVMediaCharacteristic) -> [MediaSelectionOption] {
-        guard let selector = mediaSelector(for: characteristic) else { return [] }
+        guard let selector = mediaSelector(for: characteristic),
+              queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) == nil else { return [] }
         return selector.mediaSelectionOptions()
     }
 

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -120,8 +120,7 @@ public extension Player {
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied.
     ///     Supported values include .audible, .legible, and .visual.
     ///
-    /// Criteria will be applied to an `AVPlayerItem` instance when is ready to play. They are cleared when a selection
-    /// is made using `select(mediaOption:for`).
+    /// Criteria will be applied to an `AVPlayerItem` instance when is ready to play.
     func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
         if let item = queuePlayer.currentItem {
             mediaSelectionContext.reset(for: characteristic, in: item)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -23,6 +23,18 @@ public extension Player {
         }
     }
 
+    // swiftlint:disable:next discouraged_optional_collection
+    private static func preferredMediaCharacteristics(for characteristic: AVMediaCharacteristic) -> [AVMediaCharacteristic]? {
+        switch characteristic {
+        case .audible:
+            return MAAudibleMediaCopyPreferredCharacteristics().takeRetainedValue() as? [AVMediaCharacteristic]
+        case .legible:
+            return MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics(.user).takeRetainedValue() as? [AVMediaCharacteristic]
+        default:
+            return []
+        }
+    }
+
     /// The list of media options associated with a characteristic.
     ///
     /// - Parameter characteristic: The characteristic.
@@ -129,7 +141,7 @@ public extension Player {
         if !languages.isEmpty {
             let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
                 preferredLanguages: Self.preferredLanguages(for: characteristic),
-                preferredMediaCharacteristics: nil
+                preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
             )
             queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
         }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -66,8 +66,10 @@ public extension Player {
     /// You can use `mediaCharacteristics` to retrieve available characteristics. This method does nothing if attempting
     /// to set an option that is not supported.
     func select(mediaOption: MediaSelectionOption, for characteristic: AVMediaCharacteristic) {
-        guard let item = queuePlayer.currentItem, let selector = mediaSelector(for: characteristic),
-              selector.supports(mediaSelectionOption: mediaOption) else {
+        guard let item = queuePlayer.currentItem,
+              let selector = mediaSelector(for: characteristic),
+              selector.supports(mediaSelectionOption: mediaOption),
+              queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) == nil else {
             return
         }
         selector.select(mediaOption: mediaOption, on: item)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -93,8 +93,6 @@ public extension Player {
               selector.supports(mediaSelectionOption: mediaOption) else {
             return
         }
-        // TODO: Likely clear for legible options but append for audible options
-        queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
         selector.select(mediaOption: mediaOption, on: item, in: queuePlayer)
     }
 

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -17,9 +17,9 @@ public extension Player {
     private static func preferredLanguages(for characteristic: AVMediaCharacteristic) -> [String] {
         switch characteristic {
         case .legible:
-            MACaptionAppearanceCopySelectedLanguages(.user).takeUnretainedValue() as? [String] ?? []
+            return MACaptionAppearanceCopySelectedLanguages(.user).takeUnretainedValue() as? [String] ?? []
         default:
-            []
+            return []
         }
     }
 
@@ -138,7 +138,7 @@ public extension Player {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
         }
     }
-    
+
     /// Returns media selection preferred languages for the specified media characteristic.
     ///
     /// - Parameter characteristic: The characteristic.

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -60,21 +60,8 @@ public extension Player {
             return .off
         }
 
-        let option = selectedMediaOption(in: selection, with: selector, for: characteristic)
+        let option = selector.selectedMediaOption(in: selection, of: queuePlayer)
         return selector.supports(mediaSelectionOption: option) ? option : .off
-    }
-
-    private func selectedMediaOption(
-        in selection: AVMediaSelection,
-        with selector: MediaSelector,
-        for characteristic: AVMediaCharacteristic
-    ) -> MediaSelectionOption {
-        if queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) == nil {
-            return selector.persistedSelectedMediaOption(in: selection)
-        }
-        else {
-            return selector.selectedMediaOption(in: selection)
-        }
     }
 
     /// Selects a media option for a characteristic.
@@ -93,7 +80,7 @@ public extension Player {
               selector.supports(mediaSelectionOption: mediaOption) else {
             return
         }
-        selector.select(mediaOption: mediaOption, on: item, in: queuePlayer)
+        selector.select(mediaOption: mediaOption, on: item, of: queuePlayer)
     }
 
     /// A binding to read and write the current media selection for a characteristic.

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -40,7 +40,7 @@ public extension Player {
     /// - Parameter characteristic: The characteristic.
     /// - Returns: The list of options associated with the characteristic.
     ///
-    /// Use `mediaCharacteristics` to retrieve available characteristics.
+    /// Use `mediaSelectionCharacteristics` to retrieve available characteristics.
     func mediaSelectionOptions(for characteristic: AVMediaCharacteristic) -> [MediaSelectionOption] {
         guard let selector = mediaSelector(for: characteristic) else { return [] }
         return selector.mediaSelectionOptions()
@@ -50,9 +50,6 @@ public extension Player {
     ///
     /// - Parameter characteristic: The characteristic.
     /// - Returns: The selected option.
-    ///
-    /// Returns the selection based on [Media Accessibility](https://developer.apple.com/documentation/mediaaccessibility).
-    /// This ensures that selection made in other apps relying on Media Accessibility is automatically restored.
     ///
     /// You can use `mediaCharacteristics` to retrieve available characteristics.
     func selectedMediaOption(for characteristic: AVMediaCharacteristic) -> MediaSelectionOption {
@@ -70,9 +67,6 @@ public extension Player {
     /// - Parameters:
     ///   - mediaOption: The option to select.
     ///   - characteristic: The characteristic.
-    ///
-    /// Sets the selection using [Media Accessibility](https://developer.apple.com/documentation/mediaaccessibility).
-    /// This ensures that selection is automatically restored in other apps relying on Media Accessibility.
     ///
     /// You can use `mediaCharacteristics` to retrieve available characteristics. This method does nothing if attempting
     /// to set an option that is not supported.
@@ -116,10 +110,10 @@ public extension Player {
     ///
     /// - Parameters:
     ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are 
-    ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T language
-    ///     codes.
+    ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T 
+    ///     language codes.
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied.
-    ///     Supported values include .audible, .legible, and .visual.
+    ///     Supported values include `.audible`, `.legible`, and `.visual`.
     ///
     /// Criteria will be applied to an `AVPlayerItem` instance when is ready to play.
     func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -127,16 +127,11 @@ public extension Player {
         }
 
         if !languages.isEmpty {
-            if let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) {
-                queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
-            }
-            else {
-                let selectionCriteria = AVPlayerMediaSelectionCriteria(
-                    preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
-                    preferredMediaCharacteristics: nil
-                )
-                queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
-            }
+            let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
+                preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
+                preferredMediaCharacteristics: nil
+            )
+            queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
         }
         else {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -127,11 +127,16 @@ public extension Player {
         }
 
         if !languages.isEmpty {
-            let selectionCriteria = AVPlayerMediaSelectionCriteria(
-                preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
-                preferredMediaCharacteristics: nil
-            )
-            queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
+            if let criteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) {
+                queuePlayer.setMediaSelectionCriteria(criteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
+            }
+            else {
+                let selectionCriteria = AVPlayerMediaSelectionCriteria(
+                    preferredLanguages: languages + Self.preferredLanguages(for: characteristic),
+                    preferredMediaCharacteristics: nil
+                )
+                queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
+            }
         }
         else {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -85,6 +85,17 @@ public extension Player {
         return .on(option)
     }
 
+    /// Applies automatic selection criteria for media that has the specified media characteristic.
+    /// - Parameters:
+    ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are preferred for selection.
+    ///   Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T language codes.
+    ///   - characteristic: The media characteristic for which the selection criteria are to be applied. 
+    ///   Supported values include .audible, .legible, and .visual.
+    func setMediaSelectionCriteria(preferredLanguages: [String], for characteristic: AVMediaCharacteristic) {
+        let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages, preferredMediaCharacteristics: nil)
+        queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
+    }
+
     private func mediaSelector(for characteristic: AVMediaCharacteristic) -> MediaSelector? {
         guard let group = mediaSelectionContext.group(for: characteristic) else { return nil }
         switch characteristic {

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -137,10 +137,11 @@ public extension Player {
     ///
     /// - Parameter characteristic: The characteristic.
     func mediaSelectionPreferredLanguages(for characteristic: AVMediaCharacteristic) -> [String] {
-        guard let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) else {
+        guard let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic),
+              let preferredLanguages = selectionCriteria.preferredLanguages else {
             return []
         }
-        return selectionCriteria.preferredLanguages ?? []
+        return preferredLanguages
     }
 
     private func mediaSelector(for characteristic: AVMediaCharacteristic) -> MediaSelector? {

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -92,6 +92,13 @@ public extension Player {
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied. 
     ///   Supported values include .audible, .legible, and .visual.
     func setMediaSelectionCriteria(preferredLanguages: [String], for characteristic: AVMediaCharacteristic) {
+        if let group = mediaSelectionContext.group(for: characteristic), group.options.contains(where: { option in
+                guard let code = option.languageCode else { return false }
+                return preferredLanguages.contains(code)
+        }) {
+            queuePlayer.currentItem?.selectMediaOptionAutomatically(in: group)
+        }
+
         let criteria = AVPlayerMediaSelectionCriteria(preferredLanguages: preferredLanguages, preferredMediaCharacteristics: nil)
         queuePlayer.setMediaSelectionCriteria(criteria, forMediaCharacteristic: characteristic)
     }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -45,7 +45,9 @@ public extension Player {
     ///
     /// You can use `mediaCharacteristics` to retrieve available characteristics.
     func selectedMediaOption(for characteristic: AVMediaCharacteristic) -> MediaSelectionOption {
-        guard let selection = mediaSelectionContext.selection, let selector = mediaSelector(for: characteristic) else {
+        guard let selection = mediaSelectionContext.selection,
+              let selector = mediaSelector(for: characteristic),
+              queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) == nil else {
             return .off
         }
         let option = selector.selectedMediaOption(in: selection)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -155,7 +155,7 @@ public final class Player: ObservableObject, Equatable {
         self.init(items: [item], configuration: configuration)
     }
 
-    public nonisolated static func == (lhs: Player, rhs: Player) -> Bool {
+    public static func == (lhs: Player, rhs: Player) -> Bool {
         lhs === rhs
     }
 

--- a/Sources/Streams/Stream.swift
+++ b/Sources/Streams/Stream.swift
@@ -96,6 +96,15 @@ public extension Stream {
         url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8")!,
         duration: CMTime(value: 1800, timescale: 1)
     )
+
+    /// An on-demand with many audible and legible options.
+    static let onDemandWithManyLegibleAndAudibleOptions: Self = .init(
+        url: URL(string: """
+        https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8\
+        ?cc=CH&svcId=tvs.vds.4021&a=1522121579&isExternal=true&brandId=tvs.sbd.4000&id=518077009&l=en-GB&aec=UHD
+        """)!,
+        duration: CMTime(value: 151, timescale: 1)
+    )
 }
 
 public extension Stream {

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -15,41 +15,41 @@ import XCTest
 final class MediaSelectionCriteriaTests: TestCase {
     func testAudibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.selectedMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testLegibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testAudibleOptionIgnoresInvalidLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["xy"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
     func testLegibleOptionIgnoresInvalidLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["xy"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
     func testAudibleOptionIgnoresUnsupportedLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["it"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["it"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
     func testLegibleOptionIgnoresUnsupportedLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["it"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["it"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
-    func testAudubleCriteriaOverrideSelection() {
+    func testAudibleCriteriaOverrideSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
 
@@ -57,7 +57,7 @@ final class MediaSelectionCriteriaTests: TestCase {
             option.languageIdentifier == "fr"
         }!, for: .audible)
 
-        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["en"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
@@ -69,15 +69,15 @@ final class MediaSelectionCriteriaTests: TestCase {
             option.languageIdentifier == "ja"
         }!, for: .legible)
 
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testAudibleCriteriaReset() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelectionCriteria(preferredLanguages: [], for: .audible)
+        player.setMediaSelection(preferredLanguages: [], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
@@ -85,9 +85,9 @@ final class MediaSelectionCriteriaTests: TestCase {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
@@ -95,7 +95,7 @@ final class MediaSelectionCriteriaTests: TestCase {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
@@ -103,7 +103,7 @@ final class MediaSelectionCriteriaTests: TestCase {
         MediaAccessibilityDisplayType.automatic.apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
@@ -111,7 +111,7 @@ final class MediaSelectionCriteriaTests: TestCase {
         MediaAccessibilityDisplayType.forcedOnly.apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
@@ -122,7 +122,7 @@ final class MediaSelectionCriteriaTests: TestCase {
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
         ])
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
 
         player.advanceToNextItem()
@@ -136,7 +136,7 @@ final class MediaSelectionCriteriaTests: TestCase {
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
         ])
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
 
         player.advanceToNextItem()

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -98,6 +98,22 @@ final class MediaSelectionCriteriaTests: TestCase {
         player.setMediaSelectionCriteria(preferredLanguages: [], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
+
+    func testAudibleUnselectableWithMediaSelectionCriteria() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
+
+        let option = player.mediaSelectionOptions(for: .audible).first { option in
+            option.languageIdentifier == "fr"
+        }!
+        player.select(mediaOption: option, for: .audible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+
+        player.select(mediaOption: option, for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toAlways(haveLanguageIdentifier("en"), until: .seconds(2))
+    }
 }
 
 private extension Player {

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -23,6 +23,12 @@ final class MediaSelectionCriteriaTests: TestCase {
         expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
     }
 
+    func testAudibleOptionWithMediaSelectionCriteria() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.selectedMediaOption(for: .audible)).toAlways(equal(.off), until: .seconds(2))
+    }
+
     func testLegibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -1,0 +1,102 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import AVFoundation
+import MediaAccessibility
+import Nimble
+import Streams
+import XCTest
+
+final class MediaSelectionCriteriaTests: TestCase {
+    func testCharacteristicsAndOptionsWithMediaSelectionCriteria() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.mediaSelectionCharacteristics).toEventually(equal([.audible, .legible]))
+
+        expect(player.mediaSelectionOptions(for: .audible)).to(beEmpty())
+        expect(player.mediaSelectionOptions(for: .legible)).notTo(beEmpty())
+        expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
+    }
+
+    func testLegibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testLegibleMediaSelectionCriteriaWithAvailableLanguage() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleMediaSelectionCriteriaOverride() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "ja"
+        }!, for: .legible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleMediaSelectionCriteriaReset() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testAudibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testAudibleMediaSelectionCriteriaWithAvailableLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testAudibleMediaSelectionCriteriaOverride() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .audible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .audible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testAudibleMediaSelectionCriteriaReset() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: [], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+}
+
+private extension Player {
+    func group(for characteristic: AVMediaCharacteristic) async throws -> AVMediaSelectionGroup? {
+        guard let item = systemPlayer.currentItem else { return nil }
+        return try await item.asset.loadMediaSelectionGroup(for: characteristic)
+    }
+}

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -13,79 +13,43 @@ import Streams
 import XCTest
 
 final class MediaSelectionCriteriaTests: TestCase {
-    func testCharacteristicsAndOptionsWithMediaSelectionCriteria() {
+    func testAudibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
-        expect(player.mediaSelectionCharacteristics).toEventually(equal([.audible, .legible]))
-
-        expect(player.mediaSelectionOptions(for: .audible)).to(beEmpty())
-        expect(player.mediaSelectionOptions(for: .legible)).notTo(beEmpty())
-        expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
+        expect(player.selectedMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testAudibleOptionWithMediaSelectionCriteria() {
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
-        expect(player.selectedMediaOption(for: .audible)).toAlways(equal(.off), until: .seconds(2))
-    }
-
-    func testLegibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
-    }
-
-    func testLegibleMediaSelectionCriteriaWithAvailableLanguage() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
-
+    func testLegibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testLegibleMediaSelectionCriteriaOverride() {
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
-
-        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
-            option.languageIdentifier == "ja"
-        }!, for: .legible)
-
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testLegibleMediaSelectionCriteriaReset() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
-    }
-
-    func testAudibleMediaSelectionCriteriaWithUnknownLanguage() {
+    func testAudibleOptionIgnoresInvalidLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
-    func testAudibleMediaSelectionCriteriaWithUnavailableLanguage() {
+    func testLegibleOptionIgnoresInvalidLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
+    }
+
+    func testAudibleOptionIgnoresUnsupportedLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelectionCriteria(preferredLanguages: ["it"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
-    func testAudibleMediaSelectionCriteriaWithAvailableLanguage() {
+    func testLegibleOptionIgnoresUnsupportedLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["it"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
-    func testAudibleMediaSelectionCriteriaOverride() {
+    func testAudubleCriteriaOverrideSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
 
@@ -97,7 +61,19 @@ final class MediaSelectionCriteriaTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testAudibleMediaSelectionCriteriaReset() {
+    func testLegibleCriteriaOverrideSelection() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "ja"
+        }!, for: .legible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testAudibleCriteriaReset() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
@@ -105,26 +81,101 @@ final class MediaSelectionCriteriaTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testAudibleUnselectableWithMediaSelectionCriteria() {
+    func testLegibleCriteriaReset() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testLegibleCriteriaOverridePersistedOnOption() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleCriteriaOverridePersistedAutomaticOption() {
+        MediaAccessibilityDisplayType.automatic.apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleCriteriaOverridePersistedOffOption() {
+        MediaAccessibilityDisplayType.forcedOnly.apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testAudibleCriteriaArePreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleCriteriaArePreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testAudibleSelectionIsPreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
         expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
 
-        let option = player.mediaSelectionOptions(for: .audible).first { option in
+        player.select(mediaOption: player.mediaSelectionOptions(for: .audible).first { option in
             option.languageIdentifier == "fr"
-        }!
-        player.select(mediaOption: option, for: .audible)
+        }!, for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
 
-        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
-
-        player.select(mediaOption: option, for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toAlways(haveLanguageIdentifier("en"), until: .seconds(2))
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
     }
-}
 
-private extension Player {
-    func group(for characteristic: AVMediaCharacteristic) async throws -> AVMediaSelectionGroup? {
-        guard let item = systemPlayer.currentItem else { return nil }
-        return try await item.asset.loadMediaSelectionGroup(for: characteristic)
+    func testLegibleSelectionIsPreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 }

--- a/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionCriteriaTests.swift
@@ -67,10 +67,16 @@ final class MediaSelectionCriteriaTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
-    func testAudibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
+    func testAudibleMediaSelectionCriteriaWithUnknownLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
+    }
+
+    func testAudibleMediaSelectionCriteriaWithUnavailableLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["it"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
     func testAudibleMediaSelectionCriteriaWithAvailableLanguage() {

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -266,7 +266,7 @@ final class MediaSelectionTests: TestCase {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xx"], for: .legible)
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "ja"], for: .legible)
         expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
@@ -274,7 +274,19 @@ final class MediaSelectionTests: TestCase {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr", "ja"], for: .legible)
+        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testSelectLanguageWithPreSelectedLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "ja"
+        }!, for: .legible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr", "ja"], for: .legible)
         expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 }

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -262,15 +262,15 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).to(equal(.off))
     }
 
-    func testSelectUnknownLanguage() {
+    func testMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .legible)
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
-    func testSelectLanguage() {
+    func testMediaSelectionCriteriaWithAvailableLanguage() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
@@ -278,7 +278,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testSelectLanguageWithPreSelectedLanguage() {
+    func testMediaSelectionCriteriaOverride() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
@@ -290,18 +290,12 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testSelectLanguageReset() {
+    func testMediaSelectionCriteriaReset() {
+        setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
+
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
-
-        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
-            option.languageIdentifier == "ja"
-        }!, for: .legible)
-
         player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
         player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -266,16 +266,16 @@ final class MediaSelectionTests: TestCase {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "ja"], for: .legible)
-        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
     func testSelectLanguage() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr", "ja"], for: .legible)
-        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testSelectLanguageWithPreSelectedLanguage() {
@@ -286,8 +286,24 @@ final class MediaSelectionTests: TestCase {
             option.languageIdentifier == "ja"
         }!, for: .legible)
 
-        player.setMediaSelectionCriteria(preferredLanguages: ["fr", "ja"], for: .legible)
-        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testSelectLanguageReset() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "ja"
+        }!, for: .legible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+        player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 }
 

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -261,6 +261,22 @@ final class MediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
         expect(player.currentMediaOption(for: .legible)).to(equal(.off))
     }
+
+    func testSelectUnknownLanguage() {
+        setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xx"], for: .legible)
+        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testSelectLanguage() {
+        setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .legible)
+        expect(player.mediaSelectionContext.selectedOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
 }
 
 private extension Player {

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -262,7 +262,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).to(equal(.off))
     }
 
-    func testMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
+    func testLegibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
@@ -270,7 +270,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
-    func testMediaSelectionCriteriaWithAvailableLanguage() {
+    func testLegibleMediaSelectionCriteriaWithAvailableLanguage() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
@@ -278,7 +278,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testMediaSelectionCriteriaOverride() {
+    func testLegibleMediaSelectionCriteriaOverride() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
@@ -290,7 +290,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testMediaSelectionCriteriaReset() {
+    func testLegibleMediaSelectionCriteriaReset() {
         setupAccessibilityDisplayType(.alwaysOn(languageCode: "ja"))
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
@@ -298,6 +298,38 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
         player.setMediaSelectionCriteria(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testAudibleMediaSelectionCriteriaWithUnknownOrUnavailableLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["xy", "it"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testAudibleMediaSelectionCriteriaWithAvailableLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testAudibleMediaSelectionCriteriaOverride() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .audible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .audible)
+
+        player.setMediaSelectionCriteria(preferredLanguages: ["en"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testAudibleMediaSelectionCriteriaReset() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelectionCriteria(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelectionCriteria(preferredLanguages: [], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 }
 

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -36,7 +36,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
     }
 
-    func testWithoutCharacteristicsAndOptions() {
+    func testCharacteristicsAndOptionsWhenUnavailable() {
         let player = Player(item: .simple(url: Stream.onDemandWithoutOptions.url))
         expect(player.mediaSelectionCharacteristics).toAlways(beEmpty(), until: .seconds(2))
         expect(player.mediaSelectionOptions(for: .audible)).to(beEmpty())
@@ -44,7 +44,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
     }
 
-    func testCharacteristicsAndOptionsWhenAdvancingToNextItem() {
+    func testCharacteristicsAndOptionsUpdateWhenAdvancingToNextItem() {
         let player = Player(items: [
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithoutOptions.url)

--- a/Tests/PlayerTests/Player/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/MediaSelectionTests.swift
@@ -232,6 +232,42 @@ final class MediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).to(equal(.off))
     }
 
+    func testAudibleSelectionIsPreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
+        expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .audible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testLegibleSelectionIsPreservedBetweenItems() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
+
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithOptions.url)
+        ])
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
     func testLegibleOptionSwitchFromOffToAutomatic() {
         MediaAccessibilityDisplayType.forcedOnly.apply()
 

--- a/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
@@ -25,31 +25,31 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testAudibleOptionIgnoresInvalidLanguage() {
+    func testAudibleOptionIgnoresInvalidPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["xy"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
-    func testLegibleOptionIgnoresInvalidLanguage() {
+    func testLegibleOptionIgnoresInvalidPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["xy"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
-    func testAudibleOptionIgnoresUnsupportedLanguage() {
+    func testAudibleOptionIgnoresUnsupportedPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["it"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
-    func testLegibleOptionIgnoresUnsupportedLanguage() {
+    func testLegibleOptionIgnoresUnsupportedPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["it"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
-    func testAudibleCriteriaOverrideSelection() {
+    func testPreferredAudibleLanguageOverrideSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
 
@@ -61,7 +61,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testLegibleCriteriaOverrideSelection() {
+    func testPreferredLegibleLanguageOverrideSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
@@ -73,7 +73,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testAudibleCriteriaReset() {
+    func testPreferredAudibleLanguageReset() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
@@ -81,7 +81,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testLegibleCriteriaReset() {
+    func testPreferredLegibleLanguageReset() {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
@@ -91,33 +91,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 
-    func testLegibleCriteriaOverridePersistedOnOption() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testLegibleCriteriaOverridePersistedAutomaticOption() {
-        MediaAccessibilityDisplayType.automatic.apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testLegibleCriteriaOverridePersistedOffOption() {
-        MediaAccessibilityDisplayType.forcedOnly.apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testAudibleCriteriaArePreservedBetweenItems() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
-
+    func testPreferredAudibleLanguageIsPreservedBetweenItems() {
         let player = Player(items: [
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
@@ -129,50 +103,12 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testLegibleCriteriaArePreservedBetweenItems() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
-
+    func testPreferredLegibleLanguageIsPreservedBetweenItems() {
         let player = Player(items: [
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
         ])
         player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-
-        player.advanceToNextItem()
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testAudibleSelectionIsPreservedBetweenItems() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
-
-        let player = Player(items: [
-            .simple(url: Stream.onDemandWithOptions.url),
-            .simple(url: Stream.onDemandWithOptions.url)
-        ])
-        expect(player.mediaSelectionOptions(for: .audible)).toEventuallyNot(beEmpty())
-
-        player.select(mediaOption: player.mediaSelectionOptions(for: .audible).first { option in
-            option.languageIdentifier == "fr"
-        }!, for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-
-        player.advanceToNextItem()
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-    }
-
-    func testLegibleSelectionIsPreservedBetweenItems() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "en").apply()
-
-        let player = Player(items: [
-            .simple(url: Stream.onDemandWithOptions.url),
-            .simple(url: Stream.onDemandWithOptions.url)
-        ])
-        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
-
-        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
-            option.languageIdentifier == "fr"
-        }!, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
 
         player.advanceToNextItem()

--- a/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
@@ -133,4 +133,24 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         player.returnToPrevious()
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
     }
+
+    func testSelectLegibleOffOptionWithPreferredLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+
+        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+
+        player.select(mediaOption: .off, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.off))
+    }
+
+    func testSelectLegibleAutomaticOptionWithPreferredLanguage() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+
+        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+
+        player.select(mediaOption: .automatic, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
+    }
 }

--- a/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
@@ -12,7 +12,7 @@ import Nimble
 import Streams
 import XCTest
 
-final class MediaSelectionCriteriaTests: TestCase {
+final class PreferredLanguagesForMediaSelectionTests: TestCase {
     func testAudibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)

--- a/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/Player/PreferredLanguagesForMediaSelectionTests.swift
@@ -114,4 +114,23 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         player.advanceToNextItem()
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
+
+    func testPreferredLegibleLanguageAcrossItems() {
+        let player = Player(items: [
+            .simple(url: Stream.onDemandWithOptions.url),
+            .simple(url: Stream.onDemandWithManyLegibleAndAudibleOptions.url)
+        ])
+
+        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+
+        player.advanceToNextItem()
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+
+        player.setMediaSelection(preferredLanguages: ["it"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("it"))
+
+        player.returnToPrevious()
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+    }
 }

--- a/Tests/PlayerTests/Tools/MediaAccessibilityDisplayType.swift
+++ b/Tests/PlayerTests/Tools/MediaAccessibilityDisplayType.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+import MediaAccessibility
+
+enum MediaAccessibilityDisplayType {
+    case automatic
+    case forcedOnly
+    case alwaysOn(languageCode: String)
+
+    func apply() {
+        switch self {
+        case .automatic:
+            MACaptionAppearanceSetDisplayType(.user, .automatic)
+        case .forcedOnly:
+            MACaptionAppearanceSetDisplayType(.user, .forcedOnly)
+        case let .alwaysOn(languageCode: languageCode):
+            MACaptionAppearanceSetDisplayType(.user, .alwaysOn)
+            MACaptionAppearanceAddSelectedLanguage(.user, languageCode as CFString)
+        }
+    }
+}

--- a/Tests/PlayerTests/Types/LanguageIdentifiable.swift
+++ b/Tests/PlayerTests/Types/LanguageIdentifiable.swift
@@ -24,6 +24,6 @@ extension MediaSelectionOption: LanguageIdentifiable {
 
 extension AVMediaSelectionOption: LanguageIdentifiable {
     var languageIdentifier: String? {
-        locale?.language.languageCode?.identifier
+        locale?.identifier
     }
 }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -112,7 +112,7 @@ Move tap gesture recognizers in your layout so that they do not overlap with the
 
 ## Subtitle selection might be incorrect near the end of the current item (FB13070742)
 
-When approaching the end of the current item, and if there is a next item in the list, subtitle selection might suddlenly change to an incorrect value. Subtitles displayed on screen, though, remain the same.
+When approaching the end of the current item, and if there is a next item in the list, subtitle selection might suddenly change to an incorrect value. Subtitles displayed on screen, though, remain the same as before.
 
 ### Workaround
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -109,3 +109,11 @@ When a layout contains a `RoutePickerView` as well as a tap gesture recognizer (
 ### Workaround
 
 Move tap gesture recognizers in your layout so that they do not overlap with the `RoutePickerView`.
+
+## Subtitle selection might be incorrect near the end of the current item (FB13070742)
+
+When approaching the end of the current item, and if there is a next item in the list, subtitle selection might suddlenly change to an incorrect value. Subtitles displayed on screen, though, remain the same.
+
+### Workaround
+
+No workaround is available yet.

--- a/docs/STREAM_PACKAGING_ADVICE.md
+++ b/docs/STREAM_PACKAGING_ADVICE.md
@@ -24,6 +24,16 @@ Pillarbox player supports closed captions (CC) and Subtitles for the Deaf or Har
 - CC renditions are identified by the `CLOSED-CAPTIONS` type. They must also have their `AUTOSELECT` attribute set to `YES`.
 - SDH renditions [must](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Accessibility) have the `SUBTITLES` type and the `public.accessibility.transcribes-spoken-dialog` and `public.accessibility.describes-music-and-sound` characteristics. They must also have their `AUTOSELECT` attribute set to `YES`.
 
+### Troubleshooting
+
+If you think audible or legible renditions are incorrectly handled for some content you play with Pillarbox `Player`, please check the following in order:
+
+1. Check that your master playlist adopts the standards listed in this document. You should in particular ensure that `AUTOSELECT`, `FORCED` and accessibility characteristics are properly set.
+2. If your master playlist is correct then check system settings on your device. Automatic audible and legible subtitle selection namely strongly depends on:
+  - The list of preferred languages defined in the system settings (all languages are considered as potentially understood by the user) and their relative order. Remove languages that you do not expect and reorder the list as appropriate.
+  - The user accessibility settings (AD and SDH / CC preferences). Enable or disable these settings according to your needs.
+3. Whether your code overrides rendition selection with `setMediaSelection(preferredLanguages:for:)` but should in fact not.
+
 ## Trick mode / Trick play
 
 Pillarbox player supports [trick mode](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Trick-Play) (aka trick play) which requires dedicated I-frame playlists to be delivered in video master playlists to provide for a [faster seeking experience](https://en.wikipedia.org/wiki/Trick_mode).

--- a/docs/STREAM_PACKAGING_ADVICE.md
+++ b/docs/STREAM_PACKAGING_ADVICE.md
@@ -29,10 +29,10 @@ Pillarbox player supports closed captions (CC) and Subtitles for the Deaf or Har
 If you think audible or legible renditions are incorrectly handled for some content you play with Pillarbox `Player`, please check the following in order:
 
 1. Check that your master playlist adopts the standards listed in this document. You should in particular ensure that `AUTOSELECT`, `FORCED` and accessibility characteristics are properly set.
-2. If your master playlist is correct then check system settings on your device. Automatic audible and legible subtitle selection namely strongly depends on:
+2. If your master playlist is correct then check system settings on your device. Automatic audible and legible rendition selection namely strongly depends on:
   - The list of preferred languages defined in the system settings (all languages are considered as potentially understood by the user) and their relative order. Remove languages that you do not expect and reorder the list as appropriate.
   - The user accessibility settings (AD and SDH / CC preferences). Enable or disable these settings according to your needs.
-3. Whether your code overrides rendition selection with `setMediaSelection(preferredLanguages:for:)` but should in fact not.
+3. Whether your code overrides rendition selection with `setMediaSelection(preferredLanguages:for:)` in an unexpected way.
 
 ## Trick mode / Trick play
 


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to add the ability to override media selection options at startup using the `setMediaSelection(preferredLanguages:for:)` method. 

## Changes made

- Added the `setMediaSelection(preferredLanguages:for:)` method to apply automatic selection criteria for specified media characteristics.
- The method allows specifying an array of preferred languages and a media characteristic (e.g., `.audible`, `.legible`, `.visual`).
- If the preferred languages are provided, the method sets the selection criteria using the specified languages and any additional preferred languages for the given characteristic.
- If no preferred languages are provided, the method removes any existing selection criteria for the given characteristic.

## Checklist

- [x] APIs have been properly documented.
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
