### PR TITLE
Add support for user consent

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -55,10 +55,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
 extension AppDelegate: AnalyticsDataSource {
     var comScoreGlobals: ComScoreGlobals {
-        .init(consent: .unknown, labels: [:])
+        .init(consent: .unknown, labels: [
+           "demo_key": "demo_value"
+        ])
     }
 
     var commandersActGlobals: CommandersActGlobals {
-        .init(consentServices: ["service1", "service2", "service3"], labels: [:])
+        .init(consentServices: ["service1", "service2", "service3"], labels: [
+            "demo_key": "demo_value"
+        ])
     }
 }

--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -49,6 +49,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             sourceKey: "39ae8f94-595c-4ca4-81f7-fb7748bd3f04",
             appSiteName: "pillarbox-demo-apple"
         )
-        try? Analytics.shared.start(with: configuration)
+        try? Analytics.shared.start(with: configuration, dataSource: self)
+    }
+}
+
+extension AppDelegate: AnalyticsDataSource {
+    var comScoreGlobals: ComScoreGlobals {
+        .init(consent: .unknown, labels: [:])
+    }
+
+    var commandersActGlobals: CommandersActGlobals {
+        .init(consentServices: ["service1", "service2", "service3"], labels: [:])
     }
 }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -49,6 +49,10 @@ public class Analytics {
         PackageInfo.version
     }
 
+    var comScoreGlobals: ComScoreGlobals? {
+        dataSource?.comScoreGlobals
+    }
+
     private var configuration: Configuration?
 
     private let comScoreService = ComScoreService()
@@ -75,7 +79,7 @@ public class Analytics {
 
         UIViewController.setupViewControllerTracking()
 
-        comScoreService.start(with: configuration)
+        comScoreService.start(with: configuration, globals: dataSource?.comScoreGlobals)
         commandersActService.start(with: configuration)
     }
 

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -54,7 +54,7 @@ public class Analytics {
     private let comScoreService = ComScoreService()
     private let commandersActService = CommandersActService()
 
-    weak var dataSource: AnalyticsDataSource?
+    private weak var dataSource: AnalyticsDataSource?
 
     private init() {}
 
@@ -89,13 +89,17 @@ public class Analytics {
         commandersAct commandersActPageView: CommandersActPageView
     ) {
         comScoreService.trackPageView(comScorePageView)
-        commandersActService.trackPageView(commandersActPageView)
+        commandersActService.trackPageView(
+            commandersActPageView.merging(globals: dataSource?.commandersActGlobals)
+        )
     }
 
     /// Sends an event.
     /// 
     /// - Parameter commandersAct: Commanders Act event data
     public func sendEvent(commandersAct commandersActEvent: CommandersActEvent) {
-        commandersActService.sendEvent(commandersActEvent)
+        commandersActService.sendEvent(
+            commandersActEvent.merging(globals: dataSource?.commandersActGlobals)
+        )
     }
 }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -88,7 +88,9 @@ public class Analytics {
         comScore comScorePageView: ComScorePageView,
         commandersAct commandersActPageView: CommandersActPageView
     ) {
-        comScoreService.trackPageView(comScorePageView)
+        comScoreService.trackPageView(
+            comScorePageView.merging(globals: dataSource?.comScoreGlobals)
+        )
         commandersActService.trackPageView(
             commandersActPageView.merging(globals: dataSource?.commandersActGlobals)
         )

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -54,6 +54,8 @@ public class Analytics {
     private let comScoreService = ComScoreService()
     private let commandersActService = CommandersActService()
 
+    weak var dataSource: AnalyticsDataSource?
+
     private init() {}
 
     /// Starts analytics with the specified configuration.
@@ -64,11 +66,12 @@ public class Analytics {
     /// delegate method implementation, otherwise the behavior is undefined.
     ///
     /// The method throws if called more than once.
-    public func start(with configuration: Configuration) throws {
+    public func start(with configuration: Configuration, dataSource: AnalyticsDataSource? = nil) throws {
         guard self.configuration == nil else {
             throw AnalyticsError.alreadyStarted
         }
         self.configuration = configuration
+        self.dataSource = dataSource
 
         UIViewController.setupViewControllerTracking()
 

--- a/Sources/Analytics/AnalyticsDataSource.swift
+++ b/Sources/Analytics/AnalyticsDataSource.swift
@@ -1,0 +1,12 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+public protocol AnalyticsDataSource: AnyObject {
+    var comScoreGlobals: ComScoreGlobals { get }
+    var commandersActGlobals: CommandersActGlobals { get }
+}

--- a/Sources/Analytics/AnalyticsDataSource.swift
+++ b/Sources/Analytics/AnalyticsDataSource.swift
@@ -6,7 +6,10 @@
 
 import Foundation
 
+/// A protocol for analytics data sources.
 public protocol AnalyticsDataSource: AnyObject {
+    /// comScore global labels.
     var comScoreGlobals: ComScoreGlobals { get }
+    /// Commanders Act global labels.
     var commandersActGlobals: CommandersActGlobals { get }
 }

--- a/Sources/Analytics/ComScore/ComScoreGlobals.swift
+++ b/Sources/Analytics/ComScore/ComScoreGlobals.swift
@@ -7,21 +7,25 @@
 import Foundation
 
 /// An enum representing the user consent options for ComScore.
-public enum ComScoreConsent {
+public enum ComScoreConsent: String {
     /// The user's consent status is unknown.
-    case unknown
+    case unknown = ""
 
     /// The user has accepted ComScore analytics.
-    case accepted
+    case accepted = "1"
 
     /// The user has declined ComScore analytics.
-    case declined
+    case declined = "0"
 }
 
 /// A struct representing the global labels to send to ComScore.
 public struct ComScoreGlobals {
     let consent: ComScoreConsent
     let labels: [String: String]
+
+    var allLabels: [String: String] {
+        labels.merging(["cs_ucfr": consent.rawValue]) { _, new in new }
+    }
 
     /// Creates a ComScore global labels.
     /// - Parameters:

--- a/Sources/Analytics/ComScore/ComScoreGlobals.swift
+++ b/Sources/Analytics/ComScore/ComScoreGlobals.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// An enum representing the user consent options for ComScore.
+public enum ComScoreConsent {
+    /// The user's consent status is unknown.
+    case unknown
+
+    /// The user has accepted ComScore analytics.
+    case accepted
+
+    /// The user has declined ComScore analytics.
+    case declined
+}
+
+/// A struct representing the global labels to send to ComScore.
+public struct ComScoreGlobals {
+    let consent: ComScoreConsent
+    let labels: [String: String]
+
+    /// Creates a ComScore global labels.
+    /// - Parameters:
+    ///   - consent: The user's consent status.
+    ///   - labels: Additional information associated with the global labels.
+    public init(consent: ComScoreConsent, labels: [String: String]) {
+        self.consent = consent
+        self.labels = labels
+    }
+}

--- a/Sources/Analytics/ComScore/ComScoreGlobals.swift
+++ b/Sources/Analytics/ComScore/ComScoreGlobals.swift
@@ -20,19 +20,13 @@ public enum ComScoreConsent: String {
 
 /// A struct representing the global labels to send to ComScore.
 public struct ComScoreGlobals {
-    let consent: ComScoreConsent
     let labels: [String: String]
-
-    var allLabels: [String: String] {
-        labels.merging(["cs_ucfr": consent.rawValue]) { _, new in new }
-    }
 
     /// Creates a ComScore global labels.
     /// - Parameters:
     ///   - consent: The user's consent status.
     ///   - labels: Additional information associated with the global labels.
     public init(consent: ComScoreConsent, labels: [String: String]) {
-        self.consent = consent
-        self.labels = labels
+        self.labels = labels.merging(["cs_ucfr": consent.rawValue]) { _, new in new }
     }
 }

--- a/Sources/Analytics/ComScore/ComScoreGlobals.swift
+++ b/Sources/Analytics/ComScore/ComScoreGlobals.swift
@@ -6,23 +6,24 @@
 
 import Foundation
 
-/// An enum representing the user consent options for ComScore.
+/// An enum representing the user consent options for comScore.
 public enum ComScoreConsent: String {
     /// The user's consent status is unknown.
     case unknown = ""
 
-    /// The user has accepted ComScore analytics.
+    /// The user has accepted comScore analytics.
     case accepted = "1"
 
-    /// The user has declined ComScore analytics.
+    /// The user has declined comScore analytics.
     case declined = "0"
 }
 
-/// A struct representing the global labels to send to ComScore.
+/// A struct representing global labels to send to comScore.
 public struct ComScoreGlobals {
     let labels: [String: String]
 
-    /// Creates a ComScore global labels.
+    /// Creates comScore global labels.
+    ///
     /// - Parameters:
     ///   - consent: The user's consent status.
     ///   - labels: Additional information associated with the global labels.

--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -45,6 +45,11 @@ public struct ComScoreLabels {
         extract()
     }
 
+    /// The value of `cs_ucfr` (user consent).
+    public var cs_ucfr: String? {
+        extract()
+    }
+
     // MARK: Page view labels
 
     /// The value of `c8` (page title).

--- a/Sources/Analytics/ComScore/ComScorePageView.swift
+++ b/Sources/Analytics/ComScore/ComScorePageView.swift
@@ -13,11 +13,11 @@ public struct ComScorePageView {
 
     /// Creates a comScore page view.
     ///
-    /// Custom labels which might accidentally override official labels will be ignored.
-    ///
     /// - Parameters:
     ///   - name: The page name.
     ///   - labels: Additional information associated with the page view.
+    ///
+    /// Custom labels which might accidentally override official labels will be ignored.
     public init(name: String, labels: [String: String] = [:]) {
         assert(!name.isBlank, "A name is required")
         self.name = name

--- a/Sources/Analytics/ComScore/ComScorePageView.swift
+++ b/Sources/Analytics/ComScore/ComScorePageView.swift
@@ -23,4 +23,10 @@ public struct ComScorePageView {
         self.name = name
         self.labels = labels
     }
+
+    func merging(globals: ComScoreGlobals?) -> Self {
+        guard let globals else { return self }
+        let labels = labels.merging(globals.allLabels) { _, new in new }
+        return .init(name: name, labels: labels)
+    }
 }

--- a/Sources/Analytics/ComScore/ComScorePageView.swift
+++ b/Sources/Analytics/ComScore/ComScorePageView.swift
@@ -26,7 +26,7 @@ public struct ComScorePageView {
 
     func merging(globals: ComScoreGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = labels.merging(globals.allLabels) { _, new in new }
+        let labels = labels.merging(globals.labels) { _, new in new }
         return .init(name: name, labels: labels)
     }
 }

--- a/Sources/Analytics/ComScore/ComScoreService.swift
+++ b/Sources/Analytics/ComScore/ComScoreService.swift
@@ -12,7 +12,7 @@ struct ComScoreService {
         Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
     }
 
-    func start(with configuration: Analytics.Configuration) {
+    func start(with configuration: Analytics.Configuration, globals: ComScoreGlobals?) {
         let publisherConfiguration = SCORPublisherConfiguration { builder in
             guard let builder else { return }
             builder.publisherId = "6036016"
@@ -31,6 +31,9 @@ struct ComScoreService {
                 "mp_brand": configuration.vendor.rawValue,
                 "mp_v": applicationVersion
             ])
+            if let globals {
+                comScoreConfiguration.addStartLabels(globals.allLabels)
+            }
         }
         SCORAnalytics.start()
     }

--- a/Sources/Analytics/ComScore/ComScoreService.swift
+++ b/Sources/Analytics/ComScore/ComScoreService.swift
@@ -32,7 +32,7 @@ struct ComScoreService {
                 "mp_v": applicationVersion
             ])
             if let globals {
-                comScoreConfiguration.addStartLabels(globals.allLabels)
+                comScoreConfiguration.addStartLabels(globals.labels)
             }
         }
         SCORAnalytics.start()

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -99,7 +99,7 @@ public final class ComScoreTracker: PlayerItemTracker {
     private func updateMetadata(with metadata: Metadata) {
         let builder = SCORStreamingContentMetadataBuilder()
         if let globals = Analytics.shared.comScoreGlobals {
-            builder.setCustomLabels(metadata.labels.merging(globals.allLabels) { _, new in new })
+            builder.setCustomLabels(metadata.labels.merging(globals.labels) { _, new in new })
         }
         else {
             builder.setCustomLabels(metadata.labels)

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -98,7 +98,12 @@ public final class ComScoreTracker: PlayerItemTracker {
 
     private func updateMetadata(with metadata: Metadata) {
         let builder = SCORStreamingContentMetadataBuilder()
-        builder.setCustomLabels(metadata.labels)
+        if let globals = Analytics.shared.comScoreGlobals {
+            builder.setCustomLabels(metadata.labels.merging(globals.allLabels) { _, new in new })
+        }
+        else {
+            builder.setCustomLabels(metadata.labels)
+        }
         let contentMetadata = SCORStreamingContentMetadata(builder: builder)
         streamingAnalytics.setMetadata(contentMetadata)
     }

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -29,7 +29,7 @@ public struct CommandersActEvent {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = globals.allLabels.merging(labels) { _, new in new }
+        let labels = labels.merging(globals.allLabels) { _, new in new }
         return .init(name: name, labels: labels)
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -26,4 +26,10 @@ public struct CommandersActEvent {
         self.name = name
         self.labels = labels
     }
+
+    func merging(globals: CommandersActGlobals?) -> Self {
+        guard let globals else { return self }
+        let labels = globals.allLabels.merging(labels) { _, new in new }
+        return .init(name: name, labels: labels)
+    }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -13,11 +13,11 @@ public struct CommandersActEvent {
 
     /// Creates a Commanders Act event.
     ///
-    /// Custom labels which might accidentally override official labels will be ignored.
-    ///
     /// - Parameters:
     ///   - name: The event name.
     ///   - labels: Additional information associated with the event.
+    ///
+    /// Custom labels which might accidentally override official labels will be ignored.
     public init(
         name: String,
         labels: [String: String] = [:]

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -29,7 +29,7 @@ public struct CommandersActEvent {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = labels.merging(globals.allLabels) { _, new in new }
+        let labels = labels.merging(globals.labels) { _, new in new }
         return .init(name: name, labels: labels)
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
@@ -12,7 +12,7 @@ public struct CommandersActGlobals {
     let labels: [String: String]
 
     var allLabels: [String: String] {
-        ["consent_services": consentServices.joined(separator: ",")].merging(labels) { _, new in new }
+        labels.merging(["consent_services": consentServices.joined(separator: ",")]) { _, new in new }
     }
 
     /// Creates a Commanders Act global labels.

--- a/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// A struct representing the global labels to send to Commanders Act.
+public struct CommandersActGlobals {
+    let consentServices: [String]
+    let labels: [String: String]
+
+    /// Creates a Commanders Act global labels.
+    /// - Parameters:
+    ///   - consentServices: The list of service allowed.
+    ///   - labels: Additional information associated with the global labels.
+    public init(consentServices: [String], labels: [String: String]) {
+        self.consentServices = consentServices
+        self.labels = labels
+    }
+}

--- a/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
@@ -6,15 +6,18 @@
 
 import Foundation
 
-/// A struct representing the global labels to send to Commanders Act.
+/// A struct representing global labels to send to Commanders Act.
 public struct CommandersActGlobals {
     let labels: [String: String]
 
-    /// Creates a Commanders Act global labels.
+    /// Creates Commanders Act global labels.
+    /// 
     /// - Parameters:
     ///   - consentServices: The list of service allowed.
     ///   - labels: Additional information associated with the global labels.
     public init(consentServices: [String], labels: [String: String]) {
-        self.labels = labels.merging(["consent_services": consentServices.joined(separator: ",")]) { _, new in new }
+        self.labels = labels.merging([
+            "consent_services": consentServices.joined(separator: ",")
+        ]) { _, new in new }
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
@@ -11,6 +11,10 @@ public struct CommandersActGlobals {
     let consentServices: [String]
     let labels: [String: String]
 
+    var allLabels: [String: String] {
+        ["consent_services": consentServices.joined(separator: ",")].merging(labels) { _, new in new }
+    }
+
     /// Creates a Commanders Act global labels.
     /// - Parameters:
     ///   - consentServices: The list of service allowed.

--- a/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActGlobals.swift
@@ -8,19 +8,13 @@ import Foundation
 
 /// A struct representing the global labels to send to Commanders Act.
 public struct CommandersActGlobals {
-    let consentServices: [String]
     let labels: [String: String]
-
-    var allLabels: [String: String] {
-        labels.merging(["consent_services": consentServices.joined(separator: ",")]) { _, new in new }
-    }
 
     /// Creates a Commanders Act global labels.
     /// - Parameters:
     ///   - consentServices: The list of service allowed.
     ///   - labels: Additional information associated with the global labels.
     public init(consentServices: [String], labels: [String: String]) {
-        self.consentServices = consentServices
-        self.labels = labels
+        self.labels = labels.merging(["consent_services": consentServices.joined(separator: ",")]) { _, new in new }
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -30,6 +30,9 @@ public struct CommandersActLabels: Decodable {
     /// The value of `navigation_device`.
     public let navigation_device: String?
 
+    /// The value of `consent_services`.
+    public let consent_services: String?
+
     // MARK: Page view labels
 
     /// The value of `navigation_property_type`.
@@ -127,6 +130,7 @@ private extension CommandersActLabels {
         case app_library_version
         case navigation_app_site_name
         case navigation_device
+        case consent_services
         case navigation_property_type
         case navigation_bu_distributer
         case navigation_level_0

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -30,4 +30,10 @@ public struct CommandersActPageView {
         self.levels = levels
         self.labels = labels
     }
+
+    func merging(globals: CommandersActGlobals?) -> Self {
+        guard let globals else { return self }
+        let labels = globals.allLabels.merging(labels) { _, new in new }
+        return .init(name: name, type: type, levels: levels, labels: labels)
+    }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -33,7 +33,7 @@ public struct CommandersActPageView {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = labels.merging(globals.allLabels) { _, new in new }
+        let labels = labels.merging(globals.labels) { _, new in new }
         return .init(name: name, type: type, levels: levels, labels: labels)
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -15,13 +15,13 @@ public struct CommandersActPageView {
 
     /// Creates a Commanders Act page view.
     /// 
-    /// Custom labels which might accidentally override official labels will be ignored.
-    /// 
     /// - Parameters:
     ///   - name: The page name.
     ///   - type: The page type (e.g. Article).
     ///   - labels: Additional information associated with the page view.
     ///   - levels: The page levels.
+    ///
+    /// Custom labels which might accidentally override official labels will be ignored.
     public init(name: String, type: String, levels: [String] = [], labels: [String: String] = [:]) {
         assert(!name.isBlank, "A name is required")
         assert(!type.isBlank, "A type is required")

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -33,7 +33,7 @@ public struct CommandersActPageView {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = globals.allLabels.merging(labels) { _, new in new }
+        let labels = labels.merging(globals.allLabels) { _, new in new }
         return .init(name: name, type: type, levels: levels, labels: labels)
     }
 }

--- a/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
@@ -68,7 +68,7 @@ private class ManualMockViewController: UIViewController, PageViewTracking {
 }
 
 final class ComScorePageViewTests: ComScoreTestCase {
-    func testGlobalLabels() {
+    func testGlobals() {
         expectAtLeastHits(
             .view { labels in
                 expect(labels.c2).to(equal("6036016"))
@@ -78,7 +78,7 @@ final class ComScorePageViewTests: ComScoreTestCase {
                 expect(labels.ns_st_mv).to(beNil())
                 expect(labels.mp_brand).to(equal("SRG"))
                 expect(labels.mp_v).notTo(beEmpty())
-                expect(labels.cs_ucfr).notTo(beEmpty())
+                expect(labels.cs_ucfr).to(beEmpty())
             }
         ) {
             Analytics.shared.trackPageView(
@@ -113,10 +113,14 @@ final class ComScorePageViewTests: ComScoreTestCase {
         expectAtLeastHits(
             .view { labels in
                 expect(labels.c8).to(equal("name"))
+                expect(labels.cs_ucfr).to(beEmpty())
             }
         ) {
             Analytics.shared.trackPageView(
-                comScore: .init(name: "name", labels: ["c8": "overridden_title"]),
+                comScore: .init(name: "name", labels: [
+                    "c8": "overridden_title",
+                    "cs_ucfr": "42"
+                ]),
                 commandersAct: .init(name: "name", type: "type")
             )
         }

--- a/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScorePageViewTests.swift
@@ -68,7 +68,7 @@ private class ManualMockViewController: UIViewController, PageViewTracking {
 }
 
 final class ComScorePageViewTests: ComScoreTestCase {
-    func testLabels() {
+    func testGlobalLabels() {
         expectAtLeastHits(
             .view { labels in
                 expect(labels.c2).to(equal("6036016"))
@@ -78,6 +78,7 @@ final class ComScorePageViewTests: ComScoreTestCase {
                 expect(labels.ns_st_mv).to(beNil())
                 expect(labels.mp_brand).to(equal("SRG"))
                 expect(labels.mp_v).notTo(beEmpty())
+                expect(labels.cs_ucfr).notTo(beEmpty())
             }
         ) {
             Analytics.shared.trackPageView(

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerMetadataTests.swift
@@ -33,6 +33,7 @@ final class ComScoreTrackerMetadataTests: ComScoreTestCase {
             .play { labels in
                 expect(labels["meta_1"]).to(equal("custom-1"))
                 expect(labels["meta_2"]).to(equal(42))
+                expect(labels["cs_ucfr"]).to(beEmpty())
             }
         ) {
             player.play()

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -23,7 +23,7 @@ private struct AssetMetadataMock: AssetMetadata {}
 //      Thus, to test end events resulting from tracker deallocation we need to have another event sent within the same
 //      expectation first so that the end event is provided a listener identifier.
 final class ComScoreTrackerTests: ComScoreTestCase {
-    func testMediaPlayerProperties() {
+    func testGlobalProperties() {
         let player = Player(item: .simple(
             url: Stream.onDemand.url,
             metadata: AssetMetadataMock(),
@@ -36,6 +36,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             .play { labels in
                 expect(labels.ns_st_mp).to(equal("Pillarbox"))
                 expect(labels.ns_st_mv).notTo(beEmpty())
+                expect(labels.cs_ucfr).notTo(beEmpty())
             }
         ) {
             player.play()

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -36,7 +36,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             .play { labels in
                 expect(labels.ns_st_mp).to(equal("Pillarbox"))
                 expect(labels.ns_st_mv).notTo(beEmpty())
-                expect(labels.cs_ucfr).notTo(beEmpty())
+                expect(labels.cs_ucfr).to(beEmpty())
             }
         ) {
             player.play()

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -23,7 +23,7 @@ private struct AssetMetadataMock: AssetMetadata {}
 //      Thus, to test end events resulting from tracker deallocation we need to have another event sent within the same
 //      expectation first so that the end event is provided a listener identifier.
 final class ComScoreTrackerTests: ComScoreTestCase {
-    func testGlobalProperties() {
+    func testGlobals() {
         let player = Player(item: .simple(
             url: Stream.onDemand.url,
             metadata: AssetMetadataMock(),

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -11,6 +11,30 @@ import Nimble
 import XCTest
 
 final class CommandersActEventTests: CommandersActTestCase {
+    func testMergingWithGlobals() {
+        let event = CommandersActEvent(
+            name: "name",
+            labels: [
+                "event-label": "event",
+                "common-label": "event"
+            ]
+        )
+        let globals = CommandersActGlobals(
+            consentServices: ["service1,service2,service3"],
+            labels: [
+                "globals-label": "globals",
+                "common-label": "globals"
+            ]
+        )
+
+        expect(event.merging(globals: globals).labels).to(equal([
+            "consent_services": "service1,service2,service3",
+            "globals-label": "globals",
+            "event-label": "event",
+            "common-label": "event"
+        ]))
+    }
+
     func testBlankName() {
         guard nimbleThrowAssertionsAvailable() else { return }
         expect(Analytics.shared.sendEvent(commandersAct: .init(name: " "))).to(throwAssertion())
@@ -36,16 +60,13 @@ final class CommandersActEventTests: CommandersActTestCase {
         }
     }
 
-    func testGlobalLabels() {
+    func testGlobals() {
         expectAtLeastHits(
             .custom(name: "name") { labels in
                 expect(labels.consent_services).to(equal("service1,service2,service3"))
             }
         ) {
-            Analytics.shared.sendEvent(commandersAct: .init(
-                name: "name",
-                labels: ["consent_services": "service1,service2,service3"]
-            ))
+            Analytics.shared.sendEvent(commandersAct: .init(name: "name"))
         }
     }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -71,10 +71,17 @@ final class CommandersActEventTests: CommandersActTestCase {
     }
 
     func testCustomLabelsForbiddenOverrides() {
-        expectAtLeastHits(.custom(name: "name")) {
+        expectAtLeastHits(
+            .custom(name: "name") { labels in
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
+            }
+        ) {
             Analytics.shared.sendEvent(commandersAct: .init(
                 name: "name",
-                labels: ["event_name": "overridden_name"]
+                labels: [
+                    "event_name": "overridden_name",
+                    "consent_services": "service42"
+                ]
             ))
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -36,6 +36,19 @@ final class CommandersActEventTests: CommandersActTestCase {
         }
     }
 
+    func testGlobalLabels() {
+        expectAtLeastHits(
+            .custom(name: "name") { labels in
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
+            }
+        ) {
+            Analytics.shared.sendEvent(commandersAct: .init(
+                name: "name",
+                labels: ["consent_services": "service1,service2,service3"]
+            ))
+        }
+    }
+
     func testCustomLabelsForbiddenOverrides() {
         expectAtLeastHits(.custom(name: "name")) {
             Analytics.shared.sendEvent(commandersAct: .init(

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -31,7 +31,7 @@ final class CommandersActEventTests: CommandersActTestCase {
             "consent_services": "service1,service2,service3",
             "globals-label": "globals",
             "event-label": "event",
-            "common-label": "event"
+            "common-label": "globals"
         ]))
     }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -31,6 +31,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(labels.navigation_app_site_name).to(equal("site"))
                 expect(labels.navigation_property_type).to(equal("app"))
                 expect(labels.navigation_bu_distributer).to(equal("SRG"))
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
             }
         ) {
             Analytics.shared.trackPageView(

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -32,7 +32,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             "consent_services": "service1,service2,service3",
             "globals-label": "globals",
             "pageview-label": "pageview",
-            "common-label": "pageview"
+            "common-label": "globals"
         ]))
     }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -11,6 +11,32 @@ import Nimble
 import XCTest
 
 final class CommandersActPageViewTests: CommandersActTestCase {
+    func testMergingWithGlobals() {
+        let pageView = CommandersActPageView(
+            name: "name",
+            type: "type",
+            levels: [],
+            labels: [
+                "pageview-label": "pageview",
+                "common-label": "pageview"
+            ]
+        )
+        let globals = CommandersActGlobals(
+            consentServices: ["service1,service2,service3"],
+            labels: [
+                "globals-label": "globals",
+                "common-label": "globals"
+            ]
+        )
+
+        expect(pageView.merging(globals: globals).labels).to(equal([
+            "consent_services": "service1,service2,service3",
+            "globals-label": "globals",
+            "pageview-label": "pageview",
+            "common-label": "pageview"
+        ]))
+    }
+
     func testLabels() {
         expectAtLeastHits(
             .page_view { labels in
@@ -119,6 +145,19 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                     type: "type",
                     labels: ["media_player_display": "value"]
                 )
+            )
+        }
+    }
+
+    func testGlobals() {
+        expectAtLeastHits(
+            .page_view { labels in
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
+            }
+        ) {
+            Analytics.shared.trackPageView(
+                comScore: .init(name: "name"),
+                commandersAct: .init(name: "name", type: "type")
             )
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -166,6 +166,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         expectAtLeastHits(
             .page_view { labels in
                 expect(labels.page_name).to(equal("name"))
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
             }
         ) {
             Analytics.shared.trackPageView(
@@ -173,7 +174,10 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 commandersAct: .init(
                     name: "name",
                     type: "type",
-                    labels: ["page_name": "overridden_title"]
+                    labels: [
+                        "page_name": "overridden_title",
+                        "consent_services": "service42"
+                    ]
                 )
             )
         }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -15,7 +15,6 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         let pageView = CommandersActPageView(
             name: "name",
             type: "type",
-            levels: [],
             labels: [
                 "pageview-label": "pageview",
                 "common-label": "pageview"

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -22,6 +22,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_title).to(equal("name"))
                 expect(labels.media_audio_track).to(equal("UND"))
+                expect(labels.consent_services).to(equal("service1,service2,service3"))
             }
         ) {
              player = Player(item: .simple(

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -9,12 +9,24 @@ import Foundation
 import Nimble
 import XCTest
 
+private final class TestCaseDataSource: AnalyticsDataSource {
+    var comScoreGlobals: ComScoreGlobals {
+        .init(consent: .unknown, labels: [:])
+    }
+
+    var commandersActGlobals: CommandersActGlobals {
+        .init(consentServices: ["service1", "service2", "service3"], labels: [:])
+    }
+}
+
 /// A simple test suite with more tolerant Nimble settings. Beware that `toAlways` and `toNever` expectations appearing
 /// in tests will use the same value by default and should likely always provide an explicit `until` parameter.
 class TestCase: XCTestCase {
+    private static let dataSource = TestCaseDataSource()
+
     override class func setUp() {
         PollingDefaults.timeout = .seconds(20)
-        try? Analytics.shared.start(with: .init(vendor: .SRG, sourceKey: "source", appSiteName: "site"))
+        try? Analytics.shared.start(with: .init(vendor: .SRG, sourceKey: "source", appSiteName: "site"), dataSource: dataSource)
     }
 
     override class func tearDown() {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to add the support of the user consent for **comScore** and **Commanders Act**

# Changes made

- `AnalyticsDataSource`, `ComScoreGlobals` and `CommandersGlobals` have been introduced.
- The analytics start method takes an analytics data source as parameter.
- Global labels are merged with labels for page views and events.
- `TestCaseDataSource` has been introduced for test purpose.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
