### PR TITLE
Enable new rules introduced in SwiftLint 0.53.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -101,6 +101,7 @@ opt_in_rules:
   - multiline_literal_brackets
   - multiline_parameters
   - multiline_parameters_brackets
+  - non_overridable_class_declaration
   - nslocalizedstring_key
   - object_literal
   - operator_usage_whitespace
@@ -117,6 +118,7 @@ opt_in_rules:
   - private_action
   - private_outlet
   - private_subject
+  - private_swiftui_state
   - prohibited_interface_builder
   - prohibited_super_call
   - quick_discouraged_call


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR enables new rules introduced in SwiftLint [0.5.3](https://github.com/realm/SwiftLint/releases/tag/0.53.0). Version 0.54.0 [cannot be installed with Homebrew](https://github.com/Homebrew/homebrew-core/pull/153931) yet so we will have to wait a bit for the next rule update.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
