### PR TITLE
Display SRG SSR media duration in minutes

### DIFF
--- a/Demo/Sources/Model/MediaDescription.swift
+++ b/Demo/Sources/Model/MediaDescription.swift
@@ -13,12 +13,20 @@ enum MediaDescription {
     }
 
     private static var dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeZone = TimeZone(identifier: "Europe/Zurich")
-        dateFormatter.dateStyle = .long
-        dateFormatter.timeStyle = .none
-        dateFormatter.doesRelativeDateFormatting = true
-        return dateFormatter
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "Europe/Zurich")
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        formatter.doesRelativeDateFormatting = true
+        return formatter
+    }()
+
+    private static var minuteFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = .minute
+        formatter.unitsStyle = .short
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
     }()
 
     static func title(for media: SRGMedia) -> String {
@@ -26,8 +34,7 @@ enum MediaDescription {
     }
 
     static func subtitle(for media: SRGMedia) -> String {
-        let icon = media.mediaType == .audio ? "🎧" : "🎬"
-        let description = "\(dateFormatter.string(from: media.date)) \(icon)"
+        let description = "\(date(for: media)) - \(duration(for: media)) \(icon(for: media))"
         if let show = media.show {
             return "\(show.title) - \(description)"
         }
@@ -38,5 +45,17 @@ enum MediaDescription {
 
     static func style(for media: SRGMedia) -> Style {
         media.timeAvailability(at: Date()) == .available ? .standard : .disabled
+    }
+
+    private static func date(for media: SRGMedia) -> String {
+        dateFormatter.string(from: media.date)
+    }
+
+    private static func duration(for media: SRGMedia) -> String {
+        minuteFormatter.string(from: max(media.duration / 1000, 60))!
+    }
+
+    private static func icon(for media: SRGMedia) -> String {
+        media.mediaType == .audio ? "🎧" : "🎬"
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR simply adds duration information to SRG SSR content lists, as was done on in demos for other platforms.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
