### PR TITLE
Eliminate undesired layer animations

### DIFF
--- a/Sources/Player/UserInterface/VideoLayerView.swift
+++ b/Sources/Player/UserInterface/VideoLayerView.swift
@@ -28,23 +28,24 @@ final class VideoLayerView: UIView {
 
     override func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
-        layer.synchronizeAnimations {
+        layer.synchronizeLayoutChanges {
             playerLayer.frame = layer.bounds
         }
     }
 }
 
 private extension CALayer {
-    func synchronizeAnimations(_ animations: () -> Void) {
-        CATransaction.begin()
+    func synchronizeLayoutChanges(_ changes: () -> Void) {
         if let positionAnimation = animation(forKey: "position") {
+            CATransaction.begin()
             CATransaction.setAnimationDuration(positionAnimation.duration)
             CATransaction.setAnimationTimingFunction(positionAnimation.timingFunction)
+            changes()
+            CATransaction.commit()
         }
         else {
-            CATransaction.disableActions()
+            changes()
+            sublayers?.forEach { $0.removeAllAnimations() }
         }
-        animations()
-        CATransaction.commit()
     }
 }


### PR DESCRIPTION
# Description

This PR enables us to remove some undesired layer animations.

# Changes made

- Eliminated all sublayer animations for layers that cannot be animated, preventing undesired animations.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
