### PR TITLE
Animate video view display

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -120,6 +120,7 @@ private struct MainView: View {
                     .supportsPictureInPicture(supportsPictureInPicture)
             }
         }
+        .animation(.easeInOut(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive)
     }
 
     @ViewBuilder


### PR DESCRIPTION
# Description

This PR adds a subtle video view animation when the media type or the external playback status change. This follows a question from @mbruegmann and provides an example directly in the Pillarbox demo.

No `VideoView` explicit support is required, standard SwiftUI animations can be applied externally to the `VideoView`.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
