### PR TITLE
Remove superfluous PiP identifier

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -110,7 +110,7 @@ private struct MainView: View {
                 image(name: "tv")
             }
             else {
-                VideoView(player: player, gravity: gravity, pictureInPictureIdentifier: "\(Self.self)")
+                VideoView(player: player, gravity: gravity, isPictureInPictureSupported: true)
             }
         }
     }

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -30,7 +30,7 @@ struct PlayerView: View {
 
     var body: some View {
         PlaybackView(player: Self.model.player)
-            .onPictureInPictureRelease {
+            .enabledForInAppPictureInPictureWithCleanup {
                 Self.model.media = nil
             }
             .tracked(name: "player")

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -16,7 +16,7 @@ struct SimplePlayerView: View {
 
     var body: some View {
         ZStack {
-            VideoView(player: player, pictureInPictureIdentifier: "\(Self.self)")
+            VideoView(player: player, isPictureInPictureSupported: true)
             progressView()
             playbackButton()
         }

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -25,10 +25,9 @@ struct RoutedNavigationStack<Root>: View where Root: View {
     }
 }
 
-/// Manages application routes.
+/// A router managing application presentation.
 ///
-/// You can manage navigation with a `RoutedNavigationStack` or retrieve the router through the environment
-/// to present the associated modal.
+/// You can manage navigation with a `RoutedNavigationStack` or use the router directly to present a single modal.
 final class Router: ObservableObject {
     @Published var examplesPath: [RouterDestination] = []
     @Published var showcasePath: [RouterDestination] = []

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -15,7 +15,7 @@ private enum PlayerPosition: String {
 /// Behavior: h-exp, v-exp
 private struct SingleView: View {
     @ObservedObject var player: Player
-    let pictureInPictureIdentifier: String?
+    let isPictureInPictureSupported: Bool
     let action: () -> Void
 
     @State private var isBusy = false
@@ -33,7 +33,7 @@ private struct SingleView: View {
 
     @ViewBuilder
     private func videoView(player: Player) -> some View {
-        VideoView(player: player, pictureInPictureIdentifier: pictureInPictureIdentifier)
+        VideoView(player: player, isPictureInPictureSupported: isPictureInPictureSupported)
             .accessibilityAddTraits(.isButton)
             .onTapGesture(perform: action)
     }
@@ -110,7 +110,7 @@ struct MultiView: View {
 
     @ViewBuilder
     private func playerView(player: Player, position: PlayerPosition) -> some View {
-        SingleView(player: player, pictureInPictureIdentifier: activePosition == position ? position.rawValue : nil) { activePosition = position }
+        SingleView(player: player, isPictureInPictureSupported: activePosition == position) { activePosition = position }
             .accessibilityAddTraits(.isButton)
             .saturation(activePosition == position ? 1 : 0)
     }

--- a/Demo/Sources/Showcase/MultiView.swift
+++ b/Demo/Sources/Showcase/MultiView.swift
@@ -7,7 +7,7 @@
 import Player
 import SwiftUI
 
-private enum PlayerPosition: String {
+private enum PlayerPosition {
     case top
     case bottom
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -91,7 +91,7 @@ extension PictureInPicture {
     func relinquish(for playerLayer: AVPlayerLayer) {
         guard let controller, controller.playerLayer === playerLayer else { return }
         referenceCount -= 1
-        if referenceCount == 0, isPossible {
+        if referenceCount == 0 {
             self.controller = nil
 
             // Wait until the next run loop to avoid cleanup possibly triggering body updates for discarded views.
@@ -113,6 +113,9 @@ public extension PictureInPicture {
     /// UIKit view controllers must call this method on view appearance to ensure playback can be automatically restored
     /// from Picture in Picture.
     func restoreFromInAppPictureInPicture() {
+        if let playerLayer {
+            acquire(for: playerLayer)
+        }
         stop()
         isInAppEnabled = true
     }
@@ -129,6 +132,9 @@ public extension PictureInPicture {
         else {
             cleanup()
             self.cleanup = nil
+        }
+        if let playerLayer {
+            relinquish(for: playerLayer)
         }
         isInAppEnabled = false
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -116,7 +116,6 @@ public extension PictureInPicture {
         if let playerLayer {
             acquire(for: playerLayer)
         }
-        stop()
         isInAppEnabled = true
     }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -46,6 +46,7 @@ public final class PictureInPicture: NSObject {
 
     @Published private(set) var isPossible = false
     @Published private(set) var isActive = false
+    @Published private(set) var isInAppEnabled = false
 
     private weak var delegate: PictureInPictureDelegate?
     private var cleanup: (() -> Void)?
@@ -121,6 +122,7 @@ public extension PictureInPicture {
     func restoreFromInAppPictureInPicture() {
         acquire()
         stop()
+        isInAppEnabled = true
     }
 
     /// Enables in-app Picture in Picture playback.
@@ -136,6 +138,7 @@ public extension PictureInPicture {
             cleanup()
         }
         relinquish()
+        isInAppEnabled = false
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -37,9 +37,7 @@ public final class PictureInPicture: NSObject {
         }
     }
 
-    private var identifier: String?
-
-    private var playerLayer: AVPlayerLayer? {
+    private(set) var playerLayer: AVPlayerLayer? {
         get {
             controller?.playerLayer
         }
@@ -61,31 +59,15 @@ public final class PictureInPicture: NSObject {
 }
 
 extension PictureInPicture {
-    func playerLayer(for identifier: String) -> AVPlayerLayer? {
-        if self.identifier == identifier {
-            return playerLayer
-        }
-        else {
-            if isActive {
-                release?()
-            }
-            return nil
-        }
-    }
-}
-
-extension PictureInPicture {
-    func register(for playerLayer: AVPlayerLayer, identifier: String) {
+    func register(for playerLayer: AVPlayerLayer) {
         self.playerLayer = playerLayer
-        self.identifier = identifier
         isUsed = true
     }
 
-    func unregister(for playerLayer: AVPlayerLayer, identifier: String) {
+    func unregister(for playerLayer: AVPlayerLayer) {
         isUsed = false
-        guard self.identifier == identifier, !isActive else { return }
+        guard self.playerLayer === playerLayer, !isActive else { return }
         self.playerLayer = nil
-        self.identifier = nil
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -91,7 +91,7 @@ extension PictureInPicture {
     func relinquish(for playerLayer: AVPlayerLayer) {
         guard let controller, controller.playerLayer === playerLayer else { return }
         referenceCount -= 1
-        if referenceCount == 0 {
+        if referenceCount == 0, isPossible {
             self.controller = nil
 
             // Wait until the next run loop to avoid cleanup possibly triggering body updates for discarded views.
@@ -113,9 +113,6 @@ public extension PictureInPicture {
     /// UIKit view controllers must call this method on view appearance to ensure playback can be automatically restored
     /// from Picture in Picture.
     func restoreFromInAppPictureInPicture() {
-        if let playerLayer {
-            acquire(for: playerLayer)
-        }
         stop()
         isInAppEnabled = true
     }
@@ -132,9 +129,6 @@ public extension PictureInPicture {
         else {
             cleanup()
             self.cleanup = nil
-        }
-        if let playerLayer {
-            relinquish(for: playerLayer)
         }
         isInAppEnabled = false
     }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -27,7 +27,7 @@ public final class PictureInPicture: NSObject {
     @Published private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
-    var release: (() -> Void)?
+    private var release: (() -> Void)?
 
     @objc private dynamic var controller: AVPictureInPictureController?
     private var referenceCount = 0
@@ -74,9 +74,20 @@ extension PictureInPicture {
         if referenceCount == 0 {
             controller = nil
             DispatchQueue.main.async {
-                self.release?()
+                self.clean()
             }
         }
+    }
+
+    func acquire(with release: @escaping () -> Void) {
+        self.release = release
+        acquire()
+        stop()
+    }
+
+    func clean() {
+        release?()
+        release = nil
     }
 }
 

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -27,25 +27,12 @@ public final class PictureInPicture: NSObject {
     @Published private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
-    var release: (() -> Void)?
 
-    private var isUsed = false
+    @objc private dynamic var controller: AVPictureInPictureController?
+    private var referenceCount = 0
 
-    @objc private dynamic var controller: AVPictureInPictureController? {
-        didSet {
-            isActive = controller?.isPictureInPictureActive ?? false
-        }
-    }
-
-    private(set) var playerLayer: AVPlayerLayer? {
-        get {
-            controller?.playerLayer
-        }
-        set {
-            guard controller?.playerLayer != newValue else { return }
-            controller = newValue.flatMap { AVPictureInPictureController(playerLayer: $0) }
-            controller?.delegate = self
-        }
+    var playerLayer: AVPlayerLayer? {
+        controller?.playerLayer
     }
 
     override private init() {
@@ -60,14 +47,11 @@ public final class PictureInPicture: NSObject {
 
 extension PictureInPicture {
     func register(for playerLayer: AVPlayerLayer) {
-        self.playerLayer = playerLayer
-        isUsed = true
+
     }
 
     func unregister(for playerLayer: AVPlayerLayer) {
-        isUsed = false
-        guard self.playerLayer === playerLayer, !isActive else { return }
-        self.playerLayer = nil
+
     }
 }
 
@@ -134,9 +118,5 @@ extension PictureInPicture: AVPictureInPictureControllerDelegate {
 
     public func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
         delegate?.pictureInPictureDidStop(self)
-        if !isUsed {
-            release?()
-        }
-        release = nil
     }
 }

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -80,16 +80,18 @@ extension PictureInPicture {
         }
         else {
             controller = AVPictureInPictureController(playerLayer: playerLayer)
-            controller?.delegate = self
-            referenceCount = 1
+            if let controller {
+                controller.delegate = self
+                referenceCount = 1
+            }
         }
     }
 
     func relinquish(for playerLayer: AVPlayerLayer) {
-        guard self.playerLayer === playerLayer else { return }
+        guard let controller, self.playerLayer === playerLayer else { return }
         referenceCount -= 1
         if referenceCount == 0 {
-            controller = nil
+            self.controller = nil
 
             // Wait until the next run loop to avoid cleanup possibly triggering body updates for discarded views.
             DispatchQueue.main.async {

--- a/Sources/Player/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture.swift
@@ -27,7 +27,7 @@ public final class PictureInPicture: NSObject {
     @Published private(set) var isActive = false
 
     public weak var delegate: PictureInPictureDelegate?
-    private var release: (() -> Void)?
+    private var cleanup: (() -> Void)?
 
     @objc private dynamic var controller: AVPictureInPictureController?
     private var referenceCount = 0
@@ -79,15 +79,21 @@ extension PictureInPicture {
         }
     }
 
-    func acquire(with release: @escaping () -> Void) {
-        self.release = release
+    func clean() {
+        cleanup?()
+        cleanup = nil
+    }
+}
+
+extension PictureInPicture {
+    func restoreFromInAppPictureInPicture() {
         acquire()
         stop()
     }
 
-    func clean() {
-        release?()
-        release = nil
+    func registerInAppPictureInPictureCleanup(perform cleanup: @escaping () -> Void) {
+        self.cleanup = cleanup
+        relinquish()
     }
 }
 

--- a/Sources/Player/UserInterface/DidAppearView.swift
+++ b/Sources/Player/UserInterface/DidAppearView.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+import UIKit
+
+private  final class DidAppearViewController: UIViewController {
+    var action: (() -> Void)?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        action?()
+    }
+}
+
+private struct DidAppearView: UIViewControllerRepresentable {
+    let action: () -> Void
+
+    func makeUIViewController(context: Context) -> DidAppearViewController {
+        .init()
+    }
+
+    func updateUIViewController(_ uiViewController: DidAppearViewController, context: Context) {
+        uiViewController.action = action
+    }
+}
+
+extension View {
+    func onDidAppear(perform action: @escaping () -> Void) -> some View {
+        background {
+            DidAppearView(action: action)
+        }
+    }
+}

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -6,6 +6,10 @@
 
 import SwiftUI
 
+/// A button to toggle Picture in Picture.
+///
+/// The button is automatically hidden when Picture in Picture is not available. The body closure is provided a
+/// Boolean indicating when Picture in Picture is active.
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
 
@@ -24,6 +28,10 @@ public struct PictureInPictureButton<Content>: View where Content: View {
         .onReceive(PictureInPicture.shared.$isPossible) { isPossible = $0 }
     }
 
+    /// Creates a Picture in Picture button.
+    ///
+    /// - Parameter content: The button body. Use the `isActive` Boolean to adjust your presentation according
+    ///   to the current Picture in Picture state.
     public init(@ViewBuilder content: @escaping (_ isActive: Bool) -> Content) {
         self.content = content
     }

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -10,15 +10,20 @@ import SwiftUI
 ///
 /// The button is automatically hidden when Picture in Picture is not available. The body closure is provided a
 /// Boolean indicating when Picture in Picture is active.
+///
+/// For the button to be visible one of its parent must be enabled for in-app Picture in Picture. In SwiftUI apps
+/// this is achieved by applying the `View.enabledForInAppPictureInPictureWithCleanup(perform:)` modifier. In UIKit
+/// apps `PictureInPicture.restoreFromInAppPictureInPicture()` must be called instead when the playback view appears.
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
 
     @State private var isPossible = false
     @State private var isActive = false
+    @State private var isInAppEnabled = false
 
     public var body: some View {
         ZStack {
-            if isPossible {
+            if isPossible && isInAppEnabled {
                 Button(action: PictureInPicture.shared.toggle) {
                     content(isActive)
                 }
@@ -26,6 +31,7 @@ public struct PictureInPictureButton<Content>: View where Content: View {
             }
         }
         .onReceive(PictureInPicture.shared.$isPossible) { isPossible = $0 }
+        .onReceive(PictureInPicture.shared.$isInAppEnabled) { isInAppEnabled = $0 }
     }
 
     /// Creates a Picture in Picture button.

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -40,12 +40,12 @@ private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     let gravity: AVLayerVideoGravity
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
-        PictureInPicture.shared.unregister(for: uiView.playerLayer)
+        PictureInPicture.shared.relinquish(for: uiView.playerLayer)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
         let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
-        PictureInPicture.shared.register(for: view.playerLayer)
+        PictureInPicture.shared.acquire(for: view.playerLayer)
         return view
     }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -36,25 +36,16 @@ private final class VideoLayerView: UIView {
 }
 
 private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
-    struct Coordinator {
-        let identifier: String
-    }
-
     let player: Player
     let gravity: AVLayerVideoGravity
-    let identifier: String
 
-    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Coordinator) {
-        PictureInPicture.shared.unregister(for: uiView.playerLayer, identifier: coordinator.identifier)
-    }
-
-    func makeCoordinator() -> Coordinator {
-        .init(identifier: identifier)
+    static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
+        PictureInPicture.shared.unregister(for: uiView.playerLayer)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        let view = VideoLayerView(from: PictureInPicture.shared.playerLayer(for: identifier))
-        PictureInPicture.shared.register(for: view.playerLayer, identifier: identifier)
+        let view = VideoLayerView(from: PictureInPicture.shared.playerLayer)
+        PictureInPicture.shared.register(for: view.playerLayer)
         return view
     }
 
@@ -84,11 +75,11 @@ private struct _VideoView: UIViewRepresentable {
 public struct VideoView: View {
     private let player: Player
     private let gravity: AVLayerVideoGravity
-    private let pictureInPictureIdentifier: String?
+    private let isPictureInPictureSupported: Bool
 
     public var body: some View {
-        if let pictureInPictureIdentifier {
-            _PictureInPictureSupportingVideoView(player: player, gravity: gravity, identifier: pictureInPictureIdentifier)
+        if isPictureInPictureSupported {
+            _PictureInPictureSupportingVideoView(player: player, gravity: gravity)
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     PictureInPicture.shared.stop()
                 }
@@ -98,10 +89,10 @@ public struct VideoView: View {
         }
     }
 
-    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, pictureInPictureIdentifier: String? = nil) {
+    public init(player: Player, gravity: AVLayerVideoGravity = .resizeAspect, isPictureInPictureSupported: Bool = false) {
         self.player = player
         self.gravity = gravity
-        self.pictureInPictureIdentifier = pictureInPictureIdentifier
+        self.isPictureInPictureSupported = isPictureInPictureSupported
     }
 }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -50,6 +50,9 @@ private struct _PictureInPictureSupportingVideoView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: VideoLayerView, context: Context) {
+        if uiView.player != player.queuePlayer {
+            PictureInPicture.shared.clean()
+        }
         uiView.player = player.queuePlayer
         uiView.playerLayer.videoGravity = gravity
     }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -32,10 +32,12 @@ public extension View {
     /// - Parameter release: The closure to be executed on release.
     func onPictureInPictureRelease(perform release: @escaping () -> Void) -> some View {
         onAppear {
+            PictureInPicture.shared.acquire()
+            PictureInPicture.shared.release = release
             PictureInPicture.shared.stop()
         }
         .onDisappear {
-            
+            PictureInPicture.shared.relinquish()
         }
     }
 }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -35,12 +35,7 @@ public extension View {
             PictureInPicture.shared.stop()
         }
         .onDisappear {
-            if PictureInPicture.shared.isActive {
-                PictureInPicture.shared.release = release
-            }
-            else {
-                release()
-            }
+            
         }
     }
 }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -27,15 +27,16 @@ public extension View {
 }
 
 public extension View {
-    /// Register a closure to be executed for a view when Picture in Picture is not required anymore by this view.
+    /// Enables the view for in-app Picture in Picture, registering a cleanup closure to be performed when resources
+    /// required by Picture in Picture initiated from the view are not needed anymore.
     ///
-    /// - Parameter release: The closure to be executed on release.
+    /// - Parameter cleanup: A closure to clean resources associated with the view.
     func enabledForInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) -> some View {
         onAppear {
             PictureInPicture.shared.restoreFromInAppPictureInPicture()
         }
         .onDisappear {
-            PictureInPicture.shared.registerInAppPictureInPictureCleanup(perform: cleanup)
+            PictureInPicture.shared.enableInAppPictureInPictureWithCleanup(perform: cleanup)
         }
     }
 }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -32,9 +32,7 @@ public extension View {
     /// - Parameter release: The closure to be executed on release.
     func onPictureInPictureRelease(perform release: @escaping () -> Void) -> some View {
         onAppear {
-            PictureInPicture.shared.acquire()
-            PictureInPicture.shared.release = release
-            PictureInPicture.shared.stop()
+            PictureInPicture.shared.acquire(with: release)
         }
         .onDisappear {
             PictureInPicture.shared.relinquish()

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -30,12 +30,12 @@ public extension View {
     /// Register a closure to be executed for a view when Picture in Picture is not required anymore by this view.
     ///
     /// - Parameter release: The closure to be executed on release.
-    func onPictureInPictureRelease(perform release: @escaping () -> Void) -> some View {
+    func enabledForInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) -> some View {
         onAppear {
-            PictureInPicture.shared.acquire(with: release)
+            PictureInPicture.shared.restoreFromInAppPictureInPicture()
         }
         .onDisappear {
-            PictureInPicture.shared.relinquish()
+            PictureInPicture.shared.registerInAppPictureInPictureCleanup(perform: cleanup)
         }
     }
 }

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -32,7 +32,7 @@ public extension View {
     ///
     /// - Parameter cleanup: A closure to clean resources associated with the view.
     func enabledForInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) -> some View {
-        onAppear {
+        onDidAppear {
             PictureInPicture.shared.restoreFromInAppPictureInPicture()
         }
         .onDisappear {

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -32,8 +32,11 @@ public extension View {
     ///
     /// - Parameter cleanup: A closure to clean resources associated with the view.
     func enabledForInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) -> some View {
-        onDidAppear {
+        onAppear {
             PictureInPicture.shared.restoreFromInAppPictureInPicture()
+        }
+        .onDidAppear {
+            PictureInPicture.shared.stop()
         }
         .onDisappear {
             PictureInPicture.shared.enableInAppPictureInPictureWithCleanup(perform: cleanup)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR improves #624 by removing the need for identifiers associated with PiP-supporting views.

# Changes made

- Revert to Boolean flag `isPictureInPictureSupported`.
- Implement reference counting strategy to release in-app PiP-related resources when not needed anymore.
- Improve API naming consistency.
- Add missing public documentation.
- Hide the PiP button when in-app PiP has not been properly setup for a view.

# Implementation considerations

- To automatically cleanup resources when playing another PiP-enabled content while PiP is active (e.g. play with the custom player in PiP, then tap on the simple demo) resources are cleaned up when a player change is detected.
- Cleanup is deferred from a single run loop to avoid triggering body updates in views being dismantled, which would lead to crashes.
- The following tricky use cases were thoroughly tested:
   - Open and close the player without starting PiP.
   - Enable PiP by navigating to another app.
   - Play another content with the same player already in PiP (restoration and item change).
   - Play the same content with the same player already in PiP (restoration).
   - Simple PiP integration.
   - PiP integration in multi-player example.
   - Transition between mutually exclusive PiP contexts (e.g. custom player in PiP interrupted by opening the simple or the multi-player).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
