### PR TITLE
Fix media selection issues when altering current selection programmatically

### DIFF
--- a/Sources/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player+MediaSelection.swift
@@ -79,6 +79,18 @@ public extension Player {
         queuePlayer.setMediaSelectionCriteria(updatedSelectionCriteria, forMediaCharacteristic: characteristic)
     }
 
+    /// A binding to read and write the current media selection for a characteristic.
+    ///
+    /// - Parameter characteristic: The characteristic.
+    /// - Returns: The binding.
+    func mediaOption(for characteristic: AVMediaCharacteristic) -> Binding<MediaSelectionOption> {
+        .init {
+            self.selectedMediaOption(for: characteristic)
+        } set: { newValue in
+            self.select(mediaOption: newValue, for: characteristic)
+        }
+    }
+
     /// The current media option for a characteristic.
     ///
     /// - Parameter characteristic: The characteristic.

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -33,21 +33,14 @@ private struct PlaybackSpeedMenuContent: View {
 private struct MediaSelectionMenuContent: View {
     let characteristic: AVMediaCharacteristic
     @ObservedObject var player: Player
-    @State private var selection: MediaSelectionOption = .automatic
 
     var body: some View {
-        Picker("", selection: $selection) {
+        Picker("", selection: player.mediaOption(for: characteristic)) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)
             }
         }
         .pickerStyle(.inline)
-        .onAppear {
-            selection = player.selectedMediaOption(for: characteristic)
-        }
-        .onChange(of: selection) { value in
-            player.select(mediaOption: value, for: characteristic)
-        }
     }
 
     private var mediaOptions: [MediaSelectionOption] {


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes the related bug, restoring our initial API and mitigating iOS 17 performance issues with a simple cache implemented by `QueuePlayer`.

# Changes made

- Restore media selection binding API.
- Add media selection criteria cache to `QueuePlayer`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
