### PR TITLE
Support Picture in Picture in playlists 

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -543,7 +543,9 @@ struct PlaybackView: View {
     @ObservedObject private var player: Player
     @Binding private var layout: Layout
     let isPictureInPictureSupported: Bool
+#if os(iOS)
     let playerLayout: PlayerLayout
+#endif
 
     var body: some View {
         ZStack {
@@ -565,6 +567,7 @@ struct PlaybackView: View {
         .background(.black)
     }
 
+#if os(iOS)
     init(
         player: Player,
         playerLayout: PlayerLayout = UserDefaults.standard.playerLayout,
@@ -576,6 +579,13 @@ struct PlaybackView: View {
         _layout = layout
         self.isPictureInPictureSupported = isPictureInPictureSupported
     }
+#else
+    init(player: Player, layout: Binding<Layout> = .constant(.inline), isPictureInPictureSupported: Bool = false) {
+        self.player = player
+        _layout = layout
+        self.isPictureInPictureSupported = isPictureInPictureSupported
+    }
+#endif
 
     @ViewBuilder
     private func videoView() -> some View {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -543,6 +543,7 @@ struct PlaybackView: View {
     @ObservedObject private var player: Player
     @Binding private var layout: Layout
     let isPictureInPictureSupported: Bool
+    let playerLayout: PlayerLayout
 
     var body: some View {
         ZStack {
@@ -564,8 +565,14 @@ struct PlaybackView: View {
         .background(.black)
     }
 
-    init(player: Player, layout: Binding<Layout> = .constant(.inline), isPictureInPictureSupported: Bool = false) {
+    init(
+        player: Player,
+        playerLayout: PlayerLayout = UserDefaults.standard.playerLayout,
+        layout: Binding<Layout> = .constant(.inline),
+        isPictureInPictureSupported: Bool = false
+    ) {
         self.player = player
+        self.playerLayout = playerLayout
         _layout = layout
         self.isPictureInPictureSupported = isPictureInPictureSupported
     }
@@ -574,7 +581,7 @@ struct PlaybackView: View {
     private func videoView() -> some View {
         ZStack {
 #if os(iOS)
-            switch UserDefaults.standard.playerLayout {
+            switch playerLayout {
             case .custom:
                 MainView(player: player, layout: $layout, isPictureInPictureSupported: isPictureInPictureSupported)
             case .system:

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -52,10 +52,10 @@ final class Router: ObservableObject {
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart() {
         switch presented {
-        case .player, .systemPlayer:
+        case .player, .systemPlayer, .playlist:
             previousPresented = presented
             presented = nil
-        case .inlineSystemPlayer, .playlist:
+        case .inlineSystemPlayer:
             previousPresented = presented
         default:
             break

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -55,7 +55,7 @@ extension Router: PictureInPictureDelegate {
         case .player, .systemPlayer:
             previousPresented = presented
             presented = nil
-        case .inlineSystemPlayer:
+        case .inlineSystemPlayer, .playlist:
             previousPresented = presented
         default:
             break

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -159,13 +159,21 @@ struct PlaylistView: View {
             Self.model.currentMedia = media
         }
     }
+    var medias: Binding<[Media]> {
+        Binding {
+            Self.model.medias
+        }
+        set: { medias in
+            Self.model.medias = medias
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             PlaybackView(player: Self.model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: Self.model.player, model: Self.model)
-                List(.constant(Self.model.medias), id: \.self, editActions: .all, selection: selectedMedia) { $media in
+                List(medias, id: \.self, editActions: .all, selection: selectedMedia) { $media in
                     MediaCell(media: media, isPlaying: media == Self.model.currentMedia)
                 }
             }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -149,8 +149,8 @@ private struct Toolbar: View {
 struct PlaylistView: View {
     private static let shared = PlaylistViewModel()
     @StateObject private var model = shared
-    @State var templates: [Template]
     @State private var layout: PlaybackView.Layout = .minimized
+    let templates: [Template]
 
     var body: some View {
         VStack(spacing: 0) {

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -101,6 +101,7 @@ private struct Toolbar: View {
         .sheet(isPresented: $isSelectionPlaylistPresented) {
             PlaylistSelectionView(model: model)
         }
+        .contentShape(Rectangle())
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -153,7 +153,7 @@ struct PlaylistView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            PlaybackView(player: model.player, layout: $layout)
+            PlaybackView(player: model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)
                 List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -147,30 +147,34 @@ private struct Toolbar: View {
 
 // Behavior: h-exp, v-exp
 struct PlaylistView: View {
-    private static let shared = PlaylistViewModel()
-    @StateObject private var model = shared
+    private static let model = PlaylistViewModel()
     @State private var layout: PlaybackView.Layout = .minimized
     let templates: [Template]
 
     var body: some View {
         VStack(spacing: 0) {
-            PlaybackView(player: model.player, layout: $layout, isPictureInPictureSupported: true)
+            PlaybackView(player: Self.model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
-                Toolbar(player: model.player, model: model)
-                List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
-                    MediaCell(media: media, isPlaying: media == model.currentMedia)
+                Toolbar(player: Self.model.player, model: Self.model)
+                List(.constant(Self.model.medias), id: \.self, editActions: .all, selection: .constant(Self.model.currentMedia)) { $media in
+                    MediaCell(media: media, isPlaying: media == Self.model.currentMedia)
                 }
             }
         }
         .animation(.defaultLinear, value: layout)
         .onAppear {
-            model.templates = templates
-            model.play()
+            Self.model.templates = templates
+            Self.model.play()
         }
         .onChange(of: templates) { newValue in
-            model.templates = newValue
+            Self.model.templates = newValue
         }
         .tracked(name: "playlist")
+    }
+
+    init(templates: [Template]) {
+        self.templates = templates
+        Self.model.templates = templates
     }
 }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -179,6 +179,9 @@ struct PlaylistView: View {
         .onReceive(Self.model.$items) { items in
             medias = Array(items.keys)
         }
+        .enabledForInAppPictureInPictureWithCleanup {
+            Self.model.trash()
+        }
         .tracked(name: "playlist")
     }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -153,7 +153,7 @@ struct PlaylistView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            PlaybackView(player: model.player, layout: $layout, isPictureInPictureSupported: true)
+            PlaybackView(player: model.player, playerLayout: .custom, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)
                 List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -147,8 +147,9 @@ private struct Toolbar: View {
 
 // Behavior: h-exp, v-exp
 struct PlaylistView: View {
+    private static let shared = PlaylistViewModel()
+    @StateObject private var model = shared
     @State var templates: [Template]
-    @StateObject private var model = PlaylistViewModel()
     @State private var layout: PlaybackView.Layout = .minimized
 
     var body: some View {

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -151,12 +151,21 @@ struct PlaylistView: View {
     @State private var layout: PlaybackView.Layout = .minimized
     let templates: [Template]
 
+    var selectedMedia: Binding<Media?> {
+        Binding {
+            Self.model.currentMedia
+        }
+        set: { media in
+            Self.model.currentMedia = media
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             PlaybackView(player: Self.model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: Self.model.player, model: Self.model)
-                List(.constant(Self.model.medias), id: \.self, editActions: .all, selection: .constant(Self.model.currentMedia)) { $media in
+                List(.constant(Self.model.medias), id: \.self, editActions: .all, selection: selectedMedia) { $media in
                     MediaCell(media: media, isPlaying: media == Self.model.currentMedia)
                 }
             }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -149,7 +149,6 @@ private struct Toolbar: View {
 struct PlaylistView: View {
     private static let model = PlaylistViewModel()
     @State private var layout: PlaybackView.Layout = .minimized
-    let templates: [Template]
 
     @State private var currentMedia: Media? = Self.model.currentMedia
     @State private var medias: [Media] = Self.model.medias
@@ -166,11 +165,7 @@ struct PlaylistView: View {
         }
         .animation(.defaultLinear, value: layout)
         .onAppear {
-            Self.model.templates = templates
             Self.model.play()
-        }
-        .onChange(of: templates) { newValue in
-            Self.model.templates = newValue
         }
         .onChange(of: currentMedia) { media in
             Self.model.currentMedia = media
@@ -188,7 +183,6 @@ struct PlaylistView: View {
     }
 
     init(templates: [Template]) {
-        self.templates = templates
         Self.model.templates = templates
     }
 }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -101,7 +101,6 @@ private struct Toolbar: View {
         .sheet(isPresented: $isSelectionPlaylistPresented) {
             PlaylistSelectionView(model: model)
         }
-        .contentShape(Rectangle())
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -151,6 +151,7 @@ struct PlaylistView: View {
     @State private var layout: PlaybackView.Layout = .minimized
     let templates: [Template]
 
+    @State private var currentMedia: Media?
     var selectedMedia: Binding<Media?> {
         Binding {
             Self.model.currentMedia
@@ -174,7 +175,7 @@ struct PlaylistView: View {
             if layout != .maximized {
                 Toolbar(player: Self.model.player, model: Self.model)
                 List(medias, id: \.self, editActions: .all, selection: selectedMedia) { $media in
-                    MediaCell(media: media, isPlaying: media == Self.model.currentMedia)
+                    MediaCell(media: media, isPlaying: media == currentMedia)
                 }
             }
         }
@@ -185,6 +186,9 @@ struct PlaylistView: View {
         }
         .onChange(of: templates) { newValue in
             Self.model.templates = newValue
+        }
+        .onReceive(Self.model.$currentMedia) { media in
+            currentMedia = media
         }
         .tracked(name: "playlist")
     }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -153,7 +153,11 @@ struct PlaylistView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+#if os(iOS)
             PlaybackView(player: model.player, playerLayout: .custom, layout: $layout, isPictureInPictureSupported: true)
+#else
+            PlaybackView(player: model.player, layout: $layout, isPictureInPictureSupported: true)
+#endif
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)
                 List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -152,22 +152,14 @@ struct PlaylistView: View {
     let templates: [Template]
 
     @State private var currentMedia: Media? = Self.model.currentMedia
-
-    var medias: Binding<[Media]> {
-        Binding {
-            Self.model.medias
-        }
-        set: { medias in
-            Self.model.medias = medias
-        }
-    }
+    @State private var medias: [Media] = Self.model.medias
 
     var body: some View {
         VStack(spacing: 0) {
             PlaybackView(player: Self.model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: Self.model.player, model: Self.model)
-                List(medias, id: \.self, editActions: .all, selection: $currentMedia) { $media in
+                List($medias, id: \.self, editActions: .all, selection: $currentMedia) { $media in
                     MediaCell(media: media, isPlaying: media == currentMedia)
                 }
             }
@@ -185,6 +177,12 @@ struct PlaylistView: View {
         }
         .onReceive(Self.model.$currentMedia) { media in
             currentMedia = media
+        }
+        .onChange(of: medias) { medias in
+            Self.model.medias = medias
+        }
+        .onReceive(Self.model.$items) { items in
+            medias = Array(items.keys)
         }
         .tracked(name: "playlist")
     }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -151,15 +151,8 @@ struct PlaylistView: View {
     @State private var layout: PlaybackView.Layout = .minimized
     let templates: [Template]
 
-    @State private var currentMedia: Media?
-    var selectedMedia: Binding<Media?> {
-        Binding {
-            Self.model.currentMedia
-        }
-        set: { media in
-            Self.model.currentMedia = media
-        }
-    }
+    @State private var currentMedia: Media? = Self.model.currentMedia
+
     var medias: Binding<[Media]> {
         Binding {
             Self.model.medias
@@ -174,7 +167,7 @@ struct PlaylistView: View {
             PlaybackView(player: Self.model.player, layout: $layout, isPictureInPictureSupported: true)
             if layout != .maximized {
                 Toolbar(player: Self.model.player, model: Self.model)
-                List(medias, id: \.self, editActions: .all, selection: selectedMedia) { $media in
+                List(medias, id: \.self, editActions: .all, selection: $currentMedia) { $media in
                     MediaCell(media: media, isPlaying: media == currentMedia)
                 }
             }
@@ -186,6 +179,9 @@ struct PlaylistView: View {
         }
         .onChange(of: templates) { newValue in
             Self.model.templates = newValue
+        }
+        .onChange(of: currentMedia) { media in
+            Self.model.currentMedia = media
         }
         .onReceive(Self.model.$currentMedia) { media in
             currentMedia = media

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -51,7 +51,7 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    @Published private(set) var items = OrderedDictionary<Media, PlayerItem>() {
+    @Published private var items = OrderedDictionary<Media, PlayerItem>() {
         didSet {
             player.items = items.values.elements
         }

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -51,7 +51,7 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
 
-    @Published private var items = OrderedDictionary<Media, PlayerItem>() {
+    @Published private(set) var items = OrderedDictionary<Media, PlayerItem>() {
         didSet {
             player.items = items.values.elements
         }

--- a/Sources/Player/UserInterface/WillAppearView.swift
+++ b/Sources/Player/UserInterface/WillAppearView.swift
@@ -32,6 +32,7 @@ extension View {
     func onWillAppear(perform action: @escaping () -> Void) -> some View {
         background {
             WillAppearView(action: action)
+                .allowsHitTesting(false)
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

Self-explanatory.

# Changes made

- The view model has been marked as an `ObservedObject`
- The view model is now instantiated via a shared instance.

# Result

https://github.com/SRGSSR/pillarbox-apple/assets/3347810/839f3c9a-9049-4091-9137-48061ade49e4

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
