### PR TITLE
Support subtitle appearance customization

### DIFF
--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import Player
 import SwiftUI
 
@@ -48,11 +49,17 @@ struct TransitionView: View {
 
 private extension Player {
     func enableSilentPlayback(withLanguage language: String) {
+        let textStyleRule = AVTextStyleRule(textMarkupAttributes: [
+            kCMTextMarkupAttribute_BackgroundColorARGB as String: [1, 1, 0, 0],
+            kCMTextMarkupAttribute_ItalicStyle as String: true
+        ])!
+        textStyleRules = [textStyleRule]
         setMediaSelection(preferredLanguages: [language], for: .legible)
         isMuted = true
     }
 
     func disableSilentPlayback() {
+        textStyleRules = []
         setMediaSelection(preferredLanguages: [], for: .legible)
         isMuted = false
     }

--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -50,9 +50,9 @@ struct TransitionView: View {
 private extension Player {
     func enableSilentPlayback(withLanguage language: String) {
         let textStyleRule = AVTextStyleRule(textMarkupAttributes: [
-            kCMTextMarkupAttribute_BackgroundColorARGB as String: [1, 1, 0, 0],
-            kCMTextMarkupAttribute_ItalicStyle as String: true
-        ])!
+            kCMTextMarkupAttribute_BackgroundColorARGB: [1, 1, 0, 0],
+            kCMTextMarkupAttribute_ItalicStyle: true
+        ])
         textStyleRules = [textStyleRule]
         setMediaSelection(preferredLanguages: [language], for: .legible)
         isMuted = true

--- a/Sources/Player/Extensions/AVTextStyleRule.swift
+++ b/Sources/Player/Extensions/AVTextStyleRule.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+public extension AVTextStyleRule {
+    /// Creates a text style rule object with the specified style attributes and text range information.
+    ///
+    /// - Parameters:
+    ///   - textMarkupAttributes: A dictionary of style attributes. For a list of supported keys look for constants
+    ///     starting with `kCMTextMarkupAttribute`.
+    ///   - textSelector: A string contains an identifier for the ranges of text to which the style attributes should
+    ///     be applied. Eligible identifiers are determined by the media format and its corresponding text content.
+    ///     For example, the string could contain the CSS selectors used by the corresponding text in Web Video Text
+    ///     Tracks (WebVTT) markup. Specify nil if you want the style attributes to apply to all text in the item.
+    convenience init(textMarkupAttributes: [CFString: Any] = [:], textSelector: String? = nil) {
+        self.init(textMarkupAttributes: textMarkupAttributes as [String: Any], textSelector: textSelector)!
+    }
+}

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -107,8 +107,8 @@ public extension Player {
     /// Sets media selection preferred languages for the specified media characteristic.
     ///
     /// - Parameters:
-    ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are 
-    ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T 
+    ///   - preferredLanguages: An Array of strings containing language identifiers, in order of desirability, that are
+    ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T
     ///     language codes.
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied. Supported values
     ///     include `.audible`, `.legible`, and `.visual`.
@@ -151,6 +151,21 @@ public extension Player {
             return LegibleMediaSelector(group: group)
         default:
             return nil
+        }
+    }
+}
+
+public extension Player {
+    /// An array of text style rules that specify the formatting and presentation of Web Video Text Tracks (WebVTT)
+    /// subtitles.
+    ///
+    /// Text style rules apply only to WebVTT subtitles. They don’t apply to other subtitle formats and legible text.
+    var textStyleRules: [AVTextStyleRule] {
+        get {
+            textStyleRulesPublisher.value
+        }
+        set {
+            textStyleRulesPublisher.send(newValue)
         }
     }
 }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -159,7 +159,8 @@ public extension Player {
     /// An array of text style rules that specify the formatting and presentation of Web Video Text Tracks (WebVTT)
     /// subtitles.
     ///
-    /// Text style rules apply only to WebVTT subtitles. They don’t apply to other subtitle formats and legible text.
+    /// Text style rules apply only to WebVTT subtitles. They don’t apply to other subtitle formats and legible text
+    /// or if WebVTT subtitles provide style information.
     var textStyleRules: [AVTextStyleRule] {
         get {
             textStyleRulesPublisher.value

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -127,6 +127,9 @@ public final class Player: ObservableObject, Equatable {
     // swiftlint:disable:next private_subject
     var desiredPlaybackSpeedPublisher = PassthroughSubject<Float, Never>()
 
+    // swiftlint:disable:next private_subject
+    var textStyleRulesPublisher = CurrentValueSubject<[AVTextStyleRule], Never>([])
+
     /// Creates a player with a given item queue.
     ///
     /// - Parameters:
@@ -195,6 +198,7 @@ public final class Player: ObservableObject, Equatable {
     private func configureQueuePlayerUpdatePublishers() {
         configureQueueUpdatePublisher()
         configureRateUpdatePublisher()
+        configureTextStyleRulesUpdatePublisher()
     }
 
     private func configurePublishedPropertyPublishers() {
@@ -244,6 +248,17 @@ private extension Player {
                 queuePlayer.rate = speed.effectiveValue
             }
             .store(in: &cancellables)
+    }
+
+    func configureTextStyleRulesUpdatePublisher() {
+        Publishers.CombineLatest(
+            textStyleRulesPublisher,
+            queuePlayer.publisher(for: \.currentItem)
+        )
+        .sink { textStyleRules, item in
+            item?.textStyleRules = textStyleRules
+        }
+        .store(in: &cancellables)
     }
 }
 

--- a/Tests/PlayerTests/Player/TextStyleRulesTests.swift
+++ b/Tests/PlayerTests/Player/TextStyleRulesTests.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Player
+
+import AVFoundation
+import Nimble
+import Streams
+import XCTest
+
+final class TextStyleRulesTests: TestCase {
+    private static var textStyleRules: [AVTextStyleRule] = {
+        [
+            .init(textMarkupAttributes: [
+                kCMTextMarkupAttribute_ForegroundColorARGB as String: [1, 1, 0, 0],
+                kCMTextMarkupAttribute_ItalicStyle as String: true
+            ])!
+        ]
+    }()
+
+    func testDefaultWithEmptyPlayer() {
+        let player = Player()
+        expect(player.textStyleRules).to(beEmpty())
+    }
+
+    func testDefaultWithLoadedPlayer() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        expect(player.textStyleRules).to(beEmpty())
+        expect(player.queuePlayer.currentItem?.textStyleRules).to(beEmpty())
+    }
+
+    func testStyleUpdate() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        player.textStyleRules = Self.textStyleRules
+        expect(player.textStyleRules).to(equal(Self.textStyleRules))
+        expect(player.queuePlayer.currentItem?.textStyleRules).to(equal(Self.textStyleRules))
+    }
+
+    func testStylePreservedBetweenItems() {
+        let player = Player(items: [
+            .simple(url: Stream.shortOnDemand.url),
+            .simple(url: Stream.onDemand.url)
+        ])
+        player.textStyleRules = Self.textStyleRules
+        player.advanceToNextItem()
+        expect(player.queuePlayer.currentItem?.textStyleRules).to(equal(Self.textStyleRules))
+    }
+}

--- a/Tests/PlayerTests/Player/TextStyleRulesTests.swift
+++ b/Tests/PlayerTests/Player/TextStyleRulesTests.swift
@@ -15,9 +15,9 @@ final class TextStyleRulesTests: TestCase {
     private static var textStyleRules: [AVTextStyleRule] = {
         [
             .init(textMarkupAttributes: [
-                kCMTextMarkupAttribute_ForegroundColorARGB as String: [1, 1, 0, 0],
-                kCMTextMarkupAttribute_ItalicStyle as String: true
-            ])!
+                kCMTextMarkupAttribute_ForegroundColorARGB: [1, 1, 0, 0],
+                kCMTextMarkupAttribute_ItalicStyle: true
+            ])
         ]
     }()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds a `textStyleRules` API with which player subtitle appearance can be customized.

# Changes made

- Add `textStyleRules` to `Player`.
- Customize subtitles in the transition view demo.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
