### PR TITLE
Implement a style to prevent redundant menus in the macOS app

### DIFF
--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -112,6 +112,7 @@ struct ContentListsView: View {
         } label: {
             Label("Server", systemImage: "server.rack")
         }
+        .pickerStyle(.inline)
     }
 #endif
 }

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -13,7 +13,7 @@ private struct PlaybackSpeedMenuContent: View {
     @ObservedObject var player: Player
 
     var body: some View {
-        Picker("", selection: player.playbackSpeed) {
+        Picker("Playback Speed", selection: player.playbackSpeed) {
             ForEach(playbackSpeeds, id: \.self) { speed in
                 Text("\(speed, specifier: "%g×")").tag(speed)
             }
@@ -34,8 +34,19 @@ private struct MediaSelectionMenuContent: View {
     let characteristic: AVMediaCharacteristic
     @ObservedObject var player: Player
 
+    private var title: String {
+        switch characteristic {
+        case .audible:
+            "Languages"
+        case .legible:
+            "Subtitles"
+        default:
+            ""
+        }
+    }
+
     var body: some View {
-        Picker("", selection: player.mediaOption(for: characteristic)) {
+        Picker(title, selection: player.mediaOption(for: characteristic)) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR allows us to fix a redundant title for the server settings.

## Issue
<img width="369" alt="redundant" src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/273fb262-bec4-400a-94c8-2daf98fd39a1">

## Fix
<img width="272" alt="fix" src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/eb6e1690-3224-49f5-b001-300b45f41575">


# Changes made

- A style (`.inline`) has been applied to the menu.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
