### PR TITLE
Make all skips consistently non-smooth

### DIFF
--- a/Sources/Player/Player+SkipToDefault.swift
+++ b/Sources/Player/Player+SkipToDefault.swift
@@ -33,11 +33,11 @@ public extension Player {
     func skipToDefault(completion: @escaping (Bool) -> Void = { _ in }) {
         switch streamType {
         case .dvr:
-            seek(after(seekableTimeRange.end)) { finished in
+            seek(after(seekableTimeRange.end), smooth: false) { finished in
                 completion(finished)
             }
         default:
-            seek(near(.zero)) { finished in
+            seek(near(.zero), smooth: false) { finished in
                 completion(finished)
             }
         }


### PR DESCRIPTION
# Description

Skips forward and backward are made in a non-smooth way, so that the desire to move at a given location is taken into account immediately.

This behavior was not implemented for skips to the default position. This PR fixes this inconsistency.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
