### PR TITLE
Update cells appearance for tvOS

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0ECC5AD52A517A4C0064E701 /* PlaybackSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */; };
 		0EDFF0DB2B0740DA005030B4 /* SourceCodeViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */; };
 		0EE2A3AE2B29D6D000BAAD65 /* CustomList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE2A3AD2B29D6D000BAAD65 /* CustomList.swift */; };
+		0EE2A3B02B29F82200BAAD65 /* CustomSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE2A3AF2B29F82200BAAD65 /* CustomSection.swift */; };
 		0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */ = {isa = PBXBuildFile; productRef = 0EF42CB529AE513400553165 /* SRGDataProviderCombine */; };
 		6F02B3092AB870AD002D15DB /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 6F02B3082AB870AD002D15DB /* Localizable.xcstrings */; };
 		6F0B2E852A40EBAC00B69675 /* RouterDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0B2E842A40EBAC00B69675 /* RouterDestination.swift */; };
@@ -87,6 +88,7 @@
 		0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackSlider.swift; sourceTree = "<group>"; };
 		0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceCodeViewable.swift; sourceTree = "<group>"; };
 		0EE2A3AD2B29D6D000BAAD65 /* CustomList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomList.swift; sourceTree = "<group>"; };
+		0EE2A3AF2B29F82200BAAD65 /* CustomSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSection.swift; sourceTree = "<group>"; };
 		6F010340289946220021BA76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F02B3082AB870AD002D15DB /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pillarbox-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -356,6 +358,7 @@
 				6FC5D6A32A6FACB20012BC89 /* CloseButton.swift */,
 				6F59E86629CF31E10093E6FB /* CopyButton.swift */,
 				0EE2A3AD2B29D6D000BAAD65 /* CustomList.swift */,
+				0EE2A3AF2B29F82200BAAD65 /* CustomSection.swift */,
 				6F59E86829CF31E10093E6FB /* MessageViews.swift */,
 				6FC5D6A12A6FA8D20012BC89 /* Modal.swift */,
 				0ECC5AD42A517A4C0064E701 /* PlaybackSlider.swift */,
@@ -598,6 +601,7 @@
 				6F59E89229CF31E20093E6FB /* WrappedViewModel.swift in Sources */,
 				6FD407892B189C0600D34BD1 /* TrackingVisibilityTutorial~ios.swift in Sources */,
 				0ECC5AD52A517A4C0064E701 /* PlaybackSlider.swift in Sources */,
+				0EE2A3B02B29F82200BAAD65 /* CustomSection.swift in Sources */,
 				6F59E89929CF31E20093E6FB /* PlaybackView.swift in Sources */,
 				6F59E8A029CF31E20093E6FB /* Constant.swift in Sources */,
 				6F6643D92A61140600BFD644 /* URL.swift in Sources */,

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -86,12 +86,17 @@ private struct ContentCell: View {
             .swipeActions { CopyButton(text: media.urn) }
 #endif
         case let .show(show):
+#if os(iOS)
             NavigationLink(
                 show.title,
                 destination: .contentList(configuration: .init(list: .latestMediasForShow(show), vendor: show.vendor))
             )
-#if os(iOS)
             .swipeActions { CopyButton(text: show.urn) }
+#else
+            NavigationLink(destination: RouterDestination.contentList(configuration: .init(list: .latestMediasForShow(show), vendor: show.vendor)).view()) {
+                Text(show.title)
+                    .frame(width: 300, height: 250, alignment: .leading)
+            }
 #endif
         }
     }

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -73,7 +73,7 @@ private struct ContentCell: View {
 #else
             NavigationLink(destination: RouterDestination.contentList(configuration: .init(list: .latestMediasForTopic(topic), vendor: topic.vendor)).view()) {
                 Text(topic.title)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(width: 300, height: 250, alignment: .leading)
             }
 #endif
         case let .media(media):

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -15,7 +15,7 @@ struct ContentListsView: View {
     var body: some View {
         CustomList {
             Self.content()
-                .padding(.horizontal, constant(iOS: 0, tvOS: 50))
+                .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
 #if os(iOS)
         .navigationTitle("Lists (\(selectedServerSetting.title))")
@@ -23,6 +23,8 @@ struct ContentListsView: View {
         .toolbarTitleMenu {
             serverSettingsMenu()
         }
+#else
+        .ignoresSafeArea(.all, edges: .horizontal)
 #endif
     }
 

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -51,14 +51,14 @@ struct ContentListsView: View {
 
     @ViewBuilder
     private static func section(title: String, image: String? = nil, configurations: [ContentList.Configuration]) -> some View {
-        Section {
+        CustomSection {
             ForEach(configurations) { configuration in
 #if os(iOS)
                 NavigationLink(configuration.name, destination: .contentList(configuration: configuration))
 #else
                 NavigationLink(destination: RouterDestination.contentList(configuration: configuration).view()) {
                     Text(configuration.name)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(width: 300, height: 250, alignment: .leading)
                 }
 #endif
             }

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -129,7 +129,7 @@ struct ExamplesView: View {
 
     @ViewBuilder
     private func section(title: String, medias: [Media]) -> some View {
-        Section(title) {
+        CustomSection(title: title) {
             ForEach(medias, id: \.self) { media in
                 Cell(title: media.title, subtitle: media.description) {
                     router.presented = .player(media: media)

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -82,11 +82,13 @@ struct ExamplesView: View {
     var body: some View {
         CustomList {
             content()
-                .padding(.horizontal, constant(iOS: 0, tvOS: 50))
+                .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
 #if os(iOS)
         .navigationTitle("Examples")
         .refreshable { await model.refresh() }
+#else
+        .ignoresSafeArea(.all, edges: .horizontal)
 #endif
     }
 

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -129,7 +129,7 @@ struct ExamplesView: View {
 
     @ViewBuilder
     private func section(title: String, medias: [Media]) -> some View {
-        CustomSection(title: title) {
+        CustomSection(title) {
             ForEach(medias, id: \.self) { media in
                 Cell(title: media.title, subtitle: media.description) {
                     router.presented = .player(media: media)

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -52,10 +52,11 @@ struct SearchView: View {
                             model.loadMore()
                         }
                     }
-                    .padding(.horizontal, constant(iOS: 0, tvOS: 50))
 #if os(iOS)
                     .swipeActions { CopyButton(text: media.urn) }
                     .refreshable { await model.refresh() }
+#else
+                    .ignoresSafeArea(.all, edges: .horizontal)
 #endif
                 }
             }

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -87,10 +87,12 @@ struct SettingsView: View {
     var body: some View {
         CustomList {
             content()
-                .padding(.horizontal, constant(iOS: 0, tvOS: 50))
+                .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
 #if os(iOS)
         .navigationTitle("Settings")
+#else
+        .ignoresSafeArea(.all, edges: .horizontal)
 #endif
     }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -43,7 +43,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func layoutsSection() -> some View {
-        Section("Layouts") {
+        CustomSection(title: "Layouts") {
             cell(
                 title: "Simple",
                 subtitle: "A basic video playback experience",
@@ -70,7 +70,7 @@ struct ShowcaseView: View {
     @ViewBuilder
     private func playlistsSection() -> some View {
         // swiftlint:disable:next closure_body_length
-        Section("Playlists") {
+        CustomSection(title: "Playlists") {
             cell(
                 title: "Video URLs",
                 destination: .playlist(templates: URLTemplates.videos)
@@ -110,7 +110,7 @@ struct ShowcaseView: View {
     @ViewBuilder
     private func embeddingsSection() -> some View {
         // swiftlint:disable:next closure_body_length
-        Section("Embeddings") {
+        CustomSection(title: "Embeddings") {
             cell(
                 title: "Twins",
                 subtitle: "A video displayed twice",
@@ -153,7 +153,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func systemPlayerSection() -> some View {
-        Section("System player (using Pillarbox)") {
+        CustomSection(title: "System player (using Pillarbox)") {
             cell(
                 title: "Apple Basic 16:9",
                 destination: .systemPlayer(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS))
@@ -188,7 +188,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func inlineSystemPlayerSection() -> some View {
-        Section("Inline system player (using Pillarbox)") {
+        CustomSection(title: "Inline system player (using Pillarbox)") {
             cell(
                 title: "Video URN - On-demand",
                 destination: .inlineSystemPlayer(media: Media(from: URNTemplate.onDemandVideo))
@@ -199,7 +199,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func vanillaPlayerSection() -> some View {
-        Section("System player (using AVPlayer)") {
+        CustomSection(title: "System player (using AVPlayer)") {
             cell(
                 title: "Apple Basic 16:9",
                 destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.appleBasic_16_9_TS_HLS)!)
@@ -226,7 +226,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func trackingSection() -> some View {
-        Section("Opt-in features") {
+        CustomSection(title: "Opt-in features") {
             cell(
                 title: "Video URL",
                 destination: .optInPlayer(media: Media(from: URLTemplate.onDemandVideoMP4))

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -43,7 +43,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func layoutsSection() -> some View {
-        CustomSection(title: "Layouts") {
+        CustomSection("Layouts") {
             cell(
                 title: "Simple",
                 subtitle: "A basic video playback experience",
@@ -70,7 +70,7 @@ struct ShowcaseView: View {
     @ViewBuilder
     private func playlistsSection() -> some View {
         // swiftlint:disable:next closure_body_length
-        CustomSection(title: "Playlists") {
+        CustomSection("Playlists") {
             cell(
                 title: "Video URLs",
                 destination: .playlist(templates: URLTemplates.videos)
@@ -110,7 +110,7 @@ struct ShowcaseView: View {
     @ViewBuilder
     private func embeddingsSection() -> some View {
         // swiftlint:disable:next closure_body_length
-        CustomSection(title: "Embeddings") {
+        CustomSection("Embeddings") {
             cell(
                 title: "Twins",
                 subtitle: "A video displayed twice",
@@ -153,7 +153,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func systemPlayerSection() -> some View {
-        CustomSection(title: "System player (using Pillarbox)") {
+        CustomSection("System player (using Pillarbox)") {
             cell(
                 title: "Apple Basic 16:9",
                 destination: .systemPlayer(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS))
@@ -188,7 +188,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func inlineSystemPlayerSection() -> some View {
-        CustomSection(title: "Inline system player (using Pillarbox)") {
+        CustomSection("Inline system player (using Pillarbox)") {
             cell(
                 title: "Video URN - On-demand",
                 destination: .inlineSystemPlayer(media: Media(from: URNTemplate.onDemandVideo))
@@ -199,7 +199,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func vanillaPlayerSection() -> some View {
-        CustomSection(title: "System player (using AVPlayer)") {
+        CustomSection("System player (using AVPlayer)") {
             cell(
                 title: "Apple Basic 16:9",
                 destination: .vanillaPlayer(item: Template.playerItem(from: URLTemplate.appleBasic_16_9_TS_HLS)!)
@@ -226,7 +226,7 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func trackingSection() -> some View {
-        CustomSection(title: "Opt-in features") {
+        CustomSection("Opt-in features") {
             cell(
                 title: "Video URL",
                 destination: .optInPlayer(media: Media(from: URLTemplate.onDemandVideoMP4))

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -13,10 +13,12 @@ struct ShowcaseView: View {
     var body: some View {
         CustomList {
             content()
-                .padding(.horizontal, constant(iOS: 0, tvOS: 50))
+                .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
 #if os(iOS)
         .navigationTitle("Showcase")
+#else
+        .ignoresSafeArea(.all, edges: .horizontal)
 #endif
     }
 

--- a/Demo/Sources/Views/Cell.swift
+++ b/Demo/Sources/Views/Cell.swift
@@ -24,7 +24,11 @@ struct Cell: View {
                         .foregroundColor(.secondary)
                 }
             }
+#if os(iOS)
             .frame(maxWidth: .infinity, alignment: .leading)
+#else
+            .frame(width: 300, height: 250, alignment: .leading)
+#endif
         }
     }
 

--- a/Demo/Sources/Views/CustomList.swift
+++ b/Demo/Sources/Views/CustomList.swift
@@ -20,7 +20,9 @@ struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
 #else
         ScrollView {
             if !data.isEmpty {
-                ForEach(data, id: \.self, content: content)
+                LazyVGrid(columns: (0...3).map { _ in GridItem(.flexible()) }, spacing: 30) {
+                    ForEach(data, id: \.self, content: content)
+                }
             } else {
                 VStack(alignment: .leading) {
                     content(nil)

--- a/Demo/Sources/Views/CustomSection.swift
+++ b/Demo/Sources/Views/CustomSection.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+struct CustomSection<Content>: View where Content: View {
+    let title: any StringProtocol
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+#if os(iOS)
+        Section {
+            content()
+        } header: {
+            Text(title)
+        }
+#else
+        Section {
+            ScrollView(.horizontal) {
+                HStack(spacing: 30, content: content)
+                    .padding(15)
+            }
+        } header: {
+            Text(title)
+                .padding(.vertical, -15)
+                .padding(.top, 10)
+        }
+#endif
+    }
+}

--- a/Demo/Sources/Views/CustomSection.swift
+++ b/Demo/Sources/Views/CustomSection.swift
@@ -6,16 +6,16 @@
 
 import SwiftUI
 
-struct CustomSection<Content>: View where Content: View {
-    let title: any StringProtocol
+struct CustomSection<Content, Header>: View where Content: View, Header: View {
     @ViewBuilder let content: () -> Content
+    @ViewBuilder let header: () -> Header
 
     var body: some View {
 #if os(iOS)
         Section {
             content()
         } header: {
-            Text(title)
+            header()
         }
 #else
         Section {
@@ -24,10 +24,20 @@ struct CustomSection<Content>: View where Content: View {
                     .padding(15)
             }
         } header: {
-            Text(title)
+            header()
                 .padding(.vertical, -15)
                 .padding(.top, 10)
         }
 #endif
+    }
+}
+
+extension CustomSection where Header == Text {
+    init(_ title: String, @ViewBuilder content: @escaping () -> Content) {
+        self.init {
+            content()
+        } header: {
+            Text(title)
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR enables us to update the appearance of cells on tvOS to align with the more common style found on the tvOS platform.

# Changes made

Self-explanatory

| Before | After |
|--------|--------|
|  ![1-examples-after](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/7c6c113c-a8c6-421f-a729-cb903006d8f5) | ![examples](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/c6253780-7658-418c-8196-7192b9705023) | 

> Note: The cell's aspects (font, alignments, images, spacing, etc.) will be enhanced in a future PR.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
