### PR TITLE
Add GitHub shortcuts

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -137,6 +137,9 @@
     "Presenter mode" : {
 
     },
+    "Project" : {
+
+    },
     "Search" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -38,6 +38,9 @@
     "Add a stream to the playlist" : {
 
     },
+    "Android" : {
+
+    },
     "Application" : {
 
     },
@@ -75,6 +78,9 @@
 
     },
     "Displays touches for presentation purposes." : {
+
+    },
+    "Documentation" : {
 
     },
     "Embeddings" : {
@@ -161,6 +167,9 @@
     "Smart navigation" : {
 
     },
+    "Source code" : {
+
+    },
     "Stop" : {
 
     },
@@ -186,6 +195,9 @@
 
     },
     "Version information" : {
+
+    },
+    "Web" : {
 
     }
   },

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -191,9 +191,9 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity)
     }
 
+#if os(iOS)
     @ViewBuilder
     private func gitHubSection() -> some View {
-#if os(iOS)
         Section("GitHub") {
             Button("Project") { GitHub.open(.project) }
             Button("Source code") { GitHub.open(.apple) }
@@ -206,8 +206,8 @@ struct SettingsView: View {
                         .tint(.green)
                 }
         }
-#endif
     }
+#endif
 
     private func simulateMemoryWarning() {
         UIApplication.shared.perform(Selector(("_performMemoryWarning")))

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -88,8 +88,8 @@ struct SettingsView: View {
             applicationSection()
             playerSection()
             debuggingSection()
-            versionSection()
             gitHubSection()
+            versionSection()
         }
         .navigationTitle("Settings")
         .tracked(name: "settings")

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -192,11 +192,16 @@ struct SettingsView: View {
     @ViewBuilder
     private func gitHubSection() -> some View {
         Section("GitHub") {
-            HStack {
-                Button("Project", action: {
-                    UIApplication.shared.open(Github.baseUrl().appending(path: "orgs/SRGSSR/projects/9"))
-                })
-            }
+            Button("Project") { UIApplication.shared.open(Github.baseUrl().appending(path: "orgs/SRGSSR/projects/9")) }
+            Button("Source code") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-apple")) }
+                .swipeActions {
+                    Button("Web") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-web")) }
+                        .tint(.yellow)
+                    Button("Documentation") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-documentation")) }
+                        .tint(.red)
+                    Button("Android") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-android")) }
+                        .tint(.green)
+                }
         }
     }
 

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -193,14 +193,14 @@ struct SettingsView: View {
     private func gitHubSection() -> some View {
 #if os(iOS)
         Section("GitHub") {
-            Button("Project") { UIApplication.shared.open(Github.baseUrl().appending(path: "orgs/SRGSSR/projects/9")) }
-            Button("Source code") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-apple")) }
+            Button("Project") { GitHub.open(.project) }
+            Button("Source code") { GitHub.open(.apple) }
                 .swipeActions {
-                    Button("Web") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-web")) }
+                    Button("Web") { GitHub.open(.web) }
                         .tint(.yellow)
-                    Button("Documentation") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-documentation")) }
+                    Button("Documentation") { GitHub.open(.documentation) }
                         .tint(.red)
-                    Button("Android") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-android")) }
+                    Button("Android") { GitHub.open(.android) }
                         .tint(.green)
                 }
         }

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -89,6 +89,7 @@ struct SettingsView: View {
             playerSection()
             debuggingSection()
             versionSection()
+            gitHubSection()
         }
         .navigationTitle("Settings")
         .tracked(name: "settings")
@@ -186,6 +187,17 @@ struct SettingsView: View {
             Text(" in Switzerland")
         }
         .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private func gitHubSection() -> some View {
+        Section("GitHub") {
+            HStack {
+                Button("Project", action: {
+                    UIApplication.shared.open(Github.baseUrl().appending(path: "orgs/SRGSSR/projects/9"))
+                })
+            }
+        }
     }
 
     private func simulateMemoryWarning() {

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -191,6 +191,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func gitHubSection() -> some View {
+#if os(iOS)
         Section("GitHub") {
             Button("Project") { UIApplication.shared.open(Github.baseUrl().appending(path: "orgs/SRGSSR/projects/9")) }
             Button("Source code") { UIApplication.shared.open(Github.baseUrl().appending(path: "srgssr/pillarbox-apple")) }
@@ -203,6 +204,9 @@ struct SettingsView: View {
                         .tint(.green)
                 }
         }
+#else
+        self
+#endif
     }
 
     private func simulateMemoryWarning() {

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -88,7 +88,9 @@ struct SettingsView: View {
             applicationSection()
             playerSection()
             debuggingSection()
+#if os(iOS)
             gitHubSection()
+#endif
             versionSection()
         }
         .navigationTitle("Settings")
@@ -204,8 +206,6 @@ struct SettingsView: View {
                         .tint(.green)
                 }
         }
-#else
-        self
 #endif
     }
 

--- a/Demo/Sources/Showcase/SourceCodeViewable.swift
+++ b/Demo/Sources/Showcase/SourceCodeViewable.swift
@@ -7,6 +7,18 @@
 import Player
 import SwiftUI
 
+enum Github {
+    static func baseUrl() -> URL {
+        var url = URL("github://github.com")
+        if !UIApplication.shared.canOpenURL(url) {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+            components.scheme = "https"
+            url = components.url!
+        }
+        return url
+    }
+}
+
 private struct SourceCodeButton: View {
     let action: () -> Void
 
@@ -46,15 +58,10 @@ extension View {
     private func gitHubUrl<T>(for objectType: T.Type) -> URL? where T: SourceCodeViewable {
         let separator = "/Demo/"
         guard let relativePath = objectType.filePath.split(separator: separator).last else { return nil }
-        var url = URL("github://github.com/SRGSSR/pillarbox-apple/blob")
+        return Github.baseUrl()
+            .appending(path: "SRGSSR/pillarbox-apple/blob")
             .appending(component: Player.version)
             .appending(path: separator)
             .appending(path: relativePath)
-        if !UIApplication.shared.canOpenURL(url) {
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-            components.scheme = "https"
-            url = components.url!
-        }
-        return url
     }
 }

--- a/Demo/Sources/Showcase/SourceCodeViewable.swift
+++ b/Demo/Sources/Showcase/SourceCodeViewable.swift
@@ -13,6 +13,7 @@ enum GitHub {
         case apple
         case documentation
         case project
+        case sourceCode(_ path: String)
         case web
 
         var url: URL {
@@ -25,13 +26,18 @@ enum GitHub {
                 baseUrl().appending(path: "srgssr/pillarbox-documentation")
             case .project:
                 baseUrl().appending(path: "orgs/SRGSSR/projects/9")
+            case let .sourceCode(path):
+                baseUrl()
+                    .appending(path: "SRGSSR/pillarbox-apple/blob")
+                    .appending(component: Player.version)
+                    .appending(path: path)
             case .web:
                 baseUrl().appending(path: "srgssr/pillarbox-web")
             }
         }
     }
 
-    static func baseUrl() -> URL {
+    private static func baseUrl() -> URL {
         var url = URL("github://github.com")
         if !UIApplication.shared.canOpenURL(url) {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
@@ -85,10 +91,6 @@ extension View {
     private func gitHubUrl<T>(for objectType: T.Type) -> URL? where T: SourceCodeViewable {
         let separator = "/Demo/"
         guard let relativePath = objectType.filePath.split(separator: separator).last else { return nil }
-        return GitHub.baseUrl()
-            .appending(path: "SRGSSR/pillarbox-apple/blob")
-            .appending(component: Player.version)
-            .appending(path: separator)
-            .appending(path: relativePath)
+        return GitHub.Link.sourceCode(separator + relativePath).url
     }
 }

--- a/Demo/Sources/Showcase/SourceCodeViewable.swift
+++ b/Demo/Sources/Showcase/SourceCodeViewable.swift
@@ -7,7 +7,30 @@
 import Player
 import SwiftUI
 
-enum Github {
+enum GitHub {
+    enum Link {
+        case android
+        case apple
+        case documentation
+        case project
+        case web
+
+        var url: URL {
+            switch self {
+            case .android:
+                baseUrl().appending(path: "srgssr/pillarbox-android")
+            case .apple:
+                baseUrl().appending(path: "srgssr/pillarbox-apple")
+            case .documentation:
+                baseUrl().appending(path: "srgssr/pillarbox-documentation")
+            case .project:
+                baseUrl().appending(path: "orgs/SRGSSR/projects/9")
+            case .web:
+                baseUrl().appending(path: "srgssr/pillarbox-web")
+            }
+        }
+    }
+
     static func baseUrl() -> URL {
         var url = URL("github://github.com")
         if !UIApplication.shared.canOpenURL(url) {
@@ -16,6 +39,10 @@ enum Github {
             url = components.url!
         }
         return url
+    }
+
+    static func open(_ link: Link) {
+        UIApplication.shared.open(link.url)
     }
 }
 
@@ -58,7 +85,7 @@ extension View {
     private func gitHubUrl<T>(for objectType: T.Type) -> URL? where T: SourceCodeViewable {
         let separator = "/Demo/"
         guard let relativePath = objectType.filePath.split(separator: separator).last else { return nil }
-        return Github.baseUrl()
+        return GitHub.baseUrl()
             .appending(path: "SRGSSR/pillarbox-apple/blob")
             .appending(component: Player.version)
             .appending(path: separator)


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR enables us to provide a user-friendly shortcut for accessing our project repositories.

# Changes made

- A new settings section has been added to the demo app.


![shortcut-1](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/0418c2af-4171-453f-b706-371bd9a6d045)

![shortcut-2](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/603546b4-c2c1-48f8-a8fb-4cfdcc27c466)

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
