### PR TITLE
Remove UIKit-oriented APIs

### DIFF
--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -33,11 +33,7 @@ public final class PictureInPicture {
         system.delegate = delegate
     }
 
-    /// Restores from in-app Picture in Picture playback.
-    ///
-    /// UIKit view controllers must call this method on view appearance to ensure playback can be automatically restored
-    /// from Picture in Picture.
-    public func restoreFromInAppPictureInPicture() {
+    func restoreFromInAppPictureInPicture() {
         switch mode {
         case .custom:
             custom.restoreFromInAppPictureInPicture()
@@ -46,12 +42,7 @@ public final class PictureInPicture {
         }
     }
 
-    /// Enables in-app Picture in Picture playback.
-    ///
-    /// UIKit view controllers must call this method on view disappearance to register a cleanup closure which will
-    /// ensure resources which must be kept alive during Picture in Picture are properly cleaned up when Picture
-    /// in Picture does not require them anymore.
-    public func enableInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) {
+    func enableInAppPictureInPictureWithCleanup(perform cleanup: @escaping () -> Void) {
         switch mode {
         case .custom:
             custom.enableInAppPictureInPictureWithCleanup(perform: cleanup)

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -11,9 +11,8 @@ import SwiftUI
 /// The button is automatically hidden when Picture in Picture is not available. The body closure is provided a
 /// Boolean indicating when Picture in Picture is active.
 ///
-/// For the button to be visible one of its parent must be enabled for in-app Picture in Picture. In SwiftUI apps
-/// this is achieved by applying the `View.enabledForInAppPictureInPictureWithCleanup(perform:)` modifier. In UIKit
-/// apps `PictureInPicture.restoreFromInAppPictureInPicture()` must be called instead when the playback view appears.
+/// For the button to be visible one of its parent must be enabled for in-app Picture in Picture by applying the
+/// `View.enabledForInAppPictureInPictureWithCleanup(perform:)` modifier.
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
 


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR removes some APIs initially exposed for UIKit but which are not required anyway as a player should be implenented in SwiftUI, then wrapped into UIKit code if required.

# Changes made

- Hide `PictureInPicture.restoreFromInAppPictureInPicture()`.
- Hide `PictureInPicture. enableInAppPictureInPictureWithCleanup(perform:)`.
- Update documentation to remove references to these APIs.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
