### PR TITLE
Support starting playback at a given time

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		6F0E5CD32B3394EA0031E313 /* PiPButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0E5CD22B3394EA0031E313 /* PiPButton.swift */; };
 		6F0E5CD52B33A41F0031E313 /* MonoscopicVideoView~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0E5CD42B33A41F0031E313 /* MonoscopicVideoView~ios.swift */; };
 		6F26F35E2B33B73900392ED4 /* SupportingBasicPictureInPicture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F26F35D2B33B73900392ED4 /* SupportingBasicPictureInPicture.swift */; };
+		6F49E0442B4D4C7D00F67C8F /* StartAtGivenTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F49E0432B4D4C7D00F67C8F /* StartAtGivenTimeView.swift */; };
 		6F59E87929CF31E10093E6FB /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84029CF31E10093E6FB /* SearchView.swift */; };
 		6F59E87A29CF31E10093E6FB /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84129CF31E10093E6FB /* SearchViewModel.swift */; };
 		6F59E87B29CF31E10093E6FB /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E84329CF31E10093E6FB /* DemoApp.swift */; };
@@ -118,6 +119,7 @@
 		6F45DB9D2893B773008ACCE6 /* Demo.nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Demo.nightly.xcconfig; sourceTree = "<group>"; };
 		6F45DB9E2893B773008ACCE6 /* Demo.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Demo.debug.xcconfig; sourceTree = "<group>"; };
 		6F45DB9F2893B773008ACCE6 /* Demo.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Demo.release.xcconfig; sourceTree = "<group>"; };
+		6F49E0432B4D4C7D00F67C8F /* StartAtGivenTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAtGivenTimeView.swift; sourceTree = "<group>"; };
 		6F59E84029CF31E10093E6FB /* SearchView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		6F59E84129CF31E10093E6FB /* SearchViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		6F59E84329CF31E10093E6FB /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 				6F59E87029CF31E10093E6FB /* PlayerView.swift */,
 				0E4128BE2AFB959B00D67759 /* PlayerViewModel.swift */,
 				6F59E86C29CF31E10093E6FB /* SimplePlayerView.swift */,
+				6F49E0432B4D4C7D00F67C8F /* StartAtGivenTimeView.swift */,
 				6F59E86D29CF31E10093E6FB /* SystemPlayerView.swift */,
 				6F59E86F29CF31E10093E6FB /* VanillaPlayerView.swift */,
 			);
@@ -640,6 +643,7 @@
 				6F0E5CD32B3394EA0031E313 /* PiPButton.swift in Sources */,
 				6F59E89629CF31E20093E6FB /* Cell.swift in Sources */,
 				0EF2A5452B443FEF00F01804 /* WebView~ios.swift in Sources */,
+				6F49E0442B4D4C7D00F67C8F /* StartAtGivenTimeView.swift in Sources */,
 				6F59E89A29CF31E20093E6FB /* SimplePlayerView.swift in Sources */,
 				6F59E89329CF31E20093E6FB /* LinkView.swift in Sources */,
 				6F59E89529CF31E20093E6FB /* CopyButton.swift in Sources */,

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -98,9 +98,6 @@
     "Improves playlist navigation so that it feels more natural." : {
 
     },
-    "Inline system player (using Pillarbox)" : {
-
-    },
     "Layouts" : {
 
     },

--- a/Demo/Sources/Players/StartAtGivenTimeView.swift
+++ b/Demo/Sources/Players/StartAtGivenTimeView.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import PillarboxCoreBusiness
+import PillarboxPlayer
+import SwiftUI
+
+struct StartAtGivenTimeView: View {
+    @StateObject private var player = Player(
+        item: .urn("urn:rts:video:14608947") { item in
+            item.seek(at(.init(value: 1055300, timescale: 1000)))
+        }
+    )
+
+    var body: some View {
+        SystemVideoView(player: player)
+            .onAppear(perform: player.play)
+    }
+}
+
+extension StartAtGivenTimeView: SourceCodeViewable {
+    static var filePath: String { #file }
+}
+
+#Preview {
+    StartAtGivenTimeView()
+}

--- a/Demo/Sources/Router/RouterDestination.swift
+++ b/Demo/Sources/Router/RouterDestination.swift
@@ -14,6 +14,8 @@ enum RouterDestination: Identifiable, Hashable {
     case simplePlayer(media: Media)
     case optInPlayer(media: Media)
 
+    case startAtGivenTime
+
     case vanillaPlayer(item: AVPlayerItem)
 
     case blurred(media: Media)
@@ -41,6 +43,8 @@ enum RouterDestination: Identifiable, Hashable {
             return "simplePlayer"
         case .optInPlayer:
             return "optInPlayer"
+        case .startAtGivenTime:
+            return "startAtGivenTime"
         case .vanillaPlayer:
             return "vanillaPlayer"
         case .blurred:
@@ -92,6 +96,8 @@ enum RouterDestination: Identifiable, Hashable {
             SimplePlayerView(media: media)
         case let .optInPlayer(media: media):
             OptInView(media: media)
+        case .startAtGivenTime:
+            StartAtGivenTimeView()
         case let .vanillaPlayer(item: item):
             VanillaPlayerView(item: item)
         case let .blurred(media: media):

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -30,7 +30,7 @@ struct ShowcaseView: View {
             playlistsSection()
             embeddingsSection()
             systemPlayerSection()
-            inlineSystemPlayerSection()
+            systemPlayerFeaturesSection()
             customPictureInPictureSection()
             systemPictureInPictureSection()
             vanillaPlayerSection()
@@ -205,13 +205,21 @@ struct ShowcaseView: View {
     }
 
     @ViewBuilder
-    private func inlineSystemPlayerSection() -> some View {
-        CustomSection("Inline system player (using Pillarbox)") {
+    private func systemPlayerFeaturesSection() -> some View {
+        CustomSection("System player features (using Pillarbox)") {
             cell(
                 title: "Couleur 3 (DVR)",
+                subtitle: "Inline playback",
                 destination: .inlineSystemPlayer(media: Media(from: URLTemplate.dvrVideoHLS))
             )
             .sourceCode(of: InlineSystemPlayerView.self)
+
+            cell(
+                title: "19h30 - La nature peut enfin se reposer...",
+                subtitle: "Start at a given time",
+                destination: .startAtGivenTime
+            )
+            .sourceCode(of: StartAtGivenTimeView.self)
         }
     }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -30,7 +30,7 @@ struct ShowcaseView: View {
             playlistsSection()
             embeddingsSection()
             systemPlayerSection()
-            systemPlayerFeaturesSection()
+            miscellaneousPlayerFeaturesSection()
             customPictureInPictureSection()
             systemPictureInPictureSection()
             vanillaPlayerSection()
@@ -205,18 +205,18 @@ struct ShowcaseView: View {
     }
 
     @ViewBuilder
-    private func systemPlayerFeaturesSection() -> some View {
-        CustomSection("System player features (using Pillarbox)") {
+    private func miscellaneousPlayerFeaturesSection() -> some View {
+        CustomSection("Miscellaneous player features (using Pillarbox)") {
             cell(
                 title: "Couleur 3 (DVR)",
-                subtitle: "Inline playback",
+                subtitle: "Inline system playback view",
                 destination: .inlineSystemPlayer(media: Media(from: URLTemplate.dvrVideoHLS))
             )
             .sourceCode(of: InlineSystemPlayerView.self)
 
             cell(
                 title: "19h30 - La nature peut enfin se reposer...",
-                subtitle: "Start at a given time",
+                subtitle: "Playback start at a given time",
                 destination: .startAtGivenTime
             )
             .sourceCode(of: StartAtGivenTimeView.self)

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -245,7 +245,7 @@ extension Asset {
 }
 
 extension AVPlayerItem {
-    /// An identifier to identify player items delivered by the same data source.
+    /// An identifier for player items delivered by the same data source.
     var id: UUID? {
         get {
             objc_getAssociatedObject(self, &kIdKey) as? UUID
@@ -255,7 +255,7 @@ extension AVPlayerItem {
         }
     }
 
-    /// Assigns an identifier to identify player items delivered by the same data source.
+    /// Assigns an identifier for player items delivered by the same data source.
     /// 
     /// - Parameter id: The id to assign.
     /// - Returns: The receiver with the id assigned to it.

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -6,6 +6,17 @@
 
 import AVFoundation
 
+public extension AVPlayerItem {
+    /// Seeks to a given position.
+    ///
+    /// - Parameter position: The position to seek to.
+    ///
+    /// This method can be used to start an `AVPlayerItem` at some position.
+    func seek(_ position: Position) {
+        seek(to: position.time, toleranceBefore: position.toleranceBefore, toleranceAfter: position.toleranceAfter, completionHandler: nil)
+    }
+}
+
 extension AVPlayerItem {
     var timeRange: CMTimeRange {
         TimeProperties.timeRange(loadedTimeRanges: loadedTimeRanges, seekableTimeRanges: seekableTimeRanges)

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -11,7 +11,7 @@ public extension AVPlayerItem {
     ///
     /// - Parameter position: The position to seek to.
     ///
-    /// This method can be used to start an `AVPlayerItem` at some position.
+    /// This method can be used to start playback of an `AVPlayerItem` at some position.
     func seek(_ position: Position) {
         seek(to: position.time, toleranceBefore: position.toleranceBefore, toleranceAfter: position.toleranceAfter, completionHandler: nil)
     }

--- a/Sources/Player/Player.docc/Articles/playback/playback.md
+++ b/Sources/Player/Player.docc/Articles/playback/playback.md
@@ -33,8 +33,8 @@ You create a player with or without associated items to be played. Since ``Playe
 
         ```swift
         struct PlayerView: View {
-            @StateObject private var player = Player(item:
-                .simple(url: URL(string: "https://server.com/stream.m3u8")!)
+            @StateObject private var player = Player(
+                item: .simple(url: URL(string: "https://server.com/stream.m3u8")!)
             )
         }
         ```
@@ -76,20 +76,39 @@ The resulting player item can then be played with ``Player`` instance, possibly 
 
 A player loaded with content starts in a paused state. To actually start playback you have to call ``Player/play()``, usually when the associated view appears. For example a very basic layout able to display video content would look like:
 
-<!-- markdownlint-disable MD046 -->
-```swift
-struct PlayerView: View {
-    @StateObject private var player = Player(item:
-        .simple(url: URL(string: "https://server.com/stream.m3u8")!)
-    )
+@TabNavigator {
+    @Tab("Start at the default position") {
+        ```swift
+        struct PlayerView: View {
+            @StateObject private var player = Player(
+                item: .simple(url: URL(string: "https://server.com/stream.m3u8")!)
+            )
 
-    var body: some View {
-        VideoView(player: player)
-            .onAppear(perform: player.play)
+            var body: some View {
+                VideoView(player: player)
+                    .onAppear(perform: player.play)
+            }
+        }
+        ```
+    }
+
+    @Tab("Start at a given position") {
+        ```swift
+        struct PlayerView: View {
+            @StateObject private var player = Player(
+                item: .simple(url: URL(string: "https://server.com/stream.m3u8")!) { item in
+                    item.seek(at(.init(value: 10, timescale: 1)))
+                }
+            )
+
+            var body: some View {
+                VideoView(player: player)
+                    .onAppear(perform: player.play)
+            }
+        }
+        ```
     }
 }
-```
-<!-- markdownlint-restore -->
 
 ## Play video in the background
 

--- a/Sources/Player/Player.docc/Articles/playback/playback.md
+++ b/Sources/Player/Player.docc/Articles/playback/playback.md
@@ -76,6 +76,7 @@ The resulting player item can then be played with ``Player`` instance, possibly 
 
 A player loaded with content starts in a paused state. To actually start playback you have to call ``Player/play()``, usually when the associated view appears. For example a very basic layout able to display video content would look like:
 
+<!-- markdownlint-disable MD034 -->
 @TabNavigator {
     @Tab("Start at the default position") {
         ```swift
@@ -109,6 +110,7 @@ A player loaded with content starts in a paused state. To actually start playbac
         ```
     }
 }
+<!-- markdownlint-restore -->
 
 ## Play video in the background
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -40,7 +40,7 @@ public final class PlayerItem: Equatable {
     ///
     /// - Parameters:
     ///   - asset: The asset to play.
-    ///   - configuration: A closure to configure player items created from the receiver.
+    ///   - trackerAdapters: An array of `TrackerAdapter` instances to use for tracking playback events.
     public convenience init<M>(asset: Asset<M>, trackerAdapters: [TrackerAdapter<M>] = []) where M: AssetMetadata {
         self.init(publisher: Just(asset), trackerAdapters: trackerAdapters)
     }

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -105,4 +105,18 @@ final class SeekTests: TestCase {
         player.seek(near(player.seekableTimeRange.end + CMTime(value: 10, timescale: 1)))
         expect(player.time).toEventually(equal(player.seekableTimeRange.end), timeout: .seconds(1))
     }
+
+    func testOnDemandStartAtTime() {
+        let player = Player(item: .simple(url: Stream.onDemand.url, configuration: { item in
+            item.seek(to: .init(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: nil)
+        }))
+        expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
+    }
+
+    func testDvrStartAtTime() {
+        let player = Player(item: .simple(url: Stream.dvr.url, configuration: { item in
+            item.seek(to: .init(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: nil)
+        }))
+        expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
+    }
 }

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -108,14 +108,14 @@ final class SeekTests: TestCase {
 
     func testOnDemandStartAtTime() {
         let player = Player(item: .simple(url: Stream.onDemand.url, configuration: { item in
-            item.seek(to: .init(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: nil)
+            item.seek(at(.init(value: 10, timescale: 1)))
         }))
         expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
     }
 
     func testDvrStartAtTime() {
         let player = Player(item: .simple(url: Stream.dvr.url, configuration: { item in
-            item.seek(to: .init(value: 10, timescale: 1), toleranceBefore: .zero, toleranceAfter: .zero, completionHandler: nil)
+            item.seek(at(.init(value: 10, timescale: 1)))
         }))
         expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
     }

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -107,16 +107,16 @@ final class SeekTests: TestCase {
     }
 
     func testOnDemandStartAtTime() {
-        let player = Player(item: .simple(url: Stream.onDemand.url, configuration: { item in
+        let player = Player(item: .simple(url: Stream.onDemand.url) { item in
             item.seek(at(.init(value: 10, timescale: 1)))
-        }))
+        })
         expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
     }
 
     func testDvrStartAtTime() {
-        let player = Player(item: .simple(url: Stream.dvr.url, configuration: { item in
+        let player = Player(item: .simple(url: Stream.dvr.url) { item in
             item.seek(at(.init(value: 10, timescale: 1)))
-        }))
+        })
         expect(player.time.seconds).toEventually(equal(10), timeout: .seconds(1))
     }
 }


### PR DESCRIPTION
# Description

This PR shows how playback of an item can be started at a given position (no dedicated support needed).

# Changes made

- Add configuration support for PillarboxCoreBusiness player items.
- Add convenience helper to seek an `AVPlayerItem` at a given position.
- Add example to the demo

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
