### PR TITLE
Remove all workarounds made for AirPlay

### DIFF
--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -134,8 +134,6 @@ class QueuePlayer: AVQueuePlayer {
 
 extension AVQueuePlayer {
     func replaceItems(with items: [AVPlayerItem]) {
-        cancelPendingReplacements()
-
         guard self.items() != items else { return }
 
         if let firstItem = items.first {
@@ -147,7 +145,7 @@ extension AVQueuePlayer {
                 removeAll(from: 1)
             }
             if items.count > 1 {
-                perform(#selector(append(_:)), with: Array(items.suffix(from: 1)), afterDelay: 1, inModes: [.common])
+                append(Array(items.suffix(from: 1)))
             }
         }
         else {
@@ -157,20 +155,12 @@ extension AVQueuePlayer {
 
     private func removeAll(from index: Int) {
         guard items().count > index else { return }
-        items().suffix(from: index).forEach { item in
-            remove(item)
-        }
+        items().suffix(from: index).forEach { remove($0) }
     }
 
     @objc
     private func append(_ items: [AVPlayerItem]) {
-        items.forEach { item in
-            insert(item, after: nil)
-        }
-    }
-
-    func cancelPendingReplacements() {
-        RunLoop.cancelPreviousPerformRequests(withTarget: self)
+        items.forEach { insert($0, after: nil) }
     }
 }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -190,7 +190,6 @@ public final class Player: ObservableObject, Equatable {
     }
 
     deinit {
-        queuePlayer.cancelPendingReplacements()
         uninstallRemoteCommands()
     }
 }

--- a/Tests/PlayerTests/Playlist/CurrentIndexTests.swift
+++ b/Tests/PlayerTests/Playlist/CurrentIndexTests.swift
@@ -25,7 +25,7 @@ final class CurrentIndexTests: TestCase {
         let item1 = PlayerItem.simple(url: Stream.unavailable.url)
         let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
-        expectAtLeastEqualPublished(values: [0, nil, 1, nil], from: player.$currentIndex) {
+        expectAtLeastEqualPublished(values: [0, 1, nil], from: player.$currentIndex) {
             player.play()
         }
     }

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerItemsTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerItemsTests.swift
@@ -27,8 +27,7 @@ final class QueuePlayerItemsTests: TestCase {
         let item2 = AVPlayerItem(url: Stream.onDemand.url)
         let item3 = AVPlayerItem(url: Stream.onDemand.url)
         player.replaceItems(with: [item1, item2, item3])
-        expect(player.items()).to(equalDiff([item1]))
-        expect(player.items()).toEventually(equalDiff([item1, item2, item3]), timeout: .seconds(2))
+        expect(player.items()).to(equalDiff([item1, item2, item3]))
     }
 
     func testReplaceItemsWithOtherItems() {
@@ -39,8 +38,7 @@ final class QueuePlayerItemsTests: TestCase {
         let item4 = AVPlayerItem(url: Stream.onDemand.url)
         let item5 = AVPlayerItem(url: Stream.onDemand.url)
         player.replaceItems(with: [item4, item5])
-        expect(player.items()).to(equalDiff([item4]))
-        expect(player.items()).toEventually(equalDiff([item4, item5]), timeout: .seconds(2))
+        expect(player.items()).to(equalDiff([item4, item5]))
     }
 
     func testReplaceItemsWithPreservedCurrentItem() {
@@ -50,8 +48,7 @@ final class QueuePlayerItemsTests: TestCase {
         let player = QueuePlayer(items: [item1, item2, item3])
         let item4 = AVPlayerItem(url: Stream.onDemand.url)
         player.replaceItems(with: [item1, item4])
-        expect(player.items()).to(equalDiff([item1]))
-        expect(player.items()).toEventually(equalDiff([item1, item4]), timeout: .seconds(2))
+        expect(player.items()).to(equalDiff([item1, item4]))
     }
 
     func testReplaceItemsWithIdenticalItems() {
@@ -68,8 +65,7 @@ final class QueuePlayerItemsTests: TestCase {
         let item3 = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(items: [item1, item2, item3])
         player.replaceItems(with: [item2, item3])
-        expect(player.items()).to(equalDiff([item2]))
-        expect(player.items()).toEventually(equalDiff([item2, item3]), timeout: .seconds(2))
+        expect(player.items()).to(equalDiff([item2, item3]))
     }
 
     func testReplaceItemsWithPreviousItems() {
@@ -78,8 +74,7 @@ final class QueuePlayerItemsTests: TestCase {
         let player = QueuePlayer(items: [item2, item3])
         let item1 = AVPlayerItem(url: Stream.onDemand.url)
         player.replaceItems(with: [item1, item2, item3])
-        expect(player.items()).to(equalDiff([item1]))
-        expect(player.items()).toEventually(equalDiff([item1, item2, item3]), timeout: .seconds(2))
+        expect(player.items()).to(equalDiff([item1, item2, item3]))
     }
 
     func testReplaceItemsLastReplacementWins() {
@@ -89,6 +84,6 @@ final class QueuePlayerItemsTests: TestCase {
         player.replaceItems(with: [item1, item2])
         player.replaceItems(with: [item1])
         expect(player.items()).to(equalDiff([item1]))
-        expect(player.items()).toNever(equalDiff([item1, item2]), until: .seconds(2))
+        expect(player.items()).toNever(equalDiff([item1, item2]), until: .milliseconds(500))
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR addresses issue #582 by simplifying the code and removing complexity added for AirPlay behavior.

# Changes made

- Simplified the code to improve readability and maintainability.
- Removed the previously added complexity related to AirPlay.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
