### PR TITLE
Minimize the frequency of playback rate updates sent to analytics

### DIFF
--- a/Sources/Analytics/ComScore/ComScoreHit.swift
+++ b/Sources/Analytics/ComScore/ComScoreHit.swift
@@ -11,6 +11,7 @@ public struct ComScoreHit {
     /// A name describing a comScore hit.
     public enum Name: String {
         case play
+        case playrt
         case pause
         case end
         case view

--- a/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
@@ -12,9 +12,8 @@ final class ComScoreStreamingAnalytics: SCORStreamingAnalytics {
     private var oldRate: Float?
 
     override func notifyChangePlaybackRate(_ newRate: Float) {
-        if oldRate != newRate {
-            super.notifyChangePlaybackRate(newRate)
-        }
+        guard oldRate != newRate else { return }
+        super.notifyChangePlaybackRate(newRate)
         oldRate = newRate
     }
 }

--- a/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
@@ -8,7 +8,18 @@ import ComScore
 import CoreMedia
 import Player
 
-extension SCORStreamingAnalytics {
+final class ComScoreStreamingAnalytics: SCORStreamingAnalytics {
+    private var oldRate: Float?
+
+    override func notifyChangePlaybackRate(_ newRate: Float) {
+        if oldRate != newRate {
+            super.notifyChangePlaybackRate(newRate)
+        }
+        oldRate = newRate
+    }
+}
+
+extension ComScoreStreamingAnalytics {
     private static func duration(for properties: PlayerProperties) -> Int {
         properties.seekableTimeRange.isValid ? Int(properties.seekableTimeRange.duration.seconds.toMilliseconds) : 0
     }

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -57,7 +57,7 @@ public final class ComScoreTracker: PlayerItemTracker {
         streamingAnalytics.setProperties(for: properties, time: player.time, streamType: metadata.streamType)
 
         guard applicationState == .foreground else {
-            streamingAnalytics.notifyEvent(for: .paused, at: player.effectivePlaybackSpeed)
+            streamingAnalytics.notifyEvent(for: .paused, at: properties.rate)
             return
         }
 
@@ -72,7 +72,7 @@ public final class ComScoreTracker: PlayerItemTracker {
             streamingAnalytics.notifyBufferStart()
         case (false, false):
             streamingAnalytics.notifyBufferStop()
-            streamingAnalytics.notifyEvent(for: properties.playbackState, at: player.effectivePlaybackSpeed)
+            streamingAnalytics.notifyEvent(for: properties.playbackState, at: properties.rate)
         }
     }
 

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -76,10 +76,6 @@ public final class ComScoreTracker: PlayerItemTracker {
         }
     }
 
-    private func notifyPlaybackSpeedChange(speed: Float) {
-        streamingAnalytics.notifyChangePlaybackRate(speed)
-    }
-
     private func updateMetadata(with metadata: Metadata) {
         let builder = SCORStreamingContentMetadataBuilder()
         if let globals = Analytics.shared.comScoreGlobals {

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -42,18 +42,6 @@ public final class ComScoreTracker: PlayerItemTracker {
             notify(applicationState: state, player: player, properties: properties)
         }
         .store(in: &cancellables)
-
-        player.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .map { _ in () }
-            .prepend(())
-            .weakCapture(player)
-            .map { $1.effectivePlaybackSpeed }
-            .removeDuplicates()
-            .sink { [weak self] speed in
-                self?.notifyPlaybackSpeedChange(speed: speed)
-            }
-            .store(in: &cancellables)
     }
 
     public func disable() {

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -15,7 +15,7 @@ import UIKit
 ///
 /// Analytics have to be properly started for the tracker to collect data, see `Analytics.start(with:)`.
 public final class ComScoreTracker: PlayerItemTracker {
-    private var streamingAnalytics = SCORStreamingAnalytics()
+    private var streamingAnalytics = ComScoreStreamingAnalytics()
     private var cancellables = Set<AnyCancellable>()
     @Published private var metadata: Metadata = .empty
 
@@ -58,7 +58,7 @@ public final class ComScoreTracker: PlayerItemTracker {
 
     public func disable() {
         cancellables = []
-        streamingAnalytics = SCORStreamingAnalytics()
+        streamingAnalytics = ComScoreStreamingAnalytics()
     }
 
     // swiftlint:disable:next cyclomatic_complexity

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -30,18 +30,7 @@ public final class CommandersActTracker: PlayerItemTracker {
                 guard let self else { return }
                 notify(properties: properties, player: player)
                 streamingAnalytics?.notify(isBuffering: properties.isBuffering)
-            }
-            .store(in: &cancellables)
-
-        player.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .map { _ in () }
-            .prepend(())
-            .weakCapture(player)
-            .map { $1.effectivePlaybackSpeed }
-            .removeDuplicates()
-            .sink { [weak self] speed in
-                self?.streamingAnalytics?.notifyPlaybackSpeed(speed)
+                streamingAnalytics?.notifyPlaybackSpeed(properties.rate)
             }
             .store(in: &cancellables)
     }

--- a/Tests/AnalyticsTests/ComScore/ComScoreHitExpectation.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreHitExpectation.swift
@@ -22,6 +22,11 @@ struct ComScoreHitExpectation {
         .init(name: .play, evaluate: evaluate)
     }
 
+    /// Playback rate.
+    static func playrt(evaluate: @escaping (ComScoreLabels) -> Void = { _ in }) -> Self {
+        .init(name: .playrt, evaluate: evaluate)
+    }
+
     /// Pause.
     static func pause(evaluate: @escaping (ComScoreLabels) -> Void = { _ in }) -> Self {
         .init(name: .pause, evaluate: evaluate)

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerRateTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerRateTests.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import Analytics
+
+import CoreMedia
+import Nimble
+import Player
+import Streams
+
+private struct AssetMetadataMock: AssetMetadata {}
+
+final class ComScoreTrackerRateTests: ComScoreTestCase {
+    func testInitialRate() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+
+        expectAtLeastHits(
+            .play { labels in
+                expect(labels.ns_st_rt).to(equal(200))
+            }
+        ) {
+            player.setDesiredPlaybackSpeed(2)
+            player.play()
+        }
+    }
+
+    func testWhenDifferentRateApplied() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        expectAtLeastHits(
+            .playrt { labels in
+                expect(labels.ns_st_rt).to(equal(200))
+            }
+        ) {
+            player.setDesiredPlaybackSpeed(2)
+        }
+    }
+
+    func testWhenSameRateApplied() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        expectNoHits(during: .seconds(2)) {
+            player.setDesiredPlaybackSpeed(1)
+        }
+    }
+}

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -189,4 +189,23 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             player.isTrackingEnabled = true
         }
     }
+
+    func testInitialPlaybackRate() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+
+        expectAtLeastHits(
+            .play { labels in
+                expect(labels.ns_st_rt).to(equal(200))
+            }
+        ) {
+            player.setDesiredPlaybackSpeed(2)
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/Tools/Tools.swift
+++ b/Tests/PlayerTests/Tools/Tools.swift
@@ -33,16 +33,6 @@ enum PlayerError {
             ]
         )
     }
-
-    static var segmentNotFound: NSError {
-        NSError(
-            domain: "CoreMediaErrorDomain",
-            code: -12938,
-            userInfo: [
-                NSLocalizedDescriptionKey: "HTTP 404: File Not Found"
-            ]
-        )
-    }
 }
 
 extension UUID {


### PR DESCRIPTION
# Pull request

## Description

This PR allows to avoid sending several `playrt` event to **ComScore**.

## Changes made

- Added `ComScoreStreamingAnalytics` inheriting from `SCORStreamingAnalytics` to avoid sending many `playrt`.
-  Removed streaming analytics code for playback speed monitoring for **ComScore** and **CommanderAct**.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
