### PR TITLE
Support advanced PiP integration

### DIFF
--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -123,7 +123,7 @@ struct ExamplesView: View {
     @ViewBuilder
     private func section(title: String, medias: [Media]) -> some View {
         Section(title) {
-            ForEach(medias) { media in
+            ForEach(medias, id: \.self) { media in
                 Cell(title: media.title, subtitle: media.description) {
                     router.presented = .player(media: media)
                 }

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -20,7 +20,7 @@ struct Media: Hashable {
             .urn(urn, server: .production)
         }
     }
-    
+
     let title: String
     let description: String?
     let type: `Type`

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -9,7 +9,7 @@ import Foundation
 import Player
 import YouTubeIdentifier
 
-struct Media: Hashable, Identifiable {
+struct Media: Hashable {
     enum `Type`: Hashable {
         case url(URL)
         case unbufferedUrl(URL)
@@ -20,8 +20,7 @@ struct Media: Hashable, Identifiable {
             .urn(urn, server: .production)
         }
     }
-
-    let id = UUID()
+    
     let title: String
     let description: String?
     let type: `Type`

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -110,7 +110,7 @@ private struct MainView: View {
                 image(name: "tv")
             }
             else {
-                VideoView(player: player, gravity: gravity, pictureInPictureIdentifier: "Main")
+                VideoView(player: player, gravity: gravity, pictureInPictureIdentifier: "\(Self.self)")
             }
         }
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -259,12 +259,19 @@ private struct VolumeButton: View {
 }
 
 private struct PictureInPictureButton: View {
+    @State private var isActive = false
+
     var body: some View {
         Button(action: start) {
-            Image(systemName: "pip.enter")
+            Image(systemName: imageName)
                 .tint(.white)
                 .frame(width: 45, height: 45)
         }
+        .onReceive(PictureInPicture.shared.$isActive) { isActive = $0 }
+    }
+
+    private var imageName: String {
+        isActive ? "pip.exit" : "pip.enter"
     }
 
     private func start() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -110,7 +110,7 @@ private struct MainView: View {
                 image(name: "tv")
             }
             else {
-                VideoView(player: player, gravity: gravity, isPictureInPictureSupported: true)
+                VideoView(player: player, gravity: gravity, pictureInPictureIdentifier: "Main")
             }
         }
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -262,7 +262,7 @@ private struct PictureInPictureButton: View {
     @State private var isActive = false
 
     var body: some View {
-        Button(action: start) {
+        Button(action: PictureInPicture.shared.toggle) {
             Image(systemName: imageName)
                 .tint(.white)
                 .frame(width: 45, height: 45)
@@ -272,10 +272,6 @@ private struct PictureInPictureButton: View {
 
     private var imageName: String {
         isActive ? "pip.exit" : "pip.enter"
-    }
-
-    private func start() {
-        PictureInPicture.shared.start()
     }
 }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -90,6 +90,7 @@ private struct MainView: View {
     private func topBar() -> some View {
         HStack {
             CloseButton()
+            PictureInPictureButton()
             Spacer()
             LoadingIndicator(player: player)
             VolumeButton(player: player)
@@ -254,6 +255,20 @@ private struct VolumeButton: View {
 
     private func toggleMuted() {
         player.isMuted.toggle()
+    }
+}
+
+private struct PictureInPictureButton: View {
+    var body: some View {
+        Button(action: start) {
+            Image(systemName: "pip.enter")
+                .tint(.white)
+                .frame(width: 45, height: 45)
+        }
+    }
+
+    private func start() {
+        PictureInPicture.shared.start()
     }
 }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -90,7 +90,7 @@ private struct MainView: View {
     private func topBar() -> some View {
         HStack {
             CloseButton()
-            PictureInPictureButton()
+            PiPButton()
             Spacer()
             LoadingIndicator(player: player)
             VolumeButton(player: player)
@@ -258,20 +258,13 @@ private struct VolumeButton: View {
     }
 }
 
-private struct PictureInPictureButton: View {
-    @State private var isActive = false
-
+private struct PiPButton: View {
     var body: some View {
-        Button(action: PictureInPicture.shared.toggle) {
-            Image(systemName: imageName)
+        PictureInPictureButton { isActive in
+            Image(systemName: isActive ? "pip.exit" : "pip.enter")
                 .tint(.white)
                 .frame(width: 45, height: 45)
         }
-        .onReceive(PictureInPicture.shared.$isActive) { isActive = $0 }
-    }
-
-    private var imageName: String {
-        isActive ? "pip.exit" : "pip.enter"
     }
 }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -30,7 +30,7 @@ struct PlayerView: View {
 
     var body: some View {
         PlaybackView(player: Self.model.player)
-            .onRelease {
+            .onPictureInPictureRelease {
                 Self.model.media = nil
             }
             .tracked(name: "player")

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -10,12 +10,22 @@ import SwiftUI
 final class PlayerViewModel {
     var media: Media? {
         didSet {
-            guard media != oldValue, let playerItem = media?.playerItem() else { return }
-            player.items = [playerItem]
+            guard media != oldValue else { return }
+            if let playerItem = media?.playerItem() {
+                player.items = [playerItem]
+            }
+            else {
+                player.removeAllItems()
+            }
         }
     }
 
     let player = Player(configuration: .standard)
+
+    func reset() {
+        guard !PictureInPicture.shared.isActive else { return }
+        media = nil
+    }
 }
 
 /// A standalone player view with standard controls.
@@ -26,6 +36,7 @@ struct PlayerView: View {
     var body: some View {
         PlaybackView(player: Self.model.player)
             .onAppear(perform: PictureInPicture.shared.stop)
+            .onDisappear(perform: Self.model.reset)
             .tracked(name: "player")
     }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -21,10 +21,6 @@ final class PlayerViewModel {
     }
 
     let player = Player(configuration: .standard)
-
-    func reset() {
-        media = nil
-    }
 }
 
 /// A standalone player view with standard controls.
@@ -34,7 +30,6 @@ struct PlayerView: View {
 
     var body: some View {
         PlaybackView(player: Self.model.player)
-            .onAppear(perform: PictureInPicture.shared.stop)
             .onRelease {
                 Self.model.media = nil
             }

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -35,7 +35,9 @@ struct PlayerView: View {
     var body: some View {
         PlaybackView(player: Self.model.player)
             .onAppear(perform: PictureInPicture.shared.stop)
-            .registerCleanupForInAppPictureInPicture(perform: Self.model.reset)
+            .onRelease {
+                Self.model.media = nil
+            }
             .tracked(name: "player")
     }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -23,14 +23,7 @@ final class PlayerViewModel {
     let player = Player(configuration: .standard)
 
     func reset() {
-        if PictureInPicture.shared.isActive {
-            PictureInPicture.shared.reset = {
-                self.media = nil
-            }
-        }
-        else {
-            media = nil
-        }
+        media = nil
     }
 }
 
@@ -42,7 +35,7 @@ struct PlayerView: View {
     var body: some View {
         PlaybackView(player: Self.model.player)
             .onAppear(perform: PictureInPicture.shared.stop)
-            .onDisappear(perform: Self.model.reset)
+            .registerCleanupForInAppPictureInPicture(perform: Self.model.reset)
             .tracked(name: "player")
     }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -23,8 +23,14 @@ final class PlayerViewModel {
     let player = Player(configuration: .standard)
 
     func reset() {
-        guard !PictureInPicture.shared.isActive else { return }
-        media = nil
+        if PictureInPicture.shared.isActive {
+            PictureInPicture.shared.reset = {
+                self.media = nil
+            }
+        }
+        else {
+            media = nil
+        }
     }
 }
 

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -7,20 +7,30 @@
 import Player
 import SwiftUI
 
+final class PlayerViewModel {
+    var media: Media? {
+        didSet {
+            guard media != oldValue, let playerItem = media?.playerItem() else { return }
+            player.items = [playerItem]
+        }
+    }
+
+    let player = Player(configuration: .standard)
+}
+
 /// A standalone player view with standard controls.
 /// Behavior: h-exp, v-exp
 struct PlayerView: View {
-    let media: Media
-    @StateObject private var player = Player(configuration: .standard)
+    static let model = PlayerViewModel()
 
     var body: some View {
-        PlaybackView(player: player)
-            .onAppear(perform: load)
+        PlaybackView(player: Self.model.player)
+            .onAppear(perform: PictureInPicture.shared.stop)
             .tracked(name: "player")
     }
 
-    private func load() {
-        player.append(media.playerItem())
+    init(media: Media) {
+        Self.model.media = media
     }
 }
 

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -16,7 +16,7 @@ struct SimplePlayerView: View {
 
     var body: some View {
         ZStack {
-            VideoView(player: player, pictureInPictureIdentifier: "SimplePlayerView")
+            VideoView(player: player, pictureInPictureIdentifier: "\(Self.self)")
             progressView()
             playbackButton()
         }

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -16,7 +16,7 @@ struct SimplePlayerView: View {
 
     var body: some View {
         ZStack {
-            VideoView(player: player, isPictureInPictureSupported: true)
+            VideoView(player: player, pictureInPictureIdentifier: "SimplePlayerView")
             progressView()
             playbackButton()
         }

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -16,7 +16,7 @@ struct SimplePlayerView: View {
 
     var body: some View {
         ZStack {
-            VideoView(player: player)
+            VideoView(player: player, isPictureInPictureSupported: true)
             progressView()
             playbackButton()
         }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -51,7 +51,11 @@ extension Router: PictureInPictureDelegate {
     func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {
         print("--> did start")
     }
-    
+
+    func pictureInPictureController(_ pictureInPicture: PictureInPicture, failedToStartWithError error: Error) {
+        print("--> failed to start")
+    }
+
     func pictureInPicture(_ pictureInPicture: PictureInPicture, restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
         print("--> restore")
         completionHandler(true)

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -78,8 +78,10 @@ extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {
         print("--> will stop")
     }
-    
-    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
-        print("--> did stop")
+
+    // TODO: Still to address: Player not stopped when closing from PiP overlay, next playback resumes at the same location
+
+    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture, isUsed: Bool) {
+        print("--> did stop, used: \(isUsed)")
     }
 }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -52,8 +52,13 @@ final class Router: ObservableObject {
 
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture) {
-        previousPresented = presented
-        presented = nil
+        switch presented {
+        case .player:
+            previousPresented = presented
+            presented = nil
+        default:
+            break
+        }
     }
 
     func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {}
@@ -66,8 +71,11 @@ extension Router: PictureInPictureDelegate {
     ) {
         if let previousPresented, previousPresented != presented {
             presented = previousPresented
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                completionHandler(true)
+            }
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+        else {
             completionHandler(true)
         }
     }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -38,6 +38,8 @@ final class Router: ObservableObject {
 
     @Published var presented: RouterDestination?
 
+    private var previousPresented: RouterDestination?
+
     init() {
         PictureInPicture.shared.delegate = self
     }
@@ -46,6 +48,7 @@ final class Router: ObservableObject {
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture) {
         print("--> will start")
+        previousPresented = presented
         presented = nil
     }
     
@@ -58,8 +61,10 @@ extension Router: PictureInPictureDelegate {
     }
 
     func pictureInPicture(_ pictureInPicture: PictureInPicture, restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
-        print("--> restore")
-        completionHandler(true)
+        presented = previousPresented
+        DispatchQueue.main.async {
+            completionHandler(true)
+        }
     }
     
     func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -81,7 +81,7 @@ extension Router: PictureInPictureDelegate {
 
     // TODO: Still to address: Player not stopped when closing from PiP overlay, next playback resumes at the same location
 
-    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture, isUsed: Bool) {
-        print("--> did stop, used: \(isUsed)")
+    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
+        print("--> did stop")
     }
 }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -79,8 +79,6 @@ extension Router: PictureInPictureDelegate {
         print("--> will stop")
     }
 
-    // TODO: Still to address: Player not stopped when closing from PiP overlay, next playback resumes at the same location
-
     func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
         print("--> did stop")
     }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -67,7 +67,7 @@ extension Router: PictureInPictureDelegate {
         if let previousPresented, previousPresented != presented {
             presented = previousPresented
         }
-        DispatchQueue.main.async {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
             completionHandler(true)
         }
     }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -56,7 +56,7 @@ extension Router: PictureInPictureDelegate {
         previousPresented = presented
         presented = nil
     }
-    
+
     func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {
         print("--> did start")
     }
@@ -74,7 +74,7 @@ extension Router: PictureInPictureDelegate {
             completionHandler(true)
         }
     }
-    
+
     func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {
         print("--> will stop")
     }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -37,4 +37,32 @@ final class Router: ObservableObject {
     @Published var settingsPath: [RouterDestination] = []
 
     @Published var presented: RouterDestination?
+
+    init() {
+        PictureInPicture.shared.delegate = self
+    }
+}
+
+extension Router: PictureInPictureDelegate {
+    func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture) {
+        print("--> will start")
+    }
+    
+    func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {
+        print("--> did start")
+    }
+    
+    func pictureInPicture(_ pictureInPicture: PictureInPicture, restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+        print("--> restore")
+        completionHandler(true)
+    }
+    
+    func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {
+        print("--> will stop")
+    }
+    
+    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
+        print("--> did stop")
+    }
+
 }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -46,7 +46,7 @@ final class Router: ObservableObject {
     private var previousPresented: RouterDestination?
 
     init() {
-        PictureInPicture.shared.delegate = self
+        PictureInPicture.setDelegate(self)
     }
 }
 

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -46,6 +46,7 @@ final class Router: ObservableObject {
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture) {
         print("--> will start")
+        presented = nil
     }
     
     func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -36,7 +36,12 @@ final class Router: ObservableObject {
     @Published var searchPath: [RouterDestination] = []
     @Published var settingsPath: [RouterDestination] = []
 
-    @Published var presented: RouterDestination?
+    @Published var presented: RouterDestination? {
+        didSet {
+            guard presented != nil else { return }
+            previousPresented = nil
+        }
+    }
 
     private var previousPresented: RouterDestination?
 
@@ -61,7 +66,10 @@ extension Router: PictureInPictureDelegate {
     }
 
     func pictureInPicture(_ pictureInPicture: PictureInPicture, restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
-        presented = previousPresented
+        print("--> restore")
+        if let previousPresented, previousPresented != presented {
+            presented = previousPresented
+        }
         DispatchQueue.main.async {
             completionHandler(true)
         }
@@ -74,5 +82,4 @@ extension Router: PictureInPictureDelegate {
     func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
         print("--> did stop")
     }
-
 }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -52,21 +52,18 @@ final class Router: ObservableObject {
 
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture) {
-        print("--> will start")
         previousPresented = presented
         presented = nil
     }
 
-    func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {
-        print("--> did start")
-    }
+    func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture) {}
 
-    func pictureInPictureController(_ pictureInPicture: PictureInPicture, failedToStartWithError error: Error) {
-        print("--> failed to start")
-    }
+    func pictureInPictureController(_ pictureInPicture: PictureInPicture, failedToStartWithError error: Error) {}
 
-    func pictureInPicture(_ pictureInPicture: PictureInPicture, restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
-        print("--> restore")
+    func pictureInPicture(
+        _ pictureInPicture: PictureInPicture,
+        restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+    ) {
         if let previousPresented, previousPresented != presented {
             presented = previousPresented
         }
@@ -75,11 +72,7 @@ extension Router: PictureInPictureDelegate {
         }
     }
 
-    func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {
-        print("--> will stop")
-    }
+    func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture) {}
 
-    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {
-        print("--> did stop")
-    }
+    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture) {}
 }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -15,6 +15,7 @@ private enum PlayerPosition {
 /// Behavior: h-exp, v-exp
 private struct SingleView: View {
     @ObservedObject var player: Player
+    let isPictureInPictureSupported: Bool
     let action: () -> Void
 
     @State private var isBusy = false
@@ -32,7 +33,7 @@ private struct SingleView: View {
 
     @ViewBuilder
     private func videoView(player: Player) -> some View {
-        VideoView(player: player)
+        VideoView(player: player, isPictureInPictureSupported: isPictureInPictureSupported)
             .accessibilityAddTraits(.isButton)
             .onTapGesture(perform: action)
     }
@@ -109,7 +110,7 @@ struct MultiView: View {
 
     @ViewBuilder
     private func playerView(player: Player, position: PlayerPosition) -> some View {
-        SingleView(player: player) { activePosition = position }
+        SingleView(player: player, isPictureInPictureSupported: activePosition == position) { activePosition = position }
             .accessibilityAddTraits(.isButton)
             .saturation(activePosition == position ? 1 : 0)
     }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -7,7 +7,7 @@
 import Player
 import SwiftUI
 
-private enum PlayerPosition {
+private enum PlayerPosition: String {
     case top
     case bottom
 }
@@ -15,7 +15,7 @@ private enum PlayerPosition {
 /// Behavior: h-exp, v-exp
 private struct SingleView: View {
     @ObservedObject var player: Player
-    let isPictureInPictureSupported: Bool
+    let pictureInPictureIdentifier: String?
     let action: () -> Void
 
     @State private var isBusy = false
@@ -33,7 +33,7 @@ private struct SingleView: View {
 
     @ViewBuilder
     private func videoView(player: Player) -> some View {
-        VideoView(player: player, isPictureInPictureSupported: isPictureInPictureSupported)
+        VideoView(player: player, pictureInPictureIdentifier: pictureInPictureIdentifier)
             .accessibilityAddTraits(.isButton)
             .onTapGesture(perform: action)
     }
@@ -110,7 +110,7 @@ struct MultiView: View {
 
     @ViewBuilder
     private func playerView(player: Player, position: PlayerPosition) -> some View {
-        SingleView(player: player, isPictureInPictureSupported: activePosition == position) { activePosition = position }
+        SingleView(player: player, pictureInPictureIdentifier: activePosition == position ? position.rawValue : nil) { activePosition = position }
             .accessibilityAddTraits(.isButton)
             .saturation(activePosition == position ? 1 : 0)
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -21,7 +21,7 @@ public protocol PictureInPictureDelegate: AnyObject {
 }
 
 public final class PictureInPicture: NSObject {
-    public static let shared = PictureInPicture()
+    static let shared = PictureInPicture()
 
     @Published private(set) var isPossible = false
     @Published private(set) var isActive = false
@@ -51,6 +51,10 @@ public final class PictureInPicture: NSObject {
     override private init() {
         super.init()
         configureIsPossiblePublisher()
+    }
+
+    public static func setDelegate(_ delegate: PictureInPictureDelegate) {
+        shared.delegate = delegate
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -6,8 +6,8 @@
 
 import AVKit
 
-final class PictureInPicture: NSObject {
-    static let shared = PictureInPicture()
+public final class PictureInPicture: NSObject {
+    public static let shared = PictureInPicture()
 
     private var controller: AVPictureInPictureController?
 
@@ -18,6 +18,7 @@ final class PictureInPicture: NSObject {
         set {
             guard controller?.playerLayer != newValue else { return }
             controller = newValue.flatMap { AVPictureInPictureController(playerLayer: $0) }
+            controller?.delegate = self
         }
     }
 
@@ -25,11 +26,34 @@ final class PictureInPicture: NSObject {
         super.init()
     }
 
-    func start() {
+    public func start() {
         controller?.startPictureInPicture()
     }
 
-    func stop() {
+    public func stop() {
         controller?.stopPictureInPicture()
+    }
+}
+
+extension PictureInPicture: AVPictureInPictureControllerDelegate {
+    public func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        print("--> will start")
+    }
+
+    public func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        print("--> did start")
+    }
+
+    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+        print("--> restore")
+        completionHandler(true)
+    }
+
+    public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        print("--> will stop")
+    }
+
+    public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        print("--> did stop")
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -9,6 +9,7 @@ import AVKit
 public protocol PictureInPictureDelegate: AnyObject {
     func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture)
     func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture)
+    func pictureInPictureController(_ pictureInPicture: PictureInPicture, failedToStartWithError error: Error)
     func pictureInPicture(
         _ pictureInPicture: PictureInPicture,
         restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
@@ -55,6 +56,10 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
 
     public func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         delegate?.pictureInPictureDidStart(self)
+    }
+
+    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+        delegate?.pictureInPictureController(self, failedToStartWithError: error)
     }
 
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -22,7 +22,7 @@ public protocol PictureInPictureDelegate: AnyObject {
 public final class PictureInPicture: NSObject {
     public static let shared = PictureInPicture()
 
-    @Published public private(set) var isActive = false
+    @Published private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
     var release: (() -> Void)?
@@ -61,15 +61,15 @@ public final class PictureInPicture: NSObject {
         self.playerLayer = nil
     }
 
-    public func start() {
+    func start() {
         controller?.startPictureInPicture()
     }
 
-    public func stop() {
+    func stop() {
         controller?.stopPictureInPicture()
     }
 
-    public func toggle() {
+    func toggle() {
         if isActive {
             stop()
         }
@@ -108,18 +108,5 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
             release?()
         }
         release = nil
-    }
-}
-
-public extension View {
-    func onRelease(perform release: @escaping () -> Void) -> some View {
-        onDisappear {
-            if PictureInPicture.shared.isActive {
-                PictureInPicture.shared.release = release
-            }
-            else {
-                release()
-            }
-        }
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -31,8 +31,7 @@ public final class PictureInPicture: NSObject {
 
     private var isUsed = false
 
-    @objc
-    private dynamic var controller: AVPictureInPictureController? {
+    @objc private dynamic var controller: AVPictureInPictureController? {
         didSet {
             isActive = controller?.isPictureInPictureActive ?? false
         }
@@ -104,11 +103,17 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
         delegate?.pictureInPictureDidStart(self)
     }
 
-    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+    public func pictureInPictureController(
+        _ pictureInPictureController: AVPictureInPictureController,
+        failedToStartPictureInPictureWithError error: Error
+    ) {
         delegate?.pictureInPictureController(self, failedToStartWithError: error)
     }
 
-    public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+    public func pictureInPictureController(
+        _ pictureInPictureController: AVPictureInPictureController,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+    ) {
         delegate?.pictureInPicture(self, restoreUserInterfaceForStopWithCompletionHandler: completionHandler)
     }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -52,18 +52,9 @@ public final class PictureInPicture: NSObject {
         super.init()
         configureIsPossiblePublisher()
     }
+}
 
-    private func configureIsPossiblePublisher() {
-        publisher(for: \.controller)
-            .map { controller in
-                guard let controller else { return Just(false).eraseToAnyPublisher() }
-                return controller.publisher(for: \.isPictureInPicturePossible).eraseToAnyPublisher()
-            }
-            .switchToLatest()
-            .receiveOnMainThread()
-            .assign(to: &$isPossible)
-    }
-
+extension PictureInPicture {
     func register(for playerLayer: AVPlayerLayer) {
         self.playerLayer = playerLayer
         isUsed = true
@@ -74,7 +65,22 @@ public final class PictureInPicture: NSObject {
         guard self.playerLayer == playerLayer, !isActive else { return }
         self.playerLayer = nil
     }
+}
 
+extension PictureInPicture {
+    private func configureIsPossiblePublisher() {
+        publisher(for: \.controller)
+            .map { controller in
+                guard let controller else { return Just(false).eraseToAnyPublisher() }
+                return controller.publisher(for: \.isPictureInPicturePossible).eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .receiveOnMainThread()
+            .assign(to: &$isPossible)
+    }
+}
+
+extension PictureInPicture {
     func start() {
         controller?.startPictureInPicture()
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -21,10 +21,15 @@ public protocol PictureInPictureDelegate: AnyObject {
 public final class PictureInPicture: NSObject {
     public static let shared = PictureInPicture()
 
+    @Published public private(set) var isActive = false
+
     public weak var delegate: PictureInPictureDelegate?
 
-    private var controller: AVPictureInPictureController?
-    private var isActive = false
+    private var controller: AVPictureInPictureController? {
+        didSet {
+            isActive = controller?.isPictureInPictureActive ?? false
+        }
+    }
 
     private(set) var playerLayer: AVPlayerLayer? {
         get {
@@ -33,7 +38,6 @@ public final class PictureInPicture: NSObject {
         set {
             guard controller?.playerLayer != newValue else { return }
             controller = newValue.flatMap { AVPictureInPictureController(playerLayer: $0) }
-            isActive = controller?.isPictureInPictureActive ?? false
             controller?.delegate = self
         }
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -37,8 +37,9 @@ public final class PictureInPicture: NSObject {
         }
     }
 
-    var identifier: String?
-    private(set) var playerLayer: AVPlayerLayer? {
+    private var identifier: String?
+
+    private var playerLayer: AVPlayerLayer? {
         get {
             controller?.playerLayer
         }
@@ -60,15 +61,23 @@ public final class PictureInPicture: NSObject {
 }
 
 extension PictureInPicture {
-    func register(for playerLayer: AVPlayerLayer) {
+    func playerLayer(for identifier: String) -> AVPlayerLayer? {
+        self.identifier == identifier ? playerLayer : nil
+    }
+}
+
+extension PictureInPicture {
+    func register(for playerLayer: AVPlayerLayer, identifier: String) {
         self.playerLayer = playerLayer
+        self.identifier = identifier
         isUsed = true
     }
 
     func unregister(for playerLayer: AVPlayerLayer) {
         isUsed = false
-        guard self.playerLayer == playerLayer, !isActive else { return }
+        guard self.playerLayer == playerLayer, !isActive else { return } // TODO: Check IDs
         self.playerLayer = nil
+        self.identifier = nil
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -136,6 +136,7 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
         delegate?.pictureInPictureDidStop(self)
         if !isUsed {
             release?()
+            playerLayer = nil
         }
         release = nil
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -25,7 +25,7 @@ public final class PictureInPicture: NSObject {
     @Published public private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
-    var cleanup: (() -> Void)?
+    var release: (() -> Void)?
 
     private var isUsed = false
 
@@ -105,20 +105,20 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         delegate?.pictureInPictureDidStop(self)
         if !isUsed {
-            cleanup?()
+            release?()
         }
-        cleanup = nil
+        release = nil
     }
 }
 
 public extension View {
-    func registerCleanupForInAppPictureInPicture(perform cleanup: @escaping () -> Void) -> some View {
+    func onRelease(perform release: @escaping () -> Void) -> some View {
         onDisappear {
             if PictureInPicture.shared.isActive {
-                PictureInPicture.shared.cleanup = cleanup
+                PictureInPicture.shared.release = release
             }
             else {
-                cleanup()
+                release()
             }
         }
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -24,20 +24,31 @@ public final class PictureInPicture: NSObject {
     public weak var delegate: PictureInPictureDelegate?
 
     private var controller: AVPictureInPictureController?
+    private var isActive = false
 
-    var playerLayer: AVPlayerLayer? {
+    private(set) var playerLayer: AVPlayerLayer? {
         get {
             controller?.playerLayer
         }
         set {
             guard controller?.playerLayer != newValue else { return }
             controller = newValue.flatMap { AVPictureInPictureController(playerLayer: $0) }
+            isActive = controller?.isPictureInPictureActive ?? false
             controller?.delegate = self
         }
     }
 
     override private init() {
         super.init()
+    }
+
+    func register(for playerLayer: AVPlayerLayer) {
+        self.playerLayer = playerLayer
+    }
+
+    func unregister(for playerLayer: AVPlayerLayer) {
+        guard self.playerLayer == playerLayer, !isActive else { return }
+        self.playerLayer = nil
     }
 
     public func start() {
@@ -51,6 +62,7 @@ public final class PictureInPicture: NSObject {
 
 extension PictureInPicture: AVPictureInPictureControllerDelegate {
     public func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        isActive = true
         delegate?.pictureInPictureWillStart(self)
     }
 
@@ -71,6 +83,7 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
     }
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        isActive = false
         delegate?.pictureInPictureDidStop(self)
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -62,7 +62,15 @@ public final class PictureInPicture: NSObject {
 
 extension PictureInPicture {
     func playerLayer(for identifier: String) -> AVPlayerLayer? {
-        self.identifier == identifier ? playerLayer : nil
+        if self.identifier == identifier {
+            return playerLayer
+        }
+        else {
+            if isActive {
+                release?()
+            }
+            return nil
+        }
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -73,9 +73,9 @@ extension PictureInPicture {
         isUsed = true
     }
 
-    func unregister(for playerLayer: AVPlayerLayer) {
+    func unregister(for playerLayer: AVPlayerLayer, identifier: String) {
         isUsed = false
-        guard self.playerLayer == playerLayer, !isActive else { return } // TODO: Check IDs
+        guard self.identifier == identifier, !isActive else { return }
         self.playerLayer = nil
         self.identifier = nil
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -37,6 +37,7 @@ public final class PictureInPicture: NSObject {
         }
     }
 
+    var identifier: String?
     private(set) var playerLayer: AVPlayerLayer? {
         get {
             controller?.playerLayer
@@ -136,7 +137,6 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
         delegate?.pictureInPictureDidStop(self)
         if !isUsed {
             release?()
-            playerLayer = nil
         }
         release = nil
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -24,6 +24,9 @@ public final class PictureInPicture: NSObject {
     @Published public private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
+    public var reset: (() -> Void)?
+
+    private var isUsed = false
 
     private var controller: AVPictureInPictureController? {
         didSet {
@@ -48,9 +51,11 @@ public final class PictureInPicture: NSObject {
 
     func register(for playerLayer: AVPlayerLayer) {
         self.playerLayer = playerLayer
+        isUsed = true
     }
 
     func unregister(for playerLayer: AVPlayerLayer) {
+        isUsed = false
         guard self.playerLayer == playerLayer, !isActive else { return }
         self.playerLayer = nil
     }
@@ -98,5 +103,9 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         delegate?.pictureInPictureDidStop(self)
+        if !isUsed {
+            reset?()
+        }
+        reset = nil
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -62,6 +62,15 @@ public final class PictureInPicture: NSObject {
     public func stop() {
         controller?.stopPictureInPicture()
     }
+
+    public func toggle() {
+        if isActive {
+            stop()
+        }
+        else {
+            start()
+        }
+    }
 }
 
 extension PictureInPicture: AVPictureInPictureControllerDelegate {
@@ -83,11 +92,11 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
     }
 
     public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        isActive = false
         delegate?.pictureInPictureWillStop(self)
     }
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        isActive = false
         delegate?.pictureInPictureDidStop(self)
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -6,8 +6,21 @@
 
 import AVKit
 
+public protocol PictureInPictureDelegate: AnyObject {
+    func pictureInPictureWillStart(_ pictureInPicture: PictureInPicture)
+    func pictureInPictureDidStart(_ pictureInPicture: PictureInPicture)
+    func pictureInPicture(
+        _ pictureInPicture: PictureInPicture,
+        restoreUserInterfaceForStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+    )
+    func pictureInPictureWillStop(_ pictureInPicture: PictureInPicture)
+    func pictureInPictureDidStop(_ pictureInPicture: PictureInPicture)
+}
+
 public final class PictureInPicture: NSObject {
     public static let shared = PictureInPicture()
+
+    public weak var delegate: PictureInPictureDelegate?
 
     private var controller: AVPictureInPictureController?
 
@@ -37,23 +50,22 @@ public final class PictureInPicture: NSObject {
 
 extension PictureInPicture: AVPictureInPictureControllerDelegate {
     public func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        print("--> will start")
+        delegate?.pictureInPictureWillStart(self)
     }
 
     public func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        print("--> did start")
+        delegate?.pictureInPictureDidStart(self)
     }
 
     public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
-        print("--> restore")
-        completionHandler(true)
+        delegate?.pictureInPicture(self, restoreUserInterfaceForStopWithCompletionHandler: completionHandler)
     }
 
     public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        print("--> will stop")
+        delegate?.pictureInPictureWillStop(self)
     }
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        print("--> did stop")
+        delegate?.pictureInPictureDidStop(self)
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -8,13 +8,9 @@ import SwiftUI
 
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
-    
+
     @State private var isPossible = false
     @State private var isActive = false
-
-    public init(@ViewBuilder content: @escaping (_ isActive: Bool) -> Content) {
-        self.content = content
-    }
 
     public var body: some View {
         ZStack {
@@ -26,5 +22,9 @@ public struct PictureInPictureButton<Content>: View where Content: View {
             }
         }
         .onReceive(PictureInPicture.shared.$isPossible) { isPossible = $0 }
+    }
+
+    public init(@ViewBuilder content: @escaping (_ isActive: Bool) -> Content) {
+        self.content = content
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+public struct PictureInPictureButton<Content>: View where Content: View {
+    private let content: (Bool) -> Content
+    @State private var isActive = false
+
+    public init(@ViewBuilder content: @escaping (_ isActive: Bool) -> Content) {
+        self.content = content
+    }
+
+    public var body: some View {
+        Button(action: PictureInPicture.shared.toggle) {
+            content(isActive)
+        }
+        .onReceive(PictureInPicture.shared.$isActive) { isActive = $0 }
+    }
+}

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
+    
+    @State private var isPossible = false
     @State private var isActive = false
 
     public init(@ViewBuilder content: @escaping (_ isActive: Bool) -> Content) {
@@ -15,9 +17,14 @@ public struct PictureInPictureButton<Content>: View where Content: View {
     }
 
     public var body: some View {
-        Button(action: PictureInPicture.shared.toggle) {
-            content(isActive)
+        ZStack {
+            if isPossible {
+                Button(action: PictureInPicture.shared.toggle) {
+                    content(isActive)
+                }
+                .onReceive(PictureInPicture.shared.$isActive) { isActive = $0 }
+            }
         }
-        .onReceive(PictureInPicture.shared.$isActive) { isActive = $0 }
+        .onReceive(PictureInPicture.shared.$isPossible) { isPossible = $0 }
     }
 }

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -40,13 +40,12 @@ private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     let gravity: AVLayerVideoGravity
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
-        guard uiView.playerLayer == PictureInPicture.shared.playerLayer else { return }
-        PictureInPicture.shared.playerLayer = nil
+        PictureInPicture.shared.unregister(for: uiView.playerLayer)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
         let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
-        PictureInPicture.shared.playerLayer = view.playerLayer
+        PictureInPicture.shared.register(for: view.playerLayer)
         return view
     }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -45,14 +45,8 @@ private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        let view = if PictureInPicture.shared.identifier == identifier {
-            VideoLayerView(from: PictureInPicture.shared.playerLayer)
-        }
-        else {
-            VideoLayerView()
-        }
-
-        PictureInPicture.shared.register(for: view.playerLayer)
+        let view = VideoLayerView(from: PictureInPicture.shared.playerLayer(for: identifier))
+        PictureInPicture.shared.register(for: view.playerLayer, identifier: identifier)
         return view
     }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -36,12 +36,20 @@ private final class VideoLayerView: UIView {
 }
 
 private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
+    struct Coordinator {
+        let identifier: String
+    }
+
     let player: Player
     let gravity: AVLayerVideoGravity
     let identifier: String
 
-    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
-        PictureInPicture.shared.unregister(for: uiView.playerLayer)
+    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Coordinator) {
+        PictureInPicture.shared.unregister(for: uiView.playerLayer, identifier: coordinator.identifier)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        .init(identifier: identifier)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -38,13 +38,20 @@ private final class VideoLayerView: UIView {
 private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     let player: Player
     let gravity: AVLayerVideoGravity
+    let identifier: String
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
         PictureInPicture.shared.unregister(for: uiView.playerLayer)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
+        let view = if PictureInPicture.shared.identifier == identifier {
+            VideoLayerView(from: PictureInPicture.shared.playerLayer)
+        }
+        else {
+            VideoLayerView()
+        }
+
         PictureInPicture.shared.register(for: view.playerLayer)
         return view
     }
@@ -75,11 +82,11 @@ private struct _VideoView: UIViewRepresentable {
 public struct VideoView: View {
     private let player: Player
     private let gravity: AVLayerVideoGravity
-    private let isPictureInPictureSupported: Bool
+    private let pictureInPictureIdentifier: String?
 
     public var body: some View {
-        if isPictureInPictureSupported {
-            _PictureInPictureSupportingVideoView(player: player, gravity: gravity)
+        if let pictureInPictureIdentifier {
+            _PictureInPictureSupportingVideoView(player: player, gravity: gravity, identifier: pictureInPictureIdentifier)
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     PictureInPicture.shared.stop()
                 }
@@ -89,10 +96,10 @@ public struct VideoView: View {
         }
     }
 
-    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, isPictureInPictureSupported: Bool = false) {
+    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, pictureInPictureIdentifier: String? = nil) {
         self.player = player
         self.gravity = gravity
-        self.isPictureInPictureSupported = isPictureInPictureSupported
+        self.pictureInPictureIdentifier = pictureInPictureIdentifier
     }
 }
 

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 public extension View {
     /// Assigns to a binding property a value emitted by the given player's publisher.
+    ///
     /// - Parameters:
     ///   - player: The player.
     ///   - keyPath: The key path to extract.
@@ -26,6 +27,9 @@ public extension View {
 }
 
 public extension View {
+    /// Register a closure to be executed for a view when Picture in Picture is not required anymore by this view.
+    ///
+    /// - Parameter release: The closure to be executed on release.
     func onPictureInPictureRelease(perform release: @escaping () -> Void) -> some View {
         onAppear {
             PictureInPicture.shared.stop()

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -15,13 +15,28 @@ public extension View {
     ///   - Returns: A view that fills the given binding when the player's publisher emits an
     ///   event.
     @ViewBuilder
-    func onReceive<T>(player: Player?, assign keyPath: KeyPath<PlayerProperties, T>, to binding: Binding<T>) -> some View
-        where T: Equatable {
-            if let player {
-                onReceive(player.propertiesPublisher, assign: keyPath, to: binding)
+    func onReceive<T>(player: Player?, assign keyPath: KeyPath<PlayerProperties, T>, to binding: Binding<T>) -> some View where T: Equatable {
+        if let player {
+            onReceive(player.propertiesPublisher, assign: keyPath, to: binding)
+        }
+        else {
+            self
+        }
+    }
+}
+
+public extension View {
+    func onRelease(perform release: @escaping () -> Void) -> some View {
+        onAppear {
+            PictureInPicture.shared.stop()
+        }
+        .onDisappear {
+            if PictureInPicture.shared.isActive {
+                PictureInPicture.shared.release = release
             }
             else {
-                self
+                release()
             }
+        }
     }
 }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -26,7 +26,7 @@ public extension View {
 }
 
 public extension View {
-    func onRelease(perform release: @escaping () -> Void) -> some View {
+    func onPictureInPictureRelease(perform release: @escaping () -> Void) -> some View {
         onAppear {
             PictureInPicture.shared.stop()
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to support an advance experience with the Picture in Picture.

# Changes made

- Add a `PictureInPictureButton`.
- Add a new parameter to the `VideoView` to support Picture in Picture.
- Introduce the `PictureInPictureDelegate` to manage the Picture in Picture lifecycle.
- Add `onPictureInPictureRelease`, which is a SwiftUI modifier that allows us to release certain elements with a delay. The delay corresponds to the Picture in Picture's life without the original view.
- Make `SimpleView` and `MultiView` support Picture in Picture.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
