### PR TITLE
Fix player configuration update in Picture-in-Picture implementations

### DIFF
--- a/Demo/Sources/Players/PlayerViewModel.swift
+++ b/Demo/Sources/Players/PlayerViewModel.swift
@@ -11,7 +11,7 @@ final class PlayerViewModel {
         didSet {
             guard media != oldValue else { return }
             if let playerItem = media?.playerItem() {
-                player = Player(items: [playerItem], configuration: .standard)
+                player.items = [playerItem]
             }
             else {
                 player.removeAllItems()
@@ -19,9 +19,10 @@ final class PlayerViewModel {
         }
     }
 
-    private(set) var player = Player()
+    let player = Player()
 
     func play() {
+        player.applyConfiguration(.standard)
         player.becomeActive()
         player.play()
     }

--- a/Demo/Sources/Players/PlayerViewModel.swift
+++ b/Demo/Sources/Players/PlayerViewModel.swift
@@ -11,7 +11,7 @@ final class PlayerViewModel {
         didSet {
             guard media != oldValue else { return }
             if let playerItem = media?.playerItem() {
-                player.items = [playerItem]
+                player = Player(items: [playerItem], configuration: .standard)
             }
             else {
                 player.removeAllItems()
@@ -19,7 +19,7 @@ final class PlayerViewModel {
         }
     }
 
-    let player = Player(configuration: .standard)
+    private(set) var player = Player()
 
     func play() {
         player.becomeActive()

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -53,11 +53,11 @@ final class PlaylistViewModel: ObservableObject {
 
     @Published private var items = OrderedDictionary<Media, PlayerItem>() {
         didSet {
-            player.items = items.values.elements
+            newPlayer(with: items.values.elements)
         }
     }
 
-    let player = Player(configuration: .standard)
+    private(set) var player = Player()
 
     var medias: [Media] {
         get {
@@ -111,6 +111,16 @@ final class PlaylistViewModel: ObservableObject {
             }
         }
         return items
+    }
+
+    private func newPlayer(with items: [PlayerItem]) {
+        if items.isEmpty {
+            player.removeAllItems()
+        }
+        else {
+            player = Player(items: items, configuration: .standard)
+            configureCurrentItemPublisher()
+        }
     }
 
     func add(from templates: [Template]) {

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -53,11 +53,11 @@ final class PlaylistViewModel: ObservableObject {
 
     @Published private var items = OrderedDictionary<Media, PlayerItem>() {
         didSet {
-            newPlayer(with: items.values.elements)
+            player.items = items.values.elements
         }
     }
 
-    private(set) var player = Player()
+    let player = Player()
 
     var medias: [Media] {
         get {
@@ -113,21 +113,12 @@ final class PlaylistViewModel: ObservableObject {
         return items
     }
 
-    private func newPlayer(with items: [PlayerItem]) {
-        if items.isEmpty {
-            player.removeAllItems()
-        }
-        else {
-            player = Player(items: items, configuration: .standard)
-            configureCurrentItemPublisher()
-        }
-    }
-
     func add(from templates: [Template]) {
         medias += Template.medias(from: templates)
     }
 
     func play() {
+        player.applyConfiguration(.standard)
         player.becomeActive()
         player.play()
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -56,7 +56,7 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// The player configuration.
-    public let configuration: PlayerConfiguration
+    public private(set) var configuration: PlayerConfiguration
 
     /// A publisher providing player property updates as a consolidated stream.
     ///
@@ -166,6 +166,14 @@ public final class Player: ObservableObject, Equatable {
         guard Self.currentPlayer == self else { return }
         isActive = false
         Self.currentPlayer = nil
+    }
+
+    /// Apply a new configuration to the player.
+    ///
+    /// - Parameter newConfiguration: The new configuration to apply.
+    public func applyConfiguration(_ configuration: PlayerConfiguration) {
+        self.configuration = configuration
+        configurePlayer()
     }
 
     private func configurePlayer() {

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -48,6 +48,7 @@ final class PlayerConfigurationTests: TestCase {
         )
 
         let player = Player()
+        player.applyConfiguration(configuration)
 
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
         expect(player.configuration.isSmartNavigationEnabled).to(beFalse())

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -40,4 +40,16 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.backwardSkipInterval).to(equal(42))
         expect(player.configuration.forwardSkipInterval).to(equal(47))
     }
+
+    func testApplyPlayerConfigurationAfterInit() {
+        let configuration = PlayerConfiguration(
+            allowsExternalPlayback: false,
+            smartNavigationEnabled: false
+        )
+
+        let player = Player()
+
+        expect(player.configuration.allowsExternalPlayback).to(beFalse())
+        expect(player.configuration.isSmartNavigationEnabled).to(beFalse())
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR addresses the issue related to the Picture in Picture implementation. 
Currently, the view model is shared, so the initialization occurs only once. 
Consequently, the player configuration is also done only once, leading to a situation where changes made on the settings page (smart navigation, allows external playback, etc.) have no impact on the player.

# Changes made

- ~Created a new player when items changed.~
- A new method `applyConfiguration` has been introduced to facilitate the player configuration update.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
