### PR TITLE
Restore from Picture in Picture earlier

### DIFF
--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -69,7 +69,7 @@ extension Router: PictureInPictureDelegate {
     func pictureInPictureRestoreUserInterfaceForStop(with completion: @escaping (Bool) -> Void) {
         if let previousPresented, previousPresented != presented {
             presented = previousPresented
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 completion(true)
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR decreases the restoration delay to 0.1 second. On iPhone and iPad this does not lead to playback being sometimes paused while providing a snappier restoration experience.

The fix should be tested on tvOS as well (I currently have no dedicated test device).

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
