### PR TITLE
Share current item publisher for consistency

### DIFF
--- a/Sources/Player/Player+Current.swift
+++ b/Sources/Player/Player+Current.swift
@@ -13,7 +13,7 @@ extension Player {
     }
 
     func currentPublisher() -> AnyPublisher<Current?, Never> {
-        itemUpdatePublisher()
+        itemUpdatePublisher
             .map { update in
                 guard let currentIndex = update.currentIndex() else { return nil }
                 return .init(item: update.items[currentIndex], index: currentIndex)

--- a/Sources/Player/Player+ItemUpdate.swift
+++ b/Sources/Player/Player+ItemUpdate.swift
@@ -10,17 +10,15 @@ import DequeModule
 
 extension Player {
     struct ItemUpdate {
+        static var empty: Self {
+            .init(items: [], currentItem: nil)
+        }
+
         let items: Deque<PlayerItem>
         let currentItem: AVPlayerItem?
 
         func currentIndex() -> Int? {
             items.firstIndex { $0.matches(currentItem) }
         }
-    }
-
-    func itemUpdatePublisher() -> AnyPublisher<ItemUpdate, Never> {
-        Publishers.CombineLatest($storedItems, queuePlayer.publisher(for: \.currentItem))
-            .map { ItemUpdate(items: $0, currentItem: $1) }
-            .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves item update publisher implementation by sharing updates with a `multicast`, as has been done with player properties.

# Changes made

- Use multicast to have a single item update pipeline.
- Use lazy instantiation for all multicast publishers.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
