### PR TITLE
Fix the path for accessing the source code

### DIFF
--- a/Demo/Sources/Showcase/SourceCodeViewable.swift
+++ b/Demo/Sources/Showcase/SourceCodeViewable.swift
@@ -42,8 +42,11 @@ extension View {
     }
 
     private func gitHubUrl<T>(for objectType: T.Type) -> URL? where T: SourceCodeViewable {
-        guard let relativePath = objectType.filePath.split(separator: "pillarbox-apple").last else { return nil }
-        var url = URL("github://github.com/SRGSSR/pillarbox-apple/blob/main").appending(path: relativePath)
+        let separator = "/Demo/"
+        guard let relativePath = objectType.filePath.split(separator: separator).last else { return nil }
+        var url = URL("github://github.com/SRGSSR/pillarbox-apple/blob/main")
+            .appending(path: separator)
+            .appending(path: relativePath)
         if !UIApplication.shared.canOpenURL(url) {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
             components.scheme = "https"


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes the issue related to the creation of the source code access URL, the previously applied separator was `pillarbox-apple`. The issue arises when using with the **Nightlies**, where the path takes the following form: `/Users/Shared/TeamCity/buildAgent/work/47bf7fecb000c3b6/Demo/Sources/Showcase`, and `pillarbox-apple` is not present, causing the algorithm to fail. Therefore, we have opted to split the path using `/Demo/`.

# Changes made

- Split by using `/Demo/` instead of `pillarbox-apple`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
