### PR TITLE
Prevent frame drops in grid lists on tvOS

### DIFF
--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -22,7 +22,7 @@ private struct LoadedView: View {
                             model.loadMore()
                         }
                     }
-                    .padding(.horizontal, constant(iOS: 0, tvOS: 50))
+                    .padding(.horizontal, constant(iOS: 0, tvOS: 20))
             }
         }
 #if os(iOS)

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -52,6 +52,7 @@ struct SearchView: View {
                             model.loadMore()
                         }
                     }
+                    .padding(.horizontal, constant(iOS: 0, tvOS: 20))
 #if os(iOS)
                     .swipeActions { CopyButton(text: media.urn) }
                     .refreshable { await model.refresh() }

--- a/Demo/Sources/Views/CustomList.swift
+++ b/Demo/Sources/Views/CustomList.swift
@@ -6,6 +6,28 @@
 
 import SwiftUI
 
+private struct CustomGrid<Content, Data>: View where Content: View, Data: Hashable {
+    let columns: Int = 4
+    let data: [Data]
+    @ViewBuilder let content: (Data?) -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 40) {
+            let rows = data.count / columns + 1
+            ForEach(0..<rows, id: \.self) { row in
+                HStack(spacing: 0) {
+                    ForEach(0..<columns, id: \.self) { column in
+                        let index = row * columns + column
+                        if index < data.count {
+                            content(data[index])
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
     let data: [Data]
     @ViewBuilder let content: (Data?) -> Content
@@ -20,10 +42,9 @@ struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
 #else
         ScrollView {
             if !data.isEmpty {
-                LazyVGrid(columns: (0...3).map { _ in GridItem(.flexible()) }, spacing: 30) {
-                    ForEach(data, id: \.self, content: content)
-                }
-            } else {
+                CustomGrid(data: data, content: content)
+            }
+            else {
                 VStack(alignment: .leading) {
                     content(nil)
                 }

--- a/Demo/Sources/Views/MessageViews.swift
+++ b/Demo/Sources/Views/MessageViews.swift
@@ -45,6 +45,9 @@ struct RefreshableMessageView<Model>: View where Model: Refreshable {
                     .frame(width: geometry.size.width, height: geometry.size.height)
             }
             .refreshable { await model.refresh() }
+#if os(tvOS)
+            .focusable()
+#endif
         }
     }
 }


### PR DESCRIPTION
# Description

This PR addresses frame drop issue in grid lists to enhance performance.

# Changes Made

- Replaced the lazy grid with a custom grid.

| Before | After |
|--------|--------|
| <video src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/269f1c5d-52a6-444b-af8f-6c0ca69fa70b"></video> | <video src="https://github.com/SRGSSR/pillarbox-apple/assets/3347810/a1dc4c25-b453-4c59-882e-41c50caaa7b2"></video> |


> Note: Tests have been made on a physical device running on tvOS 17.1. Additional tests are scheduled to be performed on tvOS 16.x.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
