### PR TITLE
Rename restart API as replay

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -50,7 +50,7 @@ private struct MainView: View {
     }
 
     private var isUserInterfaceHidden: Bool {
-        visibilityTracker.isUserInterfaceHidden && !areControlsAlwaysVisible && !player.canRestart()
+        visibilityTracker.isUserInterfaceHidden && !areControlsAlwaysVisible && !player.canReplay()
     }
 
     private func magnificationGesture() -> some Gesture {
@@ -181,7 +181,7 @@ private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
     private var imageName: String {
-        if player.canRestart() {
+        if player.canReplay() {
             return "arrow.counterclockwise.circle.fill"
         }
         else {
@@ -203,12 +203,12 @@ private struct PlaybackButton: View {
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
         .opacity(player.isBusy ? 0 : 1)
-        .animation(.defaultLinear, values: player.playbackState, player.canRestart())
+        .animation(.defaultLinear, values: player.playbackState, player.canReplay())
     }
 
     private func play() {
-        if player.canRestart() {
-            player.restart()
+        if player.canReplay() {
+            player.replay()
         }
         else {
             player.togglePlayPause()

--- a/Sources/Player/Player+Replay.swift
+++ b/Sources/Player/Player+Replay.swift
@@ -7,17 +7,18 @@
 import Foundation
 
 public extension Player {
-    /// Checks whether the player has finished playing its content and can be restarted.
+    /// Checks whether the player has finished playing and its content can be played again from the start.
     ///
     /// - Returns: `true` if possible.
-    func canRestart() -> Bool {
+    func canReplay() -> Bool {
         guard !storedItems.isEmpty else { return false }
         return currentItem.smoothPlayerItem(in: storedItems) == nil
     }
 
-    /// Restarts playback if possible.
-    func restart() {
-        guard canRestart() else { return }
+    /// Replays the content from the start, resuming playback automatically.
+    func replay() {
+        guard canReplay() else { return }
+        play()
         try? setCurrentIndex(0)
     }
 }

--- a/Tests/PlayerTests/Player/ReplayChecksTests.swift
+++ b/Tests/PlayerTests/Player/ReplayChecksTests.swift
@@ -10,26 +10,26 @@ import Foundation
 import Nimble
 import Streams
 
-final class RestartTests: TestCase {
+final class ReplayChecksTests: TestCase {
+    func testEmptyPlayer() {
+        let player = Player()
+        expect(player.canReplay()).to(beFalse())
+    }
+
     func testWithOneGoodItem() {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
-        player.restart()
-        expect(player.currentIndex).to(equal(0))
+        expect(player.canReplay()).to(beFalse())
     }
 
     func testWithOneGoodItemPlayedEntirely() {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
         player.play()
-        expect(player.currentIndex).toEventually(beNil())
-        player.restart()
-        expect(player.currentIndex).toEventually(equal(0))
+        expect(player.canReplay()).toEventually(beTrue())
     }
 
     func testWithOneBadItem() {
         let player = Player(item: .simple(url: Stream.unavailable.url))
-        expect(player.currentIndex).toEventually(beNil())
-        player.restart()
-        expect(player.currentIndex).toEventually(equal(0))
+        expect(player.canReplay()).toEventually(beTrue())
     }
 
     func testWithManyGoodItems() {
@@ -38,9 +38,7 @@ final class RestartTests: TestCase {
             .simple(url: Stream.shortOnDemand.url)
         ])
         player.play()
-        expect(player.currentIndex).toEventually(equal(1))
-        player.restart()
-        expect(player.currentIndex).to(equal(1))
+        expect(player.canReplay()).toEventually(beTrue())
     }
 
     func testWithManyBadItems() {
@@ -49,9 +47,7 @@ final class RestartTests: TestCase {
             .simple(url: Stream.unavailable.url)
         ])
         player.play()
-        expect(player.currentIndex).toEventually(beNil())
-        player.restart()
-        expect(player.currentIndex).to(equal(0))
+        expect(player.canReplay()).toEventually(beTrue())
     }
 
     func testWithOneGoodItemAndOneBadItem() {
@@ -60,8 +56,6 @@ final class RestartTests: TestCase {
             .simple(url: Stream.unavailable.url)
         ])
         player.play()
-        expect(player.currentIndex).toEventually(beNil())
-        player.restart()
-        expect(player.currentIndex).to(equal(0))
+        expect(player.canReplay()).toEventually(beTrue())
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves the semantics of the existing `restart` API so that playback is automatically resumed if needed. Though we have decided that usually no change of playback rate should occur outside of `play` and `pause` APIs (e.g. during seeks), for the `restart` API  I think this totally makes sense and is surprising otherwise, in a bad way:

- If the video player is sent to the background (with background video playback not enabled) playback will be automatically paused by the system. When resuming the app to the foreground calling `restart` is not resuming playback. This does not make sense IMHO since the end state where `canRestart` is `true` can only be reached with a player which is actually playing. There should therefore be some continuity in the behavior, namely that the player should be playing after calling `restart`. This way the user will never be surprised or forced to press on a play button after having pressed on a restart button.
- If the `pause` API is called when the player is in a restartable state the behavior is the same, leading to identical confusion.

For this reason I suggest we always resume playback if needed when restarting playback. To make the semantics clear I also propose we rename `restart` as `replay`.

# Alternatives

- If we think that being able to rewind the player in a paused state is useful we can add a parameter which tells if the player should pause or resume playback after rewind (but we should never keep the current state IMHO since this can be surprising in a bad way). In this case we could e.g. use the `rewind` naming and add a `resumeIfNeed` Boolean parameter (with `true` as default).
- We could also decide that, since the player finished playing, it reached a kind of paused state. In this case we could always pause when restarting (having the API called `restart` or `rewind` would probably be better), forcing all integrations to call `play` if playback must be resumed after a restart.

# Changes made

- Rename `restart` and `canRestart` as `replay` and `canReplay` respectively.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
