### PR TITLE
Mitigate media selection criteria retrieval performance issues

### DIFF
--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -79,18 +79,6 @@ public extension Player {
         queuePlayer.setMediaSelectionCriteria(updatedSelectionCriteria, forMediaCharacteristic: characteristic)
     }
 
-    /// A binding to read and write the current media selection for a characteristic.
-    ///
-    /// - Parameter characteristic: The characteristic.
-    /// - Returns: The binding.
-    func mediaOption(for characteristic: AVMediaCharacteristic) -> Binding<MediaSelectionOption> {
-        .init {
-            self.selectedMediaOption(for: characteristic)
-        } set: { newValue in
-            self.select(mediaOption: newValue, for: characteristic)
-        }
-    }
-
     /// The current media option for a characteristic.
     ///
     /// - Parameter characteristic: The characteristic.

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -36,10 +36,6 @@ private struct MediaSelectionMenuContent: View {
     @State private var selection: MediaSelectionOption = .automatic
 
     var body: some View {
-        // TODO: Improvement.
-        // We are not directly using `mediaOption(for:)` because of its performance issues.
-        // Perhaps we should consider removing the observation of the entire player
-        // and focus on listening media selection updates.
         Picker("", selection: $selection) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR removes the media selection API which can lead to performance issues as of iOS 17. Use of getter and selection APIs in a more surgical way, as done in our settings menu implementation, avoids such issues and should be more obvious with the binding API removed.

# Changes made

- Remove `Player.mediaSelection(for:)` binding API.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
