### PR TITLE
Integrate with Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [Analytics, Circumspect, Core, CoreBusiness, Player]

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,8 @@
+---
 version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: [Analytics, Circumspect, Core, CoreBusiness, Player]
+      documentation_targets: [
+        Analytics, Circumspect, Core, CoreBusiness, Player
+      ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Overview
 
-[![GitHub releases](https://img.shields.io/github/v/release/SRGSSR/pillarbox-apple)](https://github.com/SRGSSR/pillarbox-apple/releases) [![platform](https://img.shields.io/badge/platfom-ios%20%7C%20tvos-blue)](https://github.com/SRGSSR/pillarbox-apple) [![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager) [![GitHub license](https://img.shields.io/github/license/SRGSSR/pillarbox-apple)](../LICENSE)
+[![Releases](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FSRGSSR%2Fpillarbox-apple%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/SRGSSR/pillarbox-apple) [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FSRGSSR%2Fpillarbox-apple%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/SRGSSR/pillarbox-apple) [![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager) [![GitHub license](https://img.shields.io/github/license/SRGSSR/pillarbox-apple)](LICENSE)
 
 Pillarbox is the iOS and tvOS modern reactive SRG SSR player ecosystem implemented on top of AVFoundation and AVKit. Pillarbox has been designed with robustness, efficiency and flexibilty in mind, with full customization of:
 


### PR DESCRIPTION
# Description

This PR adds badges and a manifest for [Swift Package Index integration](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/information-for-package-maintainers).

# Changes made

- Add badges.
- Fix license badge link.
- Add SPI manifest for building documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
