### PR TITLE
Translate packages

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0EA8E5D52A6D9AC700AB33BB /* YouTubeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA8E5D42A6D9AC700AB33BB /* YouTubeError.swift */; };
 		0ECC5AD52A517A4C0064E701 /* PlaybackSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */; };
 		0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */ = {isa = PBXBuildFile; productRef = 0EF42CB529AE513400553165 /* SRGDataProviderCombine */; };
+		6F02B3092AB870AD002D15DB /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6F02B3082AB870AD002D15DB /* Localizable.xcstrings */; };
 		6F0B2E852A40EBAC00B69675 /* RouterDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0B2E842A40EBAC00B69675 /* RouterDestination.swift */; };
 		6F0B2E8B2A40EE0700B69675 /* ContentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0B2E8A2A40EE0700B69675 /* ContentList.swift */; };
 		6F59E87929CF31E10093E6FB /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84029CF31E10093E6FB /* SearchView.swift */; };
@@ -82,6 +83,7 @@
 		0EA8E5D42A6D9AC700AB33BB /* YouTubeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeError.swift; sourceTree = "<group>"; };
 		0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackSlider.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F02B3082AB870AD002D15DB /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F0B2E842A40EBAC00B69675 /* RouterDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterDestination.swift; sourceTree = "<group>"; };
 		6F0B2E8A2A40EE0700B69675 /* ContentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentList.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				6F917C082887EA8E004113BA /* Assets.xcassets */,
+				6F02B3082AB870AD002D15DB /* Localizable.xcstrings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -507,6 +510,10 @@
 			knownRegions = (
 				en,
 				Base,
+				fr,
+				de,
+				it,
+				rm,
 			);
 			mainGroup = 6F05B8CC2887E934005D75E3;
 			packageReferences = (
@@ -531,6 +538,7 @@
 			files = (
 				6F917C112887EA8E004113BA /* Preview Assets.xcassets in Resources */,
 				6F917C0E2887EA8E004113BA /* Assets.xcassets in Resources */,
+				6F02B3092AB870AD002D15DB /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -1,0 +1,191 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    " in Switzerland" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "Active" : {
+
+    },
+    "Add" : {
+
+    },
+    "Add a stream to the playlist" : {
+
+    },
+    "Allows external playback" : {
+
+    },
+    "Application" : {
+
+    },
+    "Audiovisual background policy" : {
+
+    },
+    "Automatic" : {
+
+    },
+    "Both" : {
+
+    },
+    "Bottom" : {
+
+    },
+    "Cancel" : {
+
+    },
+    "Clear URL cache" : {
+
+    },
+    "Content displayed" : {
+
+    },
+    "Continues if possible" : {
+
+    },
+    "Custom" : {
+
+    },
+    "Debugging" : {
+
+    },
+    "Deferred" : {
+
+    },
+    "Displays touches for presentation purposes." : {
+
+    },
+    "Embeddings" : {
+
+    },
+    "Enter URL or URN" : {
+
+    },
+    "Examples" : {
+
+    },
+    "Immediate" : {
+
+    },
+    "Improves playlist navigation so that it feels more natural." : {
+
+    },
+    "Layout" : {
+
+    },
+    "Layouts" : {
+
+    },
+    "Lists" : {
+
+    },
+    "Lists (%@)" : {
+
+    },
+    "LIVE" : {
+
+    },
+    "Made with " : {
+
+    },
+    "Mode" : {
+
+    },
+    "Opt-in features" : {
+
+    },
+    "Pauses" : {
+
+    },
+    "Play" : {
+
+    },
+    "Player" : {
+
+    },
+    "Playlists" : {
+
+    },
+    "Presenter mode" : {
+
+    },
+    "Search" : {
+
+    },
+    "Seek behavior" : {
+
+    },
+    "Server" : {
+
+    },
+    "Settings" : {
+
+    },
+    "Showcase" : {
+
+    },
+    "Simulate memory warning" : {
+
+    },
+    "Smart navigation" : {
+
+    },
+    "Stop" : {
+
+    },
+    "System" : {
+
+    },
+    "System player (using AVPlayer)" : {
+
+    },
+    "System player (using Pillarbox)" : {
+
+    },
+    "Top" : {
+
+    },
+    "Tracking" : {
+
+    },
+    "Use a proxy tool to observe events." : {
+
+    },
+    "Version %@ Build %@, Player %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %1$@ Build %2$@, Player %3$@"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,9 @@ let package = Package(
             dependencies: [
                 .target(name: "Analytics")
             ],
+            resources: [
+                .process("Resources")
+            ],
             plugins: [
                 .plugin(name: "PackageInfoPlugin")
             ]
@@ -77,6 +80,9 @@ let package = Package(
                 .target(name: "Core"),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "TimelaneCombine", package: "TimelaneCombine")
+            ],
+            resources: [
+                .process("Resources")
             ],
             plugins: [
                 .plugin(name: "PackageInfoPlugin")

--- a/Sources/CoreBusiness/DataProvider/Errors.swift
+++ b/Sources/CoreBusiness/DataProvider/Errors.swift
@@ -21,7 +21,8 @@ enum TokenError: Error {
 struct DataError: LocalizedError {
     static var noResourceAvailable: Self {
         .init(errorDescription: NSLocalizedString(
-            "No playable resources could be found",
+            "No playable resources could be found.",
+            bundle: .module,
             comment: "Generic error message returned when no playable resources could be found"
         ))
     }
@@ -29,6 +30,7 @@ struct DataError: LocalizedError {
     static var malformedData: Self {
         .init(errorDescription: NSLocalizedString(
             "The data is invalid",
+            bundle: .module,
             comment: "Generic error message returned when data is invalid"
         ))
     }

--- a/Sources/CoreBusiness/Extensions/HTTPURLResponse.swift
+++ b/Sources/CoreBusiness/Extensions/HTTPURLResponse.swift
@@ -21,7 +21,7 @@ extension HTTPURLResponse {
             return description.capitalizingFirstLetter()
         }
         else {
-            return NSLocalizedString("Unknown error", comment: "Generic error message")
+            return NSLocalizedString("Unknown error", bundle: .module, comment: "Generic error message")
         }
     }
 }

--- a/Sources/CoreBusiness/Model/BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/BlockingReason.swift
@@ -38,41 +38,49 @@ public enum BlockingReason: String, Decodable {
         case .ageRating12:
             return NSLocalizedString(
                 "To protect children this content is only available between 8PM and 6AM.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .ageRating18:
             return NSLocalizedString(
                 "To protect children this content is only available between 10PM and 5AM.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .commercial:
             return NSLocalizedString(
                 "This commercial content is not available.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .endDate:
             return NSLocalizedString(
                 "This content is not available anymore.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .geoblocked:
             return NSLocalizedString(
                 "This content is not available outside Switzerland.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .legal:
             return NSLocalizedString(
                 "This content is not available due to legal restrictions.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .startDate:
             return NSLocalizedString(
-                "This content is not available yet. Please try again later.",
+                "This content is not available yet.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         case .unknown:
             return NSLocalizedString(
                 "This content is not available.",
+                bundle: .module,
                 comment: "Blocking reason description message"
             )
         }

--- a/Sources/CoreBusiness/Resources/Localizable.xcstrings
+++ b/Sources/CoreBusiness/Resources/Localizable.xcstrings
@@ -1,0 +1,315 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "No playable resources could be found." : {
+      "comment" : "Generic error message returned when no playable resources could be found",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No playable resources could be found."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune ressource jouable n'a pu être trouvée."
+          }
+        }
+      }
+    },
+    "The data is invalid" : {
+      "comment" : "Generic error message returned when data is invalid",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The data is invalid."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données sont invalides."
+          }
+        }
+      }
+    },
+    "This commercial content is not available." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Werbe-Inhalt ist nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This commercial content is not available."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n’est actuellement pas disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo contenuto commerciale non è disponibile."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium commerzial n'è betg disponibel."
+          }
+        }
+      }
+    },
+    "This content is not available anymore." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist nicht mehr verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content is not available anymore."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n’est plus disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo media non è più disponibile."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium n'è betg pli disponibel."
+          }
+        }
+      }
+    },
+    "This content is not available due to legal restrictions." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist aus rechtlichen Gründen nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content is not available due to legal restrictions."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu a été retiré par décision de justice."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo media non è disponibile a causa di restrizioni legali."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium n'è betg disponibel perquei ch'el è scadì."
+          }
+        }
+      }
+    },
+    "This content is not available outside Switzerland." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist ausserhalb der Schweiz nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content is not available outside Switzerland."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n'est pas disponible hors de Suisse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo media non è disponibile fuori dalla Svizzera."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium n'è betg disponibel ordaifer la Svizra."
+          }
+        }
+      }
+    },
+    "This content is not available yet." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist noch nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content is not available yet."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n’est pas encore disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo media non è ancora disponibile."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium n'è betg anc disponibel."
+          }
+        }
+      }
+    },
+    "This content is not available." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content is not available."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n’est pas disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo media non è disponibile."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest medium n'è betg disponibel."
+          }
+        }
+      }
+    },
+    "To protect children this content is only available between 8PM and 6AM." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist aus Gründen des Jugendschutzes nur zwischen 20:00 und 6:00 Uhr verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To protect children this content is only available between 8PM and 6AM."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n'est disponible qu'entre 20h et 6h afin de protéger le jeune public."
+          }
+        }
+      }
+    },
+    "To protect children this content is only available between 10PM and 5AM." : {
+      "comment" : "Blocking reason description message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist aus Gründen des Jugendschutzes nur zwischen 22:00 und 5:00 Uhr verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To protect children this content is only available between 10PM and 5AM."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu n'est disponible qu'entre 22h et 5h afin de protéger le jeune public."
+          }
+        }
+      }
+    },
+    "Unknown error" : {
+      "comment" : "Generic error message",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur inconnue"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/Player/MediaSelection/MediaSelectionOption.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionOption.swift
@@ -25,9 +25,9 @@ public enum MediaSelectionOption: Hashable {
     public var displayName: String {
         switch self {
         case .automatic:
-            return NSLocalizedString("Auto (Recommended)", comment: "Subtitle selection option")
+            return NSLocalizedString("Auto (Recommended)", bundle: .module, comment: "Subtitle selection option")
         case .off:
-            return NSLocalizedString("Off", comment: "Subtitle selection option")
+            return NSLocalizedString("Off", bundle: .module, comment: "Subtitle selection option")
         case let .on(option):
             return option.displayName
         }

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -1,0 +1,405 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "%g×" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "✅ Full screen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "✅ Not full screen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "✅ Not over current context" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "✅ Over current context" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "❌ Full screen" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "❌ Not full screen" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "❌ Not over current context" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "❌ Over current context" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "Auto (Recommended)" : {
+      "comment" : "Subtitle selection option",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisch (empfohlen)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatique (recommandé)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatici (consigliato)"
+          }
+        }
+      }
+    },
+    "Languages" : {
+      "comment" : "Playback setting section",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langues"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingue"
+          }
+        }
+      }
+    },
+    "Off" : {
+      "comment" : "Subtitle selection option",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non attivi"
+          }
+        }
+      }
+    },
+    "Playback Speed" : {
+      "comment" : "Playback setting section",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiedergabetempo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vitesse de lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velocità riproduzione"
+          }
+        }
+      }
+    },
+    "Subtitles" : {
+      "comment" : "Playback setting section",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Untertitel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sous-titres"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sottotitoli"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -63,7 +63,11 @@ private struct SettingsMenuContent: View {
         Menu {
             player.playbackSpeedMenu()
         } label: {
-            Label("Playback Speed", systemImage: "speedometer")
+            Label {
+                Text("Playback Speed", bundle: .module, comment: "Playback setting section")
+            } icon: {
+                Image(systemName: "speedometer")
+            }
         }
     }
 
@@ -72,7 +76,11 @@ private struct SettingsMenuContent: View {
         Menu {
             player.mediaSelectionMenu(characteristic: .audible)
         } label: {
-            Label("Languages", systemImage: "waveform.circle")
+            Label {
+                Text("Languages", bundle: .module, comment: "Playback setting section")
+            } icon: {
+                Image(systemName: "waveform.circle")
+            }
         }
     }
 
@@ -81,7 +89,11 @@ private struct SettingsMenuContent: View {
         Menu {
             player.mediaSelectionMenu(characteristic: .legible)
         } label: {
-            Label("Subtitles", systemImage: "captions.bubble")
+            Label {
+                Text("Subtitles", bundle: .module, comment: "Playback setting section")
+            } icon: {
+                Image(systemName: "captions.bubble")
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds localization catalogs to packages requiring localization.

# Changes made

- Add localization catalogs to `Player` and `CoreBusiness` packages.
- Enable demo localization (but do not localize the demo itself).

Some localizations are missing, see #573 for automation or manual request for translation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
