### PR TITLE
Update Swift Package manifest to Swift 5.9

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
-        "version" : "2.1.2"
+        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+        "version" : "2.2.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "921c98e57e3044377ee955db5282406e11e6a787",
-        "version" : "5.4.1"
+        "revision" : "bff12bbf890409182a055999985a28b4608b9b14",
+        "version" : "5.4.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
-        "version" : "2.1.2"
+        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+        "version" : "2.2.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "921c98e57e3044377ee955db5282406e11e6a787",
-        "version" : "5.4.1"
+        "revision" : "bff12bbf890409182a055999985a28b4608b9b14",
+        "version" : "5.4.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
# Description

This PR updates the minimum required Swift version declared in the package manifest to 5.9. Pillarbox [will not compile](https://xcodereleases.com/) with Xcode 14 or below anyway.

# Changes made

- Update Swift version to 5.9.
- Update depdencies.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
