### PR TITLE
Make routing management global

### DIFF
--- a/Demo/Sources/Application/DemoApp.swift
+++ b/Demo/Sources/Application/DemoApp.swift
@@ -6,75 +6,76 @@
 
 import SwiftUI
 
-private struct ExamplesTab: View {
-    var body: some View {
-        RoutedNavigationStack {
+@main
+struct DemoApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self)
+    private var appDelegate
+
+    @StateObject private var router = Router()
+
+    @SceneBuilder var body: some Scene {
+        WindowGroup {
+            TabView {
+                examplesTab()
+                showcaseTab()
+                contentListsTab()
+                searchTab()
+                settingsTab()
+            }
+            .modal(item: $router.presented) { presented in
+                presented.view()
+            }
+            .environmentObject(router)
+        }
+    }
+
+    @ViewBuilder
+    private func examplesTab() -> some View {
+        RoutedNavigationStack(keyPath: \.examplesPath) {
             ExamplesView()
         }
         .tabItem {
             Label("Examples", systemImage: "film")
         }
     }
-}
 
-private struct ContentListsTab: View {
-    var body: some View {
-        RoutedNavigationStack {
-            ContentListsView()
-        }
-        .tabItem {
-            Label("Lists", systemImage: "list.and.film")
-        }
-    }
-}
-
-private struct SettingsTab: View {
-    var body: some View {
-        RoutedNavigationStack {
-            SettingsView()
-        }
-        .tabItem {
-            Label("Settings", systemImage: "gearshape.fill")
-        }
-    }
-}
-
-private struct SearchTab: View {
-    var body: some View {
-        RoutedNavigationStack {
-            SearchView()
-        }
-        .tabItem {
-            Label("Search", systemImage: "magnifyingglass")
-        }
-    }
-}
-
-private struct ShowcaseTab: View {
-    var body: some View {
-        RoutedNavigationStack {
+    @ViewBuilder
+    private func showcaseTab() -> some View {
+        RoutedNavigationStack(keyPath: \.showcasePath) {
             ShowcaseView()
         }
         .tabItem {
             Label("Showcase", systemImage: "text.book.closed")
         }
     }
-}
 
-@main
-struct DemoApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self)
-    private var appDelegate
+    @ViewBuilder
+    private func contentListsTab() -> some View {
+        RoutedNavigationStack(keyPath: \.contentListsPath) {
+            ContentListsView()
+        }
+        .tabItem {
+            Label("Lists", systemImage: "list.and.film")
+        }
+    }
 
-    @SceneBuilder var body: some Scene {
-        WindowGroup {
-            TabView {
-                ExamplesTab()
-                ShowcaseTab()
-                ContentListsTab()
-                SearchTab()
-                SettingsTab()
-            }
+    @ViewBuilder
+    private func searchTab() -> some View {
+        RoutedNavigationStack(keyPath: \.searchPath) {
+            SearchView()
+        }
+        .tabItem {
+            Label("Search", systemImage: "magnifyingglass")
+        }
+    }
+
+    @ViewBuilder
+    private func settingsTab() -> some View {
+        RoutedNavigationStack(keyPath: \.settingsPath) {
+            SettingsView()
+        }
+        .tabItem {
+            Label("Settings", systemImage: "gearshape.fill")
         }
     }
 }

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -117,7 +117,8 @@ struct ContentListsView: View {
 }
 
 #Preview {
-    RoutedNavigationStack {
+    NavigationStack {
         ContentListsView()
     }
+    .environmentObject(Router())
 }

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -73,7 +73,7 @@ private struct MediaEntryView: View {
     }
 
     private func play() {
-        router.present(.player(media: media))
+        router.presented = .player(media: media)
     }
 }
 
@@ -125,7 +125,7 @@ struct ExamplesView: View {
         Section(title) {
             ForEach(medias) { media in
                 Cell(title: media.title, subtitle: media.description) {
-                    router.present(.player(media: media))
+                    router.presented = .player(media: media)
                 }
             }
         }
@@ -133,7 +133,8 @@ struct ExamplesView: View {
 }
 
 #Preview {
-    RoutedNavigationStack {
+    NavigationStack {
         ExamplesView()
     }
+    .environmentObject(Router())
 }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -5,58 +5,22 @@
 //
 
 import Combine
+import Player
 import SwiftUI
 
 /// Manages navigation using an associated router.
 struct RoutedNavigationStack<Root>: View where Root: View {
+    let keyPath: ReferenceWritableKeyPath<Router, [RouterDestination]>
+
     @ViewBuilder let root: () -> Root
-    @StateObject private var router = Router()
+    @EnvironmentObject private var router: Router
 
     var body: some View {
-        NavigationStack(path: $router.path) {
+        NavigationStack(path: Binding(router, at: keyPath)) {
             root()
-                .modal(item: $router.presented) { presented in
-                    view(for: presented)
-                }
                 .navigationDestination(for: RouterDestination.self) { destination in
-                    view(for: destination)
+                    destination.view()
                 }
-        }
-        .environmentObject(router)
-    }
-
-    @ViewBuilder
-    private func view(for destination: RouterDestination) -> some View {
-        // swiftlint:disable:previous cyclomatic_complexity
-        switch destination {
-        case let .player(media: media):
-            PlayerView(media: media)
-        case let .systemPlayer(media: media):
-            SystemPlayerView(media: media)
-        case let .simplePlayer(media: media):
-            SimplePlayerView(media: media)
-        case let .optInPlayer(media: media):
-            OptInView(media: media)
-        case let .vanillaPlayer(item: item):
-            VanillaPlayerView(item: item)
-        case let .blurred(media: media):
-            BlurredView(media: media)
-        case let .twins(media: media):
-            TwinsView(media: media)
-        case let .multi(media1: media1, media2: media2):
-            MultiView(media1: media1, media2: media2)
-        case let .link(media: media):
-            LinkView(media: media)
-        case let .wrapped(media: media):
-            WrappedView(media: media)
-        case let .transition(media: media):
-            TransitionView(media: media)
-        case .stories:
-            StoriesView()
-        case let .playlist(templates: templates):
-            PlaylistView(templates: templates)
-        case let .contentList(configuration: configuration):
-            ContentListView(configuration: configuration)
         }
     }
 }
@@ -66,10 +30,11 @@ struct RoutedNavigationStack<Root>: View where Root: View {
 /// You can manage navigation with a `RoutedNavigationStack` or retrieve the router through the environment
 /// to present the associated modal.
 final class Router: ObservableObject {
-    @Published fileprivate var path: [RouterDestination] = []
-    @Published fileprivate var presented: RouterDestination?
+    @Published var examplesPath: [RouterDestination] = []
+    @Published var showcasePath: [RouterDestination] = []
+    @Published var contentListsPath: [RouterDestination] = []
+    @Published var searchPath: [RouterDestination] = []
+    @Published var settingsPath: [RouterDestination] = []
 
-    func present(_ destination: RouterDestination) {
-        presented = destination
-    }
+    @Published var presented: RouterDestination?
 }

--- a/Demo/Sources/Router/RouterDestination.swift
+++ b/Demo/Sources/Router/RouterDestination.swift
@@ -29,34 +29,69 @@ enum RouterDestination: Identifiable, Hashable {
 
     var id: String {
         switch self {
-        case let .player(media):
-            return "player_\(media.id)"
-        case let .systemPlayer(media: media):
-            return "systemPlayer_\(media.id)"
-        case let .simplePlayer(media: media):
-            return "simplePlayer_\(media.id)"
-        case let .optInPlayer(media: media):
-            return "optInPlayer_\(media.id)"
-        case let .vanillaPlayer(item: item):
-            return "vanillaPlayer\(item.hash)"
-        case let .blurred(media: media):
-            return "blurred_\(media.id)"
-        case let .twins(media: media):
-            return "twins_\(media.id)"
-        case let .multi(media1: media1, media2: media2):
-            return "multi_\(media1.id)_\(media2.id)"
-        case let .link(media: media):
-            return "link_\(media.id)"
-        case let .wrapped(media: media):
-            return "wrapped_\(media.id)"
-        case let .transition(media: media):
-            return "transition_\(media.id)"
+        case .player:
+            return "player"
+        case .systemPlayer:
+            return "systemPlayer"
+        case .simplePlayer:
+            return "simplePlayer"
+        case .optInPlayer:
+            return "optInPlayer"
+        case .vanillaPlayer:
+            return "vanillaPlayer"
+        case .blurred:
+            return "blurred"
+        case .twins:
+            return "twins"
+        case .multi:
+            return "multi"
+        case .link:
+            return "link"
+        case .wrapped:
+            return "wrapped"
+        case .transition:
+            return "transition"
         case .stories:
             return "stories"
         case .playlist:
             return "playlist"
+        case .contentList:
+            return "contentList"
+        }
+    }
+
+    @ViewBuilder
+    func view() -> some View {
+        // swiftlint:disable:previous cyclomatic_complexity
+        switch self {
+        case let .player(media: media):
+            PlayerView(media: media)
+        case let .systemPlayer(media: media):
+            SystemPlayerView(media: media)
+        case let .simplePlayer(media: media):
+            SimplePlayerView(media: media)
+        case let .optInPlayer(media: media):
+            OptInView(media: media)
+        case let .vanillaPlayer(item: item):
+            VanillaPlayerView(item: item)
+        case let .blurred(media: media):
+            BlurredView(media: media)
+        case let .twins(media: media):
+            TwinsView(media: media)
+        case let .multi(media1: media1, media2: media2):
+            MultiView(media1: media1, media2: media2)
+        case let .link(media: media):
+            LinkView(media: media)
+        case let .wrapped(media: media):
+            WrappedView(media: media)
+        case let .transition(media: media):
+            TransitionView(media: media)
+        case .stories:
+            StoriesView()
+        case let .playlist(templates: templates):
+            PlaylistView(templates: templates)
         case let .contentList(configuration: configuration):
-            return "contentList_\(configuration.id)"
+            ContentListView(configuration: configuration)
         }
     }
 }

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -44,7 +44,7 @@ struct SearchView: View {
                 let title = MediaDescription.title(for: media)
                 Cell(title: title, subtitle: MediaDescription.subtitle(for: media), style: MediaDescription.style(for: media)) {
                     let media = Media(title: media.title, type: .urn(media.urn))
-                    router.present(.player(media: media))
+                    router.presented = .player(media: media)
                 }
                 .onAppear {
                     if let index = medias.firstIndex(of: media), medias.count - index < kPageSize {
@@ -65,7 +65,8 @@ struct SearchView: View {
 }
 
 #Preview {
-    RoutedNavigationStack {
+    NavigationStack {
         SearchView()
     }
+    .environmentObject(Router())
 }

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -162,7 +162,8 @@ struct SettingsView: View {
 }
 
 #Preview {
-    RoutedNavigationStack {
+    NavigationStack {
         SettingsView()
     }
+    .environmentObject(Router())
 }

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -26,7 +26,7 @@ struct ShowcaseView: View {
     @ViewBuilder
     private func cell(title: String, subtitle: String? = nil, destination: RouterDestination) -> some View {
         Cell(title: title, subtitle: subtitle) {
-            router.present(destination)
+            router.presented = destination
         }
     }
 
@@ -200,7 +200,8 @@ struct ShowcaseView: View {
 }
 
 #Preview {
-    RoutedNavigationStack {
+    NavigationStack {
         ShowcaseView()
     }
+    .environmentObject(Router())
 }

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -9,7 +9,7 @@ import Combine
 /// A protocol for player item tracking implementation.
 ///
 /// If your application needs to track items being played, for example for analytics or diagnostics purposes, implement
-/// this protocol to hook into the playback lifecycle. This allows you to setup your tracker at and to relinquish
+/// this protocol to hook into the playback life cycle. This allows you to setup your tracker at and to relinquish
 /// associated resources when appropriate.
 ///
 /// The protocol provides two associated types through which your tracker can define any configuration or metadata it
@@ -36,12 +36,12 @@ public protocol PlayerItemTracker: AnyObject {
     ///   - metadataPublisher: The publisher that provides metadata updates.
     init(configuration: Configuration, metadataPublisher: AnyPublisher<Metadata, Never>)
 
-    /// The lifecycle method called when the tracker is enabled for a player.
+    /// The life cycle method called when the tracker is enabled for a player.
     ///
     /// - Parameter player: The player for which the tracker must be enabled.
     func enable(for player: Player)
 
-    /// The lifecycle method called when the tracker is disabled.
+    /// The life cycle method called when the tracker is disabled.
     func disable()
 }
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -270,7 +270,7 @@ Pillarbox makes it possible to easily integrate any kind of tracker, for example
 
 1. Create a new tracker class, say `CustomTracker`, and add conformance to the `PlayerItemTracker` protocol.
 2. The `PlayerItemTracker` protocol declares `Configuration` and `Metadata` associated types. If your tracker requires a configuration or metadata related to the item being tracked just create dedicated types which contain all required parameters. Use `Void` for any type that is not required for your tracker.
-3. Trackers are automatically instantiated by the item they are associated with. You therefore never instantiate a tracker directly but rather achieve the behavior you need by implementing `PlayerItemTracker` lifecycle methods instead:
+3. Trackers are automatically instantiated by the item they are associated with. You therefore never instantiate a tracker directly but rather achieve the behavior you need by implementing `PlayerItemTracker` life cycle methods instead:
   - When created `init(configuration:metadataPublisher:)` is called on your tracker with the configuration you provided as well as a publisher for the metadata type you chose. You can either use these values directly to setup your tracker or store them for later use.
   - Subscribe to player events which must be followed in `enable(for:)`. This method is called when the item to which the tracker is bound becomes the current one. Store the subscription tokens in your tracker and implement how the tracker should handle the events you subscribed to.
   - Metadata updates are automatically received from the `metadataPublisher`. You can combine this publisher with other publishers like `$playbackState` to achieve the behavior you need.


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes routing management, most notably modal presentation which takes place globally.

# Changes made

- Revisit routing.
- Present playlist view using the router.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
