### PR TITLE
Preserve media selection characteristics between selections

### DIFF
--- a/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
+++ b/Sources/Player/Extensions/AVPlayerMediaSelectionCriteria.swift
@@ -7,11 +7,15 @@
 import AVFoundation
 
 extension AVPlayerMediaSelectionCriteria {
-    func adding(preferredLanguages languages: [String]) -> Self {
-        let existingPreferredLanguages = preferredLanguages ?? []
+    func selectionCriteria(byAdding preferredLanguages: [String], with preferredMediaCharacteristics: [AVMediaCharacteristic]) -> Self {
+        let existingPreferredLanguages = self.preferredLanguages ?? []
         return Self(
-            preferredLanguages: (languages + existingPreferredLanguages).removeDuplicates(),
+            preferredLanguages: (preferredLanguages + existingPreferredLanguages).removeDuplicates(),
             preferredMediaCharacteristics: preferredMediaCharacteristics
         )
+    }
+
+    func selectionCriteria(byAdding preferredLanguages: [String]) -> Self {
+        selectionCriteria(byAdding: preferredLanguages, with: preferredMediaCharacteristics ?? [])
     }
 }

--- a/Sources/Player/MediaSelection/AudibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/AudibleMediaSelector.swift
@@ -45,13 +45,20 @@ struct AudibleMediaSelector: MediaSelector {
     ) -> AVPlayerMediaSelectionCriteria? {
         guard let languageCode = option.languageCode else { return nil }
         if let selectionCriteria {
-            return selectionCriteria.adding(preferredLanguages: [languageCode])
+            return selectionCriteria.selectionCriteria(
+                byAdding: [languageCode],
+                with: audibleCharacteristics(for: option)
+            )
         }
         else {
             return AVPlayerMediaSelectionCriteria(
                 preferredLanguages: [languageCode],
-                preferredMediaCharacteristics: MAAudibleMediaCopyPreferredCharacteristics().takeRetainedValue() as? [AVMediaCharacteristic]
+                preferredMediaCharacteristics: audibleCharacteristics(for: option)
             )
         }
+    }
+
+    private func audibleCharacteristics(for option: AVMediaSelectionOption) -> [AVMediaCharacteristic] {
+        option.hasMediaCharacteristic(.describesVideoForAccessibility) ? [.describesVideoForAccessibility] : []
     }
 }

--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -124,7 +124,10 @@ public extension Player {
                 preferredLanguages: Self.preferredLanguages(for: characteristic),
                 preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
             )
-            queuePlayer.setMediaSelectionCriteria(selectionCriteria.adding(preferredLanguages: languages), forMediaCharacteristic: characteristic)
+            queuePlayer.setMediaSelectionCriteria(
+                selectionCriteria.selectionCriteria(byAdding: languages),
+                forMediaCharacteristic: characteristic
+            )
         }
         else {
             queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes an issue which was preventing media selection characteristics to be preserved between consecutive items in a playlist.

# Changes made

Self-explanatory. No tests have been written since preferred media characteristics cannot be set by unit tests (system setting).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
