### PR TITLE
Reset media selection context when no item is being played

### DIFF
--- a/Sources/Player/Publishers/AVPlayerPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerPublishers.swift
@@ -80,7 +80,10 @@ extension AVPlayer {
 
     func currentItemMediaSelectionContextPublisher() -> AnyPublisher<MediaSelectionContext, Never> {
         publisher(for: \.currentItem)
-            .compactMap { $0?.mediaSelectionContextPublisher() }
+            .map { item -> AnyPublisher<MediaSelectionContext, Never> in
+                guard let item else { return Just(.empty).eraseToAnyPublisher() }
+                return item.mediaSelectionContextPublisher()
+            }
             .switchToLatest()
             .prepend(.empty)
             .eraseToAnyPublisher()

--- a/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
@@ -41,7 +41,7 @@ final class MediaSelectionTests: TestCase {
         expect(player.mediaSelectionCharacteristics).toEventuallyNot(beEmpty())
         player.play()
         expect(player.playbackState).toEventually(equal(.ended))
-        expect(player.mediaSelectionCharacteristics).to(beEmpty())
+        expect(player.mediaSelectionCharacteristics).toEventually(beEmpty())
     }
 
     func testCharacteristicsAndOptionsWhenUnavailable() {

--- a/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
@@ -36,6 +36,14 @@ final class MediaSelectionTests: TestCase {
         expect(player.mediaSelectionOptions(for: .visual)).to(beEmpty())
     }
 
+    func testCharacteristicsAndOptionsWhenExhausted() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionCharacteristics).toEventuallyNot(beEmpty())
+        player.play()
+        expect(player.playbackState).toEventually(equal(.ended))
+        expect(player.mediaSelectionCharacteristics).to(beEmpty())
+    }
+
     func testCharacteristicsAndOptionsWhenUnavailable() {
         let player = Player(item: .simple(url: Stream.onDemandWithoutOptions.url))
         expect(player.mediaSelectionCharacteristics).toAlways(beEmpty(), until: .seconds(2))


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes subtitle and audio selection when there is no current item in the player (most notably after item exhaustion).

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
