### PR TITLE
Improve setting support

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -38,9 +38,6 @@
     "Add a stream to the playlist" : {
 
     },
-    "Allows external playback" : {
-
-    },
     "Application" : {
 
     },

--- a/Demo/Sources/Players/PlayerConfiguration.swift
+++ b/Demo/Sources/Players/PlayerConfiguration.swift
@@ -13,7 +13,6 @@ extension PlayerConfiguration {
         return .init(
             allowsExternalPlayback: userDefaults.allowsExternalPlaybackEnabled,
             usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
-            audiovisualBackgroundPlaybackPolicy: userDefaults.audiovisualBackgroundPlaybackPolicy,
             smartNavigationEnabled: userDefaults.smartNavigationEnabled
         )
     }
@@ -22,7 +21,6 @@ extension PlayerConfiguration {
         let userDefaults = UserDefaults.standard
         return .init(
             allowsExternalPlayback: false,
-            audiovisualBackgroundPlaybackPolicy: userDefaults.audiovisualBackgroundPlaybackPolicy,
             smartNavigationEnabled: userDefaults.smartNavigationEnabled
         )
     }

--- a/Demo/Sources/Players/PlayerConfiguration.swift
+++ b/Demo/Sources/Players/PlayerConfiguration.swift
@@ -11,7 +11,6 @@ extension PlayerConfiguration {
     static var standard: Self {
         let userDefaults = UserDefaults.standard
         return .init(
-            allowsExternalPlayback: userDefaults.allowsExternalPlaybackEnabled,
             usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
             smartNavigationEnabled: userDefaults.smartNavigationEnabled
         )

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -48,9 +48,6 @@ struct SettingsView: View {
     private var playerLayout: PlayerLayout = .custom
 #endif
 
-    @AppStorage(UserDefaults.allowsExternalPlaybackKey)
-    private var allowsExternalPlayback = true
-
     @AppStorage(UserDefaults.smartNavigationEnabledKey)
     private var isSmartNavigationEnabled = true
 
@@ -91,7 +88,6 @@ struct SettingsView: View {
 #if os(iOS)
             playerLayoutPicker()
 #endif
-            Toggle("Allows external playback", isOn: $allowsExternalPlayback)
             Toggle(isOn: $isSmartNavigationEnabled) {
                 Text("Smart navigation")
                 Text("Improves playlist navigation so that it feels more natural.").font(.footnote)

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -57,9 +57,6 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.seekBehaviorSettingKey)
     private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
 
-    @AppStorage(UserDefaults.audiovisualBackgroundPlaybackPolicyKey)
-    private var audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
-
     private var version: String {
         Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
     }
@@ -100,7 +97,6 @@ struct SettingsView: View {
                 Text("Improves playlist navigation so that it feels more natural.").font(.footnote)
             }
             seekBehaviorPicker()
-            audiovisualBackgroundPlaybackPolicyPicker()
         }
     }
 
@@ -119,15 +115,6 @@ struct SettingsView: View {
         Picker("Seek behavior", selection: $seekBehaviorSetting) {
             Text("Immediate").tag(SeekBehaviorSetting.immediate)
             Text("Deferred").tag(SeekBehaviorSetting.deferred)
-        }
-    }
-
-    @ViewBuilder
-    private func audiovisualBackgroundPlaybackPolicyPicker() -> some View {
-        Picker("Audiovisual background policy", selection: $audiovisualBackgroundPlaybackPolicyKey) {
-            Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
-            Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
-            Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
         }
     }
 

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -25,7 +25,6 @@ extension UserDefaults {
     static let playerLayoutKey = "playerLayout"
 #endif
 
-    static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
     static let serverSettingKey = "serverSetting"
@@ -39,10 +38,6 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.playerLayoutKey)) ?? .custom
     }
 #endif
-
-    @objc dynamic var allowsExternalPlaybackEnabled: Bool {
-        bool(forKey: Self.allowsExternalPlaybackKey)
-    }
 
     @objc dynamic var smartNavigationEnabled: Bool {
         bool(forKey: Self.smartNavigationEnabledKey)
@@ -69,7 +64,6 @@ extension UserDefaults {
         register(defaults: [
             Self.presenterModeEnabledKey: false,
             Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
-            Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
             Self.serverSettingKey: ServerSetting.production.rawValue
         ])

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -28,7 +28,6 @@ extension UserDefaults {
     static let allowsExternalPlaybackKey = "allowsExternalPlayback"
     static let smartNavigationEnabledKey = "smartNavigationEnabled"
     static let seekBehaviorSettingKey = "seekBehaviorSetting"
-    static let audiovisualBackgroundPlaybackPolicyKey = "audiovisualBackgroundPlaybackPolicy"
     static let serverSettingKey = "serverSetting"
 
     @objc dynamic var presenterModeEnabled: Bool {
@@ -62,10 +61,6 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: Self.seekBehaviorSettingKey)) ?? .immediate
     }
 
-    @objc dynamic var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {
-        .init(rawValue: integer(forKey: Self.audiovisualBackgroundPlaybackPolicyKey)) ?? .automatic
-    }
-
     @objc dynamic var serverSetting: ServerSetting {
         .init(rawValue: integer(forKey: Self.serverSettingKey)) ?? .production
     }
@@ -76,7 +71,6 @@ extension UserDefaults {
             Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
             Self.allowsExternalPlaybackKey: true,
             Self.smartNavigationEnabledKey: true,
-            Self.audiovisualBackgroundPlaybackPolicyKey: AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic.rawValue,
             Self.serverSettingKey: ServerSetting.production.rawValue
         ])
     }

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -4,31 +4,37 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import Player
 import SwiftUI
 
 struct OptInView: View {
     let media: Media
+
     @StateObject private var player = Player(configuration: .standard)
 
     @State private var isActive = true
+    @State private var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
 
     var body: some View {
         VStack {
             PlaybackView(player: player)
-            VStack(alignment: .leading) {
+                .background(.black)
+            List {
                 Toggle(isOn: $isActive) {
                     Text("Active")
                 }
-                Toggle(isOn: $player.isTrackingEnabled) {
-                    Text("Tracking")
+                audiovisualBackgroundPlaybackPolicyPicker()
+
+                Section {
+                    Toggle(isOn: $player.isTrackingEnabled) {
+                        Text("Tracking")
+                    }
+                } footer: {
+                    Text("Use a proxy tool to observe events.")
                 }
-                Label("Use a proxy tool to observe events.", systemImage: "eyes")
             }
-            .foregroundColor(.white)
-            .padding()
         }
-        .background(.black)
         .onChange(of: isActive) { newValue in
             if newValue {
                 player.becomeActive()
@@ -37,8 +43,20 @@ struct OptInView: View {
                 player.resignActive()
             }
         }
+        .onChange(of: audiovisualBackgroundPlaybackPolicy) { newValue in
+            player.audiovisualBackgroundPlaybackPolicy = newValue
+        }
         .onAppear(perform: play)
         .tracked(name: "tracking")
+    }
+
+    @ViewBuilder
+    private func audiovisualBackgroundPlaybackPolicyPicker() -> some View {
+        Picker("Audiovisual background policy", selection: $audiovisualBackgroundPlaybackPolicy) {
+            Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
+            Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
+            Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
+        }
     }
 
     private func play() {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -106,6 +106,17 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer
     }
 
+    /// A policy that determines how playback of audiovisual media continues when the app transitions
+    /// to the background.
+    public var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {
+        get {
+            queuePlayer.audiovisualBackgroundPlaybackPolicy
+        }
+        set {
+            queuePlayer.audiovisualBackgroundPlaybackPolicy = newValue
+        }
+    }
+
     let queuePlayer = QueuePlayer()
     let nowPlayingSession: MPNowPlayingSession
 
@@ -172,7 +183,6 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer.allowsExternalPlayback = false
         queuePlayer.usesExternalPlaybackWhileExternalScreenIsActive = configuration.usesExternalPlaybackWhileMirroring
         queuePlayer.preventsDisplaySleepDuringVideoPlayback = configuration.preventsDisplaySleepDuringVideoPlayback
-        queuePlayer.audiovisualBackgroundPlaybackPolicy = configuration.audiovisualBackgroundPlaybackPolicy
     }
 
     private func configureControlCenterPublishers() {

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -19,10 +19,6 @@ public struct PlayerConfiguration {
     /// A Boolean indicating whether video playback prevents display and device sleep.
     public let preventsDisplaySleepDuringVideoPlayback: Bool
 
-    /// A policy that determines how playback of audiovisual media continues when the app transitions
-    /// to the background.
-    public let audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy
-
     /// A Boolean controlling whether smart playlist navigation is enabled.
     ///
     /// See `returnToPrevious()` for more information.
@@ -39,7 +35,6 @@ public struct PlayerConfiguration {
         allowsExternalPlayback: Bool = true,
         usesExternalPlaybackWhileMirroring: Bool = false,
         preventsDisplaySleepDuringVideoPlayback: Bool = true,
-        audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic,
         smartNavigationEnabled: Bool = true,
         backwardSkipInterval: TimeInterval = 10,
         forwardSkipInterval: TimeInterval = 10
@@ -49,7 +44,6 @@ public struct PlayerConfiguration {
         self.allowsExternalPlayback = allowsExternalPlayback
         self.usesExternalPlaybackWhileMirroring = usesExternalPlaybackWhileMirroring
         self.preventsDisplaySleepDuringVideoPlayback = preventsDisplaySleepDuringVideoPlayback
-        self.audiovisualBackgroundPlaybackPolicy = audiovisualBackgroundPlaybackPolicy
         self.isSmartNavigationEnabled = smartNavigationEnabled
         self.backwardSkipInterval = backwardSkipInterval
         self.forwardSkipInterval = forwardSkipInterval

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -15,7 +15,6 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.allowsExternalPlayback).to(beTrue())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
         expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beTrue())
-        expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.automatic))
         expect(player.configuration.isSmartNavigationEnabled).to(beTrue())
         expect(player.configuration.backwardSkipInterval).to(equal(10))
         expect(player.configuration.forwardSkipInterval).to(equal(10))
@@ -26,7 +25,6 @@ final class PlayerConfigurationTests: TestCase {
             allowsExternalPlayback: false,
             usesExternalPlaybackWhileMirroring: true,
             preventsDisplaySleepDuringVideoPlayback: false,
-            audiovisualBackgroundPlaybackPolicy: .pauses,
             smartNavigationEnabled: false,
             backwardSkipInterval: 42,
             forwardSkipInterval: 47
@@ -35,7 +33,6 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
         expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
         expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beFalse())
-        expect(player.configuration.audiovisualBackgroundPlaybackPolicy).to(equal(.pauses))
         expect(player.configuration.isSmartNavigationEnabled).to(beFalse())
         expect(player.configuration.backwardSkipInterval).to(equal(42))
         expect(player.configuration.forwardSkipInterval).to(equal(47))


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

Following a proposal made in #636 here is a variant which does not make the configuration mutable while still providing mutability for the audiovisual background policy.

# Changes made

- Make `audiovisualBackgroundPlaybackPolicy` a computed property instead of an immutable player configuration setting.
- Remove external playback and audiovisual background policy from global app settings. External playback is now always available with our custom player and unavailable in some limited demos, which means we still can observe all behaviors in the demo app.
- Add audiovisual policy setting to the opt-in demo. Its layout has slightly been improved in the process (use of a `List`).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
