### PR TITLE
Fix seek bar slowness due to media selection

### DIFF
--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -36,6 +36,10 @@ private struct MediaSelectionMenuContent: View {
     @State private var selection: MediaSelectionOption = .automatic
 
     var body: some View {
+        // TODO: Improvement.
+        // We are not directly using `mediaOption(for:)` because of its performance issues.
+        // Perhaps we should consider removing the observation of the entire player
+        // and focus on listening media selection updates.
         Picker("", selection: $selection) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -43,10 +43,10 @@ private struct MediaSelectionMenuContent: View {
         }
         .pickerStyle(.inline)
         .onAppear {
-            selection = player.mediaOption(for: characteristic).wrappedValue
+            selection = player.selectedMediaOption(for: characteristic)
         }
         .onChange(of: selection) { value in
-            player.mediaOption(for: characteristic).wrappedValue = value
+            player.select(mediaOption: value, for: characteristic)
         }
     }
 

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -33,14 +33,21 @@ private struct PlaybackSpeedMenuContent: View {
 private struct MediaSelectionMenuContent: View {
     let characteristic: AVMediaCharacteristic
     @ObservedObject var player: Player
+    @State private var selection: MediaSelectionOption = .automatic
 
     var body: some View {
-        Picker("", selection: player.mediaOption(for: characteristic)) {
+        Picker("", selection: $selection) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)
             }
         }
         .pickerStyle(.inline)
+        .onAppear {
+            selection = player.mediaOption(for: characteristic).wrappedValue
+        }
+        .onChange(of: selection) { value in
+            player.mediaOption(for: characteristic).wrappedValue = value
+        }
     }
 
     private var mediaOptions: [MediaSelectionOption] {


### PR DESCRIPTION
# Pull request

## Description

This pull request addresses the performance issue reported in issue #584.

## Changes made

- Introduced a new `@State` property `selection`.
- Added an `.onAppear` modifier to set the initial value of `selection`.
- Added an `.onChange` modifier to update the player's media option.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).