### PR TITLE
Make efficient seeks near the end of the available range safe

### DIFF
--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -90,7 +90,7 @@ class QueuePlayer: AVQueuePlayer {
 
     private func seek(safelyTo time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {
         let endTimeRange = CMTimeRange(start: timeRange.end - CMTime(value: 18, timescale: 1), end: timeRange.end)
-        if !endTimeRange.containsTime(time) {
+        if itemDuration.isIndefinite || !endTimeRange.containsTime(time) {
             super.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, completionHandler: completionHandler)
         }
         else {

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -83,8 +83,18 @@ class QueuePlayer: AVQueuePlayer {
     }
 
     func enqueue(seek: Seek, completion: @escaping () -> Void) {
-        super.seek(to: seek.time, toleranceBefore: seek.toleranceBefore, toleranceAfter: seek.toleranceAfter) { [weak self] finished in
+        self.seek(safelyTo: seek.time, toleranceBefore: seek.toleranceBefore, toleranceAfter: seek.toleranceAfter) { [weak self] finished in
             self?.process(seek: seek, finished: finished, completion: completion)
+        }
+    }
+
+    private func seek(safelyTo time: CMTime, toleranceBefore: CMTime, toleranceAfter: CMTime, completionHandler: @escaping (Bool) -> Void) {
+        let endTimeRange = CMTimeRange(start: timeRange.end - CMTime(value: 18, timescale: 1), end: timeRange.end)
+        if !endTimeRange.containsTime(time) {
+            super.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter, completionHandler: completionHandler)
+        }
+        else {
+            super.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: completionHandler)
         }
     }
 

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -104,6 +104,6 @@ final class SeekTests: TestCase {
         expect(player.streamType).toEventually(equal(.onDemand))
         player.play()
         player.seek(near(player.timeRange.end + CMTime(value: 10, timescale: 1)))
-        expect(player.time).toAlways(beLessThanOrEqualTo(player.timeRange.end), until: .seconds(1))
+        expect(player.time).toEventually(equal(player.timeRange.end), timeout: .seconds(1))
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to bypass an issue that occurs when we seek at the end with some streams.

# Changes made

- Enhance accuracy towards the end of playback by removing the tolerance before and after.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
