### PR TITLE
Add audio tracks and subtitles analytics

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -13,6 +13,7 @@ public struct CommandersActLabels: Decodable {
     private let _media_position: String?
     private let _media_timeshift: String?
     private let _media_volume: String?
+    private let _media_subtitles_on: String?
 
     let event_name: String?
     let listener_session_id: String?
@@ -96,6 +97,18 @@ public struct CommandersActLabels: Decodable {
         extract(\._media_volume)
     }
 
+    /// The value of `media_subtitles_on`.
+    public var media_subtitles_on: Bool? {
+        // swiftlint:disable:previous discouraged_optional_boolean
+        extract(\._media_subtitles_on)
+    }
+
+    /// The value of `media_subtitle_selection`.
+    public var media_subtitle_selection: String?
+
+    /// The value of `media_audio_track`.
+    public var media_audio_track: String?
+
     private func extract<T>(_ keyPath: KeyPath<Self, String?>) -> T? where T: LosslessStringConvertible {
         guard let value = self[keyPath: keyPath] else { return nil }
         return .init(value)
@@ -104,6 +117,10 @@ public struct CommandersActLabels: Decodable {
 
 private extension CommandersActLabels {
     enum CodingKeys: String, CodingKey {
+        case _media_position = "media_position"
+        case _media_timeshift = "media_timeshift"
+        case _media_volume = "media_volume"
+        case _media_subtitles_on = "media_subtitles_on"
         case event_name
         case listener_session_id
         case media_title
@@ -126,8 +143,7 @@ private extension CommandersActLabels {
         case content_title
         case media_player_display
         case media_player_version
-        case _media_position = "media_position"
-        case _media_timeshift = "media_timeshift"
-        case _media_volume = "media_volume"
+        case media_subtitle_selection
+        case media_audio_track
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -95,6 +95,15 @@ private extension CommandersActTracker {
         return Int(AVAudioSession.sharedInstance().outputVolume * 100)
     }
 
+    private func audioTrack(for player: Player) -> String {
+        switch player.currentMediaOption(for: .audible) {
+        case let .on(option):
+            return option.locale?.language.languageCode?.identifier.uppercased() ?? "UND"
+        default:
+            return "UND"
+        }
+    }
+
     private func bitrate(for player: Player) -> Int {
         guard let event = player.systemPlayer.currentItem?.accessLog()?.events.last else { return 0 }
         return Int(max(event.indicatedBitrate, 0))
@@ -104,7 +113,8 @@ private extension CommandersActTracker {
         metadata.labels.merging([
             "media_player_display": "Pillarbox",
             "media_player_version": Player.version,
-            "media_volume": "\(volume(for: player))"
+            "media_volume": "\(volume(for: player))",
+            "media_audio_track": "\(audioTrack(for: player))"
         ]) { _, new in new }
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -104,11 +104,6 @@ private extension CommandersActTracker {
         }
     }
 
-    private func bitrate(for player: Player) -> Int {
-        guard let event = player.systemPlayer.currentItem?.accessLog()?.events.last else { return 0 }
-        return Int(max(event.indicatedBitrate, 0))
-    }
-
     func labels(for player: Player) -> [String: String] {
         metadata.labels.merging([
             "media_player_display": "Pillarbox",

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -104,12 +104,22 @@ private extension CommandersActTracker {
         }
     }
 
+    private func areSubtitlesEnabled(for player: Player) -> Bool {
+        switch player.currentMediaOption(for: .legible) {
+        case let .on(option):
+            return !option.hasMediaCharacteristic(.containsOnlyForcedSubtitles)
+        default:
+            return false
+        }
+    }
+
     func labels(for player: Player) -> [String: String] {
         metadata.labels.merging([
             "media_player_display": "Pillarbox",
             "media_player_version": Player.version,
             "media_volume": "\(volume(for: player))",
-            "media_audio_track": "\(audioTrack(for: player))"
+            "media_audio_track": "\(audioTrack(for: player))",
+            "media_subtitles_on": "\(areSubtitlesEnabled(for: player))"
         ]) { _, new in new }
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -134,4 +134,29 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             player.pause()
         }
     }
+
+    func testSubtitlesOn() {
+        let player = Player(item: .simple(
+            url: Stream.onDemandWithOptions.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                CommandersActTracker.adapter { _ in
+                    .test(streamType: .onDemand)
+                }
+            ]
+        ))
+
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventuallyNot(equal(.off))
+
+        expectAtLeastHits(
+            .pause { labels in
+                expect(labels.media_subtitles_on).to(beTrue())
+            }
+        ) {
+            player.pause()
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -146,14 +146,14 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             ]
         ))
 
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         player.play()
         expect(player.playbackState).toEventually(equal(.playing))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventuallyNot(equal(.off))
 
         expectAtLeastHits(
             .pause { labels in
                 expect(labels.media_subtitles_on).to(beTrue())
+                expect(labels.media_subtitle_selection).to(equal("FR"))
             }
         ) {
             player.pause()

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -86,7 +86,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
         }
     }
 
-    func testMediaOptions() {
+    func testAudioTrack() {
         let player = Player(item: .simple(
             url: Stream.onDemandWithOptions.url,
             metadata: AssetMetadataMock(),
@@ -104,6 +104,31 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
         expectAtLeastHits(
             .pause { labels in
                 expect(labels.media_audio_track).to(equal("FR"))
+            }
+        ) {
+            player.pause()
+        }
+    }
+
+    func testSubtitlesOff() {
+        let player = Player(item: .simple(
+            url: Stream.onDemandWithOptions.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                CommandersActTracker.adapter { _ in
+                    .test(streamType: .onDemand)
+                }
+            ]
+        ))
+
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+        player.select(mediaOption: .off, for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+
+        expectAtLeastHits(
+            .pause { labels in
+                expect(labels.media_subtitles_on).to(beFalse())
             }
         ) {
             player.pause()

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -97,8 +97,8 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             ]
         ))
 
-        player.play()
         player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.play()
         expect(player.playbackState).toEventually(equal(.playing))
 
         expectAtLeastHits(

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -21,6 +21,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_title).to(equal("name"))
+                expect(labels.media_audio_track).to(equal("UND"))
             }
         ) {
              player = Player(item: .simple(
@@ -57,6 +58,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_player_version).notTo(beEmpty())
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_title).to(equal("name"))
+                expect(labels.media_audio_track).to(equal("UND"))
             }
         ) {
             player = nil
@@ -81,6 +83,30 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             ))
             player?.isMuted = true
             player?.play()
+        }
+    }
+
+    func testMediaOptions() {
+        let player = Player(item: .simple(
+            url: Stream.onDemandWithOptions.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                CommandersActTracker.adapter { _ in
+                    .test(streamType: .onDemand)
+                }
+            ]
+        ))
+
+        player.play()
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        expectAtLeastHits(
+            .pause { labels in
+                expect(labels.media_audio_track).to(equal("FR"))
+            }
+        ) {
+            player.pause()
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to send the analytics related to audio tracks and subtitles to **CommadersAct**.

# Changes made

- The following labels are now sent: 
   - `media_audio_track`
   - `media_subtitles_on` 
   - `media_subtitle_selection`

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
