### PR TITLE
Fix media composition parsing 

### DIFF
--- a/Sources/CoreBusiness/Model/Chapter.swift
+++ b/Sources/CoreBusiness/Model/Chapter.swift
@@ -11,13 +11,13 @@ public struct Chapter: Decodable {
     enum CodingKeys: String, CodingKey {
         case _analyticsData = "analyticsData"
         case _analyticsMetadata = "analyticsMetadata"
+        case _resources = "resourceList"
         case blockingReason = "blockReason"
         case contentType = "type"
         case date
         case description
         case endDate = "validTo"
         case imageUrl
-        case resources = "resourceList"
         case startDate = "validFrom"
         case title
         case urn
@@ -46,7 +46,9 @@ public struct Chapter: Decodable {
     public let date: Date
 
     /// The available resources.
-    public let resources: [Resource]
+    public var resources: [Resource] {
+        _resources ?? []
+    }
 
     /// The date at which the content is made available.
     public let startDate: Date?
@@ -68,6 +70,8 @@ public struct Chapter: Decodable {
     private let _analyticsData: [String: String]?
     // swiftlint:disable:next discouraged_optional_collection
     private let _analyticsMetadata: [String: String]?
+    // swiftlint:disable:next discouraged_optional_collection
+    private let _resources: [Resource]?
 
     /// Returns whether the content is blocked for some reason.
     /// 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to fix a parsing issue with our Media Composition.

# Changes made

- The chapter resources (`resourceList`) are now optional.
- A computer var (`resources`) has been added to manage the optionality.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
