### PR TITLE
Fix missing media information in iOS cells

### DIFF
--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -89,8 +89,8 @@ private struct ContentCell: View {
             let title = MediaDescription.title(for: media)
             Cell(
                 size: .init(width: 570, height: 350),
-                title: media.show?.title,
-                subtitle: media.title,
+                title: constant(iOS: title, tvOS: media.show?.title),
+                subtitle: constant(iOS: MediaDescription.subtitle(for: media), tvOS: media.title),
                 image: SRGDataProvider.current!.url(for: media.image, size: .large),
                 type: MediaDescription.systemImage(for: media),
                 duration: MediaDescription.duration(for: media),

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -45,8 +45,8 @@ struct SearchView: View {
                 if let media {
                     Cell(
                         size: .init(width: 520, height: 300),
-                        title: media.show?.title,
-                        subtitle: media.title,
+                        title: constant(iOS: MediaDescription.title(for: media), tvOS: media.show?.title),
+                        subtitle: constant(iOS: MediaDescription.subtitle(for: media), tvOS: media.title),
                         image: SRGDataProvider.current!.url(for: media.image, size: .large),
                         type: MediaDescription.systemImage(for: media),
                         duration: MediaDescription.duration(for: media),

--- a/Demo/Sources/Views/MediaCardView.swift
+++ b/Demo/Sources/Views/MediaCardView.swift
@@ -53,6 +53,7 @@ private struct CardBottomView: View {
                     .padding(.horizontal, 50)
                     .padding(.bottom, date == nil ? 30 : 0)
                     .lineLimit(2)
+                    .multilineTextAlignment(.center)
             }
             if let date {
                 Text(date)


### PR DESCRIPTION
# Description

This PR put back the previous layout design for iOS cells.

# Changes made

- Restored the previous layout for iOS cells.
- Centered description in multiple lines.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
