### PR TITLE
Fix custom slider animation

### DIFF
--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -56,9 +56,9 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                 rectangle(opacity: 0.1)
                     .background(.ultraThinMaterial)
                 rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(buffer))
+                    .animation(.linear(duration: 0.5), value: buffer)
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
             }
-            .animation(.linear(duration: 0.5), value: buffer)
             .gesture(
                 DragGesture(minimumDistance: 1)
                     .updating($gestureValue) { value, state, _ in

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -58,7 +58,16 @@ public final class Player: ObservableObject, Equatable {
     /// The player configuration.
     public let configuration: PlayerConfiguration
 
-    /// A publisher providing player updates as a consolidated stream.
+    /// A publisher providing player property updates as a consolidated stream.
+    ///
+    /// Rarely changing player properties, like `mediaType` or `streamType`, can be directly observed and read from
+    /// a `Player` instance. Properties which change more often, like `isSeeking` or `buffer`, require an explicit,
+    /// subscription to be read. You have to register to the `propertiesPublisher` update stream, possibly restricting
+    /// observation to a key path using `Publisher.slice(at:)`. Current property values are automatically published
+    /// upon subscription.
+    ///
+    /// When implementing a custom SwiftUI user interface, you should use `View.onReceive(player:assign:to:)` to read
+    /// fast-paced property changes into corresponding local bindings.
     public let propertiesPublisher: AnyPublisher<PlayerProperties, Never>
 
     /// A Boolean setting whether the audio output of the player must be muted.


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR makes minor improvements to #587.

# Changes made

- Fix progress animation to avoid starting at 0, especially when starting playback of a DVR stream.
- Improve property publisher documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
