### PR TITLE
Add basic Picture in Picture support to `VideoView`

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -109,7 +109,7 @@ private struct MainView: View {
                 image(name: "tv")
             }
             else {
-                VideoView(player: player, gravity: gravity, supportsPictureInPicture: true)
+                VideoView(player: player, gravity: gravity, isPictureInPictureSupported: true)
             }
         }
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -570,10 +570,6 @@ struct PlaybackView: View {
             case .system:
                 SystemVideoView(player: player)
                     .ignoresSafeArea()
-                    .overlay(alignment: .topLeading) {
-                        CloseButton()
-                            .offset(y: -5)
-                    }
             }
 #else
             SystemVideoView(player: player)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -109,7 +109,7 @@ private struct MainView: View {
                 image(name: "tv")
             }
             else {
-                VideoView(player: player, gravity: gravity)
+                VideoView(player: player, gravity: gravity, supportsPictureInPicture: true)
             }
         }
     }

--- a/Demo/Sources/Players/VanillaPlayerView.swift
+++ b/Demo/Sources/Players/VanillaPlayerView.swift
@@ -16,9 +16,6 @@ struct VanillaPlayerView: View {
     var body: some View {
         VideoPlayer(player: player)
             .ignoresSafeArea()
-            .overlay(alignment: .topLeading) {
-                CloseButton()
-            }
             .onAppear(perform: play)
     }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -6,7 +6,9 @@
 
 import AVKit
 
+/// A service for managing Picture in Picture.
 public final class PictureInPicture: NSObject {
+    /// The shared service instance.
     public static let shared = PictureInPicture()
 
     private var controller: AVPictureInPictureController?
@@ -30,10 +32,15 @@ public final class PictureInPicture: NSObject {
         super.init()
     }
 
+    /// Starts Picture in Picture programmatically.
+    ///
+    /// Only begin PiP playback in response to explicit user interaction. The App Store review team rejects apps that
+    /// fail to follow this requirement.
     public func start() {
         controller?.startPictureInPicture()
     }
 
+    /// Stops Picture in Picture programmatically.
     public func stop() {
         controller?.stopPictureInPicture()
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -6,10 +6,8 @@
 
 import AVKit
 
-/// A service for managing Picture in Picture.
-public final class PictureInPicture: NSObject {
-    /// The shared service instance.
-    public static let shared = PictureInPicture()
+final class PictureInPicture: NSObject {
+    static let shared = PictureInPicture()
 
     private var controller: AVPictureInPictureController?
 
@@ -32,16 +30,11 @@ public final class PictureInPicture: NSObject {
         super.init()
     }
 
-    /// Starts Picture in Picture programmatically.
-    ///
-    /// Only begin PiP playback in response to explicit user interaction. The App Store review team rejects apps that
-    /// fail to follow this requirement.
-    public func start() {
+    func start() {
         controller?.startPictureInPicture()
     }
-
-    /// Stops Picture in Picture programmatically.
-    public func stop() {
+    
+    func stop() {
         controller?.stopPictureInPicture()
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -33,7 +33,7 @@ final class PictureInPicture: NSObject {
     func start() {
         controller?.startPictureInPicture()
     }
-    
+
     func stop() {
         controller?.stopPictureInPicture()
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -16,13 +16,8 @@ final class PictureInPicture: NSObject {
             controller?.playerLayer
         }
         set {
-            if let newValue {
-                guard controller?.playerLayer != newValue else { return }
-                controller = AVPictureInPictureController(playerLayer: newValue)
-            }
-            else {
-                controller = nil
-            }
+            guard controller?.playerLayer != newValue else { return }
+            controller = newValue.flatMap { AVPictureInPictureController(playerLayer: $0) }
         }
     }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVKit
+
+public final class PictureInPicture: NSObject {
+    public static let shared = PictureInPicture()
+
+    private var controller: AVPictureInPictureController?
+
+    var playerLayer: AVPlayerLayer? {
+        get {
+            controller?.playerLayer
+        }
+        set {
+            if let newValue {
+                guard controller?.playerLayer != newValue else { return }
+                controller = AVPictureInPictureController(playerLayer: newValue)
+            }
+            else {
+                controller = nil
+            }
+        }
+    }
+
+    override private init() {
+        super.init()
+    }
+
+    public func start() {
+        controller?.startPictureInPicture()
+    }
+
+    public func stop() {
+        controller?.stopPictureInPicture()
+    }
+}

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -46,8 +46,9 @@ private struct _VideoView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> VideoLayerView {
         if supportsPictureInPicture {
-            let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
-            PictureInPicture.shared.playerLayer = view.playerLayer
+            let playerLayer = PictureInPicture.shared.playerLayer
+            let view = VideoLayerView(from: playerLayer)
+            PictureInPicture.shared.playerLayer = playerLayer
             return view
         }
         else {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import SwiftUI
 import UIKit
 
-public final class VideoLayerView: UIView {
+private final class VideoLayerView: UIView {
     let playerLayer: AVPlayerLayer
 
     var player: AVPlayer? {
@@ -27,7 +27,7 @@ public final class VideoLayerView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override public func layoutSubviews() {
+    override func layoutSubviews() {
         super.layoutSubviews()
         playerLayer.frame = layer.bounds
         playerLayer.removeAllAnimations()

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -46,9 +46,8 @@ private struct _VideoView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> VideoLayerView {
         if supportsPictureInPicture {
-            let playerLayer = PictureInPicture.shared.playerLayer
-            let view = VideoLayerView(from: playerLayer)
-            PictureInPicture.shared.playerLayer = playerLayer
+            let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
+            PictureInPicture.shared.playerLayer = view.playerLayer
             return view
         }
         else {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -27,8 +27,8 @@ private final class VideoLayerView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    override func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
         playerLayer.frame = layer.bounds
         playerLayer.removeAllAnimations()
     }

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -38,7 +38,7 @@ private final class VideoLayerView: UIView {
 private struct _VideoView: UIViewRepresentable {
     let player: Player
     let gravity: AVLayerVideoGravity
-    let supportsPictureInPicture: Bool
+    let isPictureInPictureSupported: Bool
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
         guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
@@ -46,7 +46,7 @@ private struct _VideoView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        if supportsPictureInPicture {
+        if isPictureInPictureSupported {
             let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
             PictureInPicture.shared.playerLayer = view.playerLayer
             return view
@@ -68,19 +68,19 @@ private struct _VideoView: UIViewRepresentable {
 public struct VideoView: View {
     private let player: Player
     private let gravity: AVLayerVideoGravity
-    private let supportsPictureInPicture: Bool
+    private let isPictureInPictureSupported: Bool
 
     public var body: some View {
-        _VideoView(player: player, gravity: gravity, supportsPictureInPicture: supportsPictureInPicture)
+        _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: isPictureInPictureSupported)
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                 PictureInPicture.shared.stop()
             }
     }
 
-    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, supportsPictureInPicture: Bool = false) {
+    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, isPictureInPictureSupported: Bool = false) {
         self.player = player
         self.gravity = gravity
-        self.supportsPictureInPicture = supportsPictureInPicture
+        self.isPictureInPictureSupported = isPictureInPictureSupported
     }
 }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -39,16 +39,14 @@ private struct _VideoView: UIViewRepresentable {
     let supportsPictureInPicture: Bool
 
     func makeUIView(context: Context) -> VideoLayerView {
-        let view = if supportsPictureInPicture {
-            VideoLayerView(from: PictureInPicture.shared.playerLayer)
+        if supportsPictureInPicture {
+            let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
+            PictureInPicture.shared.playerLayer = view.playerLayer
+            return view
         }
         else {
-            VideoLayerView()
+            return VideoLayerView()
         }
-        view.backgroundColor = .clear
-        view.player = player.queuePlayer
-        PictureInPicture.shared.playerLayer = view.playerLayer
-        return view
     }
 
     func updateUIView(_ uiView: VideoLayerView, context: Context) {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -29,8 +29,9 @@ private final class VideoLayerView: UIView {
 
     override func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
-        playerLayer.frame = layer.bounds
-        playerLayer.removeAllAnimations()
+        layer.synchronizeAnimations {
+            playerLayer.frame = layer.bounds
+        }
     }
 }
 
@@ -80,5 +81,20 @@ public struct VideoView: View {
         self.player = player
         self.gravity = gravity
         self.supportsPictureInPicture = supportsPictureInPicture
+    }
+}
+
+private extension CALayer {
+    func synchronizeAnimations(_ animations: () -> Void) {
+        CATransaction.begin()
+        if let positionAnimation = animation(forKey: "position") {
+            CATransaction.setAnimationDuration(positionAnimation.duration)
+            CATransaction.setAnimationTimingFunction(positionAnimation.timingFunction)
+        }
+        else {
+            CATransaction.disableActions()
+        }
+        animations()
+        CATransaction.commit()
     }
 }

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -39,6 +39,11 @@ private struct _VideoView: UIViewRepresentable {
     let gravity: AVLayerVideoGravity
     let supportsPictureInPicture: Bool
 
+    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: ()) {
+        guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
+        PictureInPicture.shared.playerLayer = nil
+    }
+
     func makeUIView(context: Context) -> VideoLayerView {
         if supportsPictureInPicture {
             let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
@@ -53,11 +58,6 @@ private struct _VideoView: UIViewRepresentable {
     func updateUIView(_ uiView: VideoLayerView, context: Context) {
         uiView.player = player.queuePlayer
         uiView.playerLayer.videoGravity = gravity
-    }
-
-    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: ()) {
-        guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
-        PictureInPicture.shared.playerLayer = nil
     }
 }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -30,6 +30,7 @@ public final class VideoLayerView: UIView {
     override public func layoutSubviews() {
         super.layoutSubviews()
         playerLayer.frame = layer.bounds
+        playerLayer.removeAllAnimations()
     }
 }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -39,7 +39,7 @@ private struct _VideoView: UIViewRepresentable {
     let gravity: AVLayerVideoGravity
     let supportsPictureInPicture: Bool
 
-    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: ()) {
+    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
         guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
         PictureInPicture.shared.playerLayer = nil
     }

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -55,6 +55,11 @@ private struct _VideoView: UIViewRepresentable {
         uiView.player = player.queuePlayer
         uiView.playerLayer.videoGravity = gravity
     }
+
+    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: ()) {
+        guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
+        PictureInPicture.shared.playerLayer = nil
+    }
 }
 
 /// A view displaying video content provided by an associated player.

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -71,10 +71,15 @@ public struct VideoView: View {
     private let isPictureInPictureSupported: Bool
 
     public var body: some View {
-        _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: isPictureInPictureSupported)
-            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                PictureInPicture.shared.stop()
-            }
+        if isPictureInPictureSupported {
+            _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: true)
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                    PictureInPicture.shared.stop()
+                }
+        }
+        else {
+            _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: false)
+        }
     }
 
     public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, isPictureInPictureSupported: Bool = false) {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -34,16 +34,9 @@ public final class VideoLayerView: UIView {
 }
 
 private struct _VideoView: UIViewRepresentable {
-    @ObservedObject private var player: Player
-
-    private let gravity: AVLayerVideoGravity
-    private let supportsPictureInPicture: Bool
-
-    init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, supportsPictureInPicture: Bool = false) {
-        self.player = player
-        self.gravity = gravity
-        self.supportsPictureInPicture = supportsPictureInPicture
-    }
+    let player: Player
+    let gravity: AVLayerVideoGravity
+    let supportsPictureInPicture: Bool
 
     func makeUIView(context: Context) -> VideoLayerView {
         let view = if supportsPictureInPicture {
@@ -68,8 +61,7 @@ private struct _VideoView: UIViewRepresentable {
 ///
 /// Behavior: h-exp, v-exp
 public struct VideoView: View {
-    @ObservedObject private var player: Player
-
+    private let player: Player
     private let gravity: AVLayerVideoGravity
     private let supportsPictureInPicture: Bool
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -35,10 +35,9 @@ private final class VideoLayerView: UIView {
     }
 }
 
-private struct _VideoView: UIViewRepresentable {
+private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     let player: Player
     let gravity: AVLayerVideoGravity
-    let isPictureInPictureSupported: Bool
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
         guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
@@ -46,14 +45,23 @@ private struct _VideoView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        if isPictureInPictureSupported {
-            let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
-            PictureInPicture.shared.playerLayer = view.playerLayer
-            return view
-        }
-        else {
-            return VideoLayerView()
-        }
+        let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
+        PictureInPicture.shared.playerLayer = view.playerLayer
+        return view
+    }
+
+    func updateUIView(_ uiView: VideoLayerView, context: Context) {
+        uiView.player = player.queuePlayer
+        uiView.playerLayer.videoGravity = gravity
+    }
+}
+
+private struct _VideoView: UIViewRepresentable {
+    let player: Player
+    let gravity: AVLayerVideoGravity
+
+    func makeUIView(context: Context) -> VideoLayerView {
+        .init()
     }
 
     func updateUIView(_ uiView: VideoLayerView, context: Context) {
@@ -72,13 +80,13 @@ public struct VideoView: View {
 
     public var body: some View {
         if isPictureInPictureSupported {
-            _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: true)
+            _PictureInPictureSupportingVideoView(player: player, gravity: gravity)
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     PictureInPicture.shared.stop()
                 }
         }
         else {
-            _VideoView(player: player, gravity: gravity, isPictureInPictureSupported: false)
+            _VideoView(player: player, gravity: gravity)
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR adds basic PiP support to `VideoView`. A view only has to be marked as supporting PiP for the layer to be detachable when leaving the application. No dismissal / restoration mechanism is required (or supported for the basic implementation).

# Changes made

- Implement basic PiP service for controller instantiation and persistence.
- Add flag to enable PiP support for a `VideoView`.
- Remove close buttons for players involving the system view. The player layout will be updated in 17.2 beta and gestures are available to close the player, until we replace it with a custom view controller representable anyway.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
