### PR TITLE
Fix methods incorrectly marked as deprecated in documentation catalogs

### DIFF
--- a/Sources/Player/UserInterface/LayoutReader.swift
+++ b/Sources/Player/UserInterface/LayoutReader.swift
@@ -21,6 +21,7 @@ public struct LayoutInfo {
 }
 
 /// An internal view controller which can determine whether it covers its current context or is full screen.
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 private final class LayoutReaderViewController: UIViewController, UIGestureRecognizerDelegate {
     var layoutInfo: Binding<LayoutInfo> = .constant(.none)
@@ -68,6 +69,7 @@ private final class LayoutReaderViewController: UIViewController, UIGestureRecog
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 private struct LayoutReader: UIViewControllerRepresentable {
     @Binding private var layoutInfo: LayoutInfo
@@ -85,6 +87,7 @@ private struct LayoutReader: UIViewControllerRepresentable {
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public extension View {
     /// Read layout information.
@@ -98,6 +101,7 @@ public extension View {
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 struct LayoutReader_Previews: PreviewProvider {
     private struct IgnoredSafeArea: View {

--- a/Sources/Player/UserInterface/Slider.swift
+++ b/Sources/Player/UserInterface/Slider.swift
@@ -6,6 +6,7 @@
 
 import SwiftUI
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public extension Slider {
     /// Creates a slider bound to a progress tracker.
@@ -36,6 +37,7 @@ public extension Slider {
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public extension Slider where ValueLabel == EmptyView {
     /// Creates a slider bound to a progress tracker.
@@ -60,6 +62,7 @@ public extension Slider where ValueLabel == EmptyView {
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public extension Slider where Label == EmptyView, ValueLabel == EmptyView {
     /// Creates a slider bound to a progress tracker.

--- a/Sources/Player/UserInterface/VisibilityTracker.swift
+++ b/Sources/Player/UserInterface/VisibilityTracker.swift
@@ -14,6 +14,7 @@ import UIKit
 ///
 /// The tracker automatically provides meaningful default behaviors, most notably to automatically turn visibility off
 /// after a delay during playback. This mechanism is disabled when playback is paused or when VoiceOver is enabled.
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public final class VisibilityTracker: ObservableObject {
     private enum TriggerId {
@@ -141,6 +142,7 @@ public final class VisibilityTracker: ObservableObject {
     }
 }
 
+@available(iOS 16, *)
 @available(tvOS, unavailable)
 public extension View {
     /// Binds a visibility tracker to a player.


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->
# Description

This PR fixes an issue with DocC generation, preventing methods marked as `unavailable` on a platform from being reported as deprecated when looking at the documentation catalog generated for another platform. This most notably occurs for methods extending types outside the documented package.

| Before | After |
|--------|--------|
| ![before](https://github.com/SRGSSR/pillarbox-apple/assets/170201/9ae7ab76-341b-4e85-9394-53f996bcf94f) | ![after](https://github.com/SRGSSR/pillarbox-apple/assets/170201/9ce5381f-8e74-4013-953c-aec063ecdfe9) |

# Changes made

- Explicitly mark methods unavailable for one platform as available for other ones.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
