### PR TITLE
Make player animations smoother

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -120,7 +120,7 @@ private struct MainView: View {
                     .supportsPictureInPicture(supportsPictureInPicture)
             }
         }
-        .animation(.easeInOut(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive)
+        .animation(.easeIn(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -478,15 +478,11 @@ private struct PlaybackButton: View {
         if player.canReplay() {
             return "arrow.counterclockwise.circle.fill"
         }
+        else if player.rate == 0 {
+            return "play.circle.fill"
+        }
         else {
-            switch player.playbackState {
-            case .playing:
-                return "pause.circle.fill"
-            case .paused:
-                return "play.circle.fill"
-            default:
-                return nil
-            }
+            return "pause.circle.fill"
         }
     }
 

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -37,7 +37,7 @@ struct SimplePlayerView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+            Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 50)

--- a/Demo/Sources/Showcase/Multi/SingleView.swift
+++ b/Demo/Sources/Showcase/Multi/SingleView.swift
@@ -44,7 +44,7 @@ struct SingleView: View {
     @ViewBuilder
     private func playbackButton(player: Player) -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+            Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 50)

--- a/README.md
+++ b/README.md
@@ -54,20 +54,11 @@ struct PlayerView: View {
         item: .simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
     )
 
-    private var buttonImage: String {
-        switch player.playbackState {
-        case .playing:
-            return "pause.circle.fill"
-        default:
-            return "play.circle.fill"
-        }
-    }
-
     var body: some View {
         ZStack {
             VideoView(player: player)
             Button(action: player.togglePlayPause) {
-                Image(systemName: buttonImage)
+                Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                     .resizable()
                     .frame(width: 80, height: 80)
             }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-6.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-6.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
         ZStack {
             VideoView(player: player)
             Button(action: player.togglePlayPause) {
-                Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
             VideoView(player: player)
             HStack(spacing: 20) {
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-4.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-4.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-5.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-5.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-6.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-6.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.playbackState == .playing ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.rate == 0 ? "play.circle.fill" : "pause.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)


### PR DESCRIPTION
# Description

This PR slightly tweaks player animations for a better result.

# Changes made

- Use `rate` to decide whether we should display a pause or play button. Since play and pause are ultimately related to the rate of the player, this provides a better result and avoids unnecessary button flickering. Moreover this makes sense even while content is being loaded since the rate can be changed at any time.
- Update all player implementations consistently (except the Playground which is removed in #719).
- Tweak video view animation curve introduced in #713. Note that #713 produces a bit of flickering when changing items in a playlist. If this is unacceptable we can remove this animation entirely.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
