### PR TITLE
Make the version script more tolerant for build by Swift Package Index

### DIFF
--- a/Artifacts/PackageInfo.artifactbundle/package-info.sh
+++ b/Artifacts/PackageInfo.artifactbundle/package-info.sh
@@ -6,13 +6,11 @@ if [ "$#" -ne 2 ]; then
 fi
 
 if ! VERSION=$(git --git-dir "$1/.git" describe --tags 2> /dev/null); then
-    echo "No tag was found in the specified directory or the directory is not a valid git repository."
-    exit 1
+    VERSION="0.0.0"
 fi
 
 if ! SHORT_VERSION=$(git --git-dir "$1/.git" describe --tags --abbrev=0 2> /dev/null); then
-    echo "No tag was found in the specified repository."
-    exit 1
+    SHORT_VERSION="0.0.0"
 fi
 
 GENERATED_FILE_PATH="$2/PackageInfo.swift"


### PR DESCRIPTION
# Description

This PR addresses build issues with Swift Package index:

```
...
" /Users/admin/builds/h8344Zi3/0/finestructure/swiftpackageindex-builder/spi-builder-workspace/Artifacts/PackageInfo.artifactbundle/package-info.sh /Users/admin/builds/h8344Zi3/0/finestructure/swiftpackageindex-builder/spi-builder-workspace/Sources/Player/../.. /Users/admin/builds/h8344Zi3/0/finestructure/swiftpackageindex-builder/spi-builder-workspace/.dependencies/plugins/spi-builder-workspace.output/Player/PackageInfoPlugin
No tag was found in the specified directory or the directory is not a valid git repository.
** BUILD INTERRUPTED **
```

# Changes made

Use `0.0.0` as version fallback if one of the version extraction script commands fails.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
