### PR TITLE
Correct the deferred seek

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -427,7 +427,9 @@ private struct TimeSlider: View {
                 label(withText: formattedTotalTime)
             },
             onDragging: {
-                visibilityTracker.reset()
+                if UserDefaults.standard.seekBehavior == .deferred {
+                    visibilityTracker.reset()
+                }
             }
         )
         .foregroundColor(.white)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -340,7 +340,7 @@ private struct TimeBar: View {
         HStack(spacing: 8) {
             routePickerView()
             HStack(spacing: 20) {
-                TimeSlider(player: player, progressTracker: progressTracker)
+                TimeSlider(player: player, progressTracker: progressTracker, visibilityTracker: visibilityTracker)
                 LiveLabel(player: player, progressTracker: progressTracker)
 
                 Group {
@@ -398,6 +398,7 @@ private struct TimeSlider: View {
 
     @ObservedObject var player: Player
     @ObservedObject var progressTracker: ProgressTracker
+    @ObservedObject var visibilityTracker: VisibilityTracker
     @State private var streamType: StreamType = .unknown
 
     private var formattedElapsedTime: String? {
@@ -424,6 +425,9 @@ private struct TimeSlider: View {
             },
             maximumValueLabel: {
                 label(withText: formattedTotalTime)
+            },
+            onDragging: {
+                visibilityTracker.reset()
             }
         )
         .foregroundColor(.white)

--- a/Demo/Sources/Views/PlaybackSlider.swift
+++ b/Demo/Sources/Views/PlaybackSlider.swift
@@ -14,6 +14,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
     let onEditingChanged: (Bool) -> Void
+    let onDragging: () -> Void
 
     @GestureState private var gestureValue: DragGesture.Value?
     @State private var initialProgress: Float = 0
@@ -33,12 +34,14 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         progressTracker: ProgressTracker,
         @ViewBuilder minimumValueLabel: @escaping () -> ValueLabel,
         @ViewBuilder maximumValueLabel: @escaping () -> ValueLabel,
-        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onDragging: @escaping () -> Void = {}
     ) {
         self.progressTracker = progressTracker
         self.minimumValueLabel = minimumValueLabel
         self.maximumValueLabel = maximumValueLabel
         self.onEditingChanged = onEditingChanged
+        self.onDragging = onDragging
     }
 
     @ViewBuilder
@@ -77,6 +80,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
     private func updateProgress(for value: DragGesture.Value?, in geometry: GeometryProxy) {
         if let value {
+            onDragging()
             if !progressTracker.isInteracting {
                 progressTracker.isInteracting = true
                 initialProgress = progressTracker.progress

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -153,7 +153,7 @@ public final class ProgressTracker: ObservableObject {
     }
 
     private func pausePlaybackIfNeeded(with player: Player?) {
-        guard let player, player.playbackState == .playing else { return }
+        guard let player, player.playbackState == .playing, seekBehavior == .immediate else { return }
         player.pause()
         wasPaused = true
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

Self-explanatory.

# Changes made

- Avoid pausing playback when seeking in deferred mode.
- Avoid hiding playback controls when the user interacts with the slider in deferred mode.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
