### PR TITLE
Display the URL cache size

### DIFF
--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -8,6 +8,31 @@ import AVFoundation
 import Player
 import SwiftUI
 
+private struct UrlCacheView: View {
+    @State private var urlCacheSize: String = ""
+
+    var body: some View {
+        HStack {
+            Button("Clear URL cache", action: clearUrlCache)
+            Spacer()
+            Text(urlCacheSize)
+                .font(.footnote)
+        }
+        .onAppear {
+            updateCacheSize()
+        }
+    }
+
+    private func updateCacheSize() {
+        urlCacheSize = ByteCountFormatter.string(fromByteCount: Int64(URLCache.shared.currentDiskUsage), countStyle: .binary)
+    }
+
+    private func clearUrlCache() {
+        URLCache.shared.removeAllCachedResponses()
+        updateCacheSize()
+    }
+}
+
 struct SettingsView: View {
     @AppStorage(UserDefaults.presenterModeEnabledKey)
     private var isPresenterModeEnabled = false
@@ -104,7 +129,7 @@ struct SettingsView: View {
     private func debuggingSection() -> some View {
         Section {
             Button("Simulate memory warning", action: simulateMemoryWarning)
-            Button("Clear URL cache", action: clearUrlCache)
+            UrlCacheView()
         } header: {
             Text("Debugging")
         } footer: {
@@ -129,10 +154,6 @@ struct SettingsView: View {
 
     private func simulateMemoryWarning() {
         UIApplication.shared.perform(Selector(("_performMemoryWarning")))
-    }
-
-    private func clearUrlCache() {
-        URLCache.shared.removeAllCachedResponses()
     }
 }
 

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -20,6 +20,7 @@ private struct UrlCacheView: View {
             Spacer()
             Text(urlCacheSize)
                 .font(.footnote)
+                .foregroundColor(.red)
         }
         .onAppear {
             updateCacheSize()

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -14,6 +14,9 @@ private struct UrlCacheView: View {
     var body: some View {
         HStack {
             Button("Clear URL cache", action: clearUrlCache)
+#if os(iOS)
+                .buttonStyle(.borderless)
+#endif
             Spacer()
             Text(urlCacheSize)
                 .font(.footnote)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

Self-explanatory.

<img width="374" alt="clear_cache" src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/c58081c0-bb52-483d-a21c-5fb64bb40904">

# Changes made

- Added `UrlCacheView`.
- Updated `SettingView`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
