### PR TITLE
Improve visibility tracking with VoiceOver enabled

### DIFF
--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -12,8 +12,8 @@ import UIKit
 
 /// An observable object tracking user interface visibility.
 ///
-/// The tracker automatically turns off visibility after a delay while playing content. It also automatically turns
-/// on visibility when playback is paused externally (e.g. by another app or through the control center).
+/// The tracker automatically provides meaningful default behaviors, most notably to automatically turn visibility off
+/// after a delay during playback. This mechanism is disabled when playback is paused or when VoiceOver is enabled.
 @available(tvOS, unavailable)
 public final class VisibilityTracker: ObservableObject {
     private enum TriggerId {

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -119,23 +119,22 @@ public final class VisibilityTracker: ObservableObject {
             .eraseToAnyPublisher()
     }
 
-    private func voiceOverRunningPublisher() -> AnyPublisher<Bool, Never> {
+   private func voiceOverStatusPublisher() -> AnyPublisher<Bool, Never> {
         NotificationCenter.default.publisher(for: UIAccessibility.voiceOverStatusDidChangeNotification)
-            .map { _ in }
-            .prepend(())
             .map { _ in UIAccessibility.isVoiceOverRunning }
             .eraseToAnyPublisher()
     }
 
+    private func voiceOverRunningPublisher() -> AnyPublisher<Bool, Never> {
+        voiceOverStatusPublisher()
+            .prepend(UIAccessibility.isVoiceOverRunning)
+            .eraseToAnyPublisher()
+    }
+
     private func voiceOverUnhidePublisher() -> AnyPublisher<Bool, Never> {
-        NotificationCenter.default.publisher(for: UIAccessibility.voiceOverStatusDidChangeNotification)
-            .map { _ -> AnyPublisher<Bool, Never> in
-                guard UIAccessibility.isVoiceOverRunning else {
-                    return Empty().eraseToAnyPublisher()
-                }
-                return Just(false).eraseToAnyPublisher()
-            }
-            .switchToLatest()
+        voiceOverStatusPublisher()
+            .filter { $0 }
+            .map { _ in false }
             .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves `VisibilityTracker` behavior when VoiceOver is enabled or running.

# Discussion

These changes are meant to improve the user experience when VoiceOver is enabled. Controls should never disappear automatically when VoiceOver is enabled (which is confusing since accessible controls will change without the user noticing it).

Apple system player implements this behavior, though it does not show the UI when VoiceOver is toggled on (an improvement proposed in this PR).

# Changes made

- Show controls when VoiceOver is enabled (controls remain togglable).
- Disable auto-hide when VoiceOver is running.

No tests have been written since the changes are based on VoiceOver status change notifications.

# Further possible improvements

`VisibilityTracker` packs a few sensible default behaviors which should be good for almost all applications. If for some reason some features should not be desired in some cases we can later introduce a configuration with dedicated opt-outs for auto-hide or VoiceOver behaviors.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
