### PR TITLE
Rename isRunning as shouldPlay

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -478,7 +478,7 @@ private struct PlaybackButton: View {
         if player.canReplay() {
             return "arrow.counterclockwise.circle.fill"
         }
-        else if player.isRunning {
+        else if player.shouldPlay {
             return "pause.circle.fill"
         }
         else {

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -37,7 +37,7 @@ struct SimplePlayerView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+            Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 50)

--- a/Demo/Sources/Showcase/Multi/SingleView.swift
+++ b/Demo/Sources/Showcase/Multi/SingleView.swift
@@ -44,7 +44,7 @@ struct SingleView: View {
     @ViewBuilder
     private func playbackButton(player: Player) -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+            Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 50)

--- a/Demo/Tutorials/TrackingVisibilityTutorial~ios.swift
+++ b/Demo/Tutorials/TrackingVisibilityTutorial~ios.swift
@@ -39,7 +39,7 @@ struct TrackingVisibilityTutorial: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ struct PlayerView: View {
         ZStack {
             VideoView(player: player)
             Button(action: player.togglePlayPause) {
-                Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                     .resizable()
                     .frame(width: 80, height: 80)
             }

--- a/Sources/Core/BodyCounter.swift
+++ b/Sources/Core/BodyCounter.swift
@@ -71,13 +71,13 @@ public extension View {
         ProcessInfo.processInfo.environment["PILLARBOX_DEBUG_BODY_COUNTER"] != nil
     }
 
-    private var isRunningInXcodePreviews: Bool {
+    private var shouldPlayInXcodePreviews: Bool {
         ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
     }
 
     @ViewBuilder
     private func debugBodyCounterOverlay(color: UIColor) -> some View {
-        if isDebuggingEnabled || isRunningInXcodePreviews {
+        if isDebuggingEnabled || shouldPlayInXcodePreviews {
             BodyCounterView(color: color)
                 .allowsHitTesting(false)
         }

--- a/Sources/Player/Player+Playback.swift
+++ b/Sources/Player/Player+Playback.swift
@@ -7,21 +7,16 @@
 public extension Player {
     /// Resumes playback.
     func play() {
-        queuePlayer.play()
+        shouldPlay = true
     }
 
     /// Pauses playback.
     func pause() {
-        queuePlayer.pause()
+        shouldPlay = false
     }
 
     /// Toggles playback between play and pause.
     func togglePlayPause() {
-        if shouldPlay {
-            queuePlayer.pause()
-        }
-        else {
-            queuePlayer.play()
-        }
+        shouldPlay.toggle()
     }
 }

--- a/Sources/Player/Player+Playback.swift
+++ b/Sources/Player/Player+Playback.swift
@@ -17,7 +17,7 @@ public extension Player {
 
     /// Toggles playback between play and pause.
     func togglePlayPause() {
-        if isRunning {
+        if shouldPlay {
             queuePlayer.pause()
         }
         else {

--- a/Sources/Player/Player.docc/Articles/state-observation/state-observation.md
+++ b/Sources/Player/Player.docc/Articles/state-observation/state-observation.md
@@ -29,7 +29,7 @@ struct PlaybackView: View {
         VStack {
             VideoView(player: player)
             Button(action: player.togglePlayPause) {
-                Text(player.isRunning ? "Pause" : "Play")
+                Text(player.shouldPlay ? "Pause" : "Play")
             }
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-6.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-6.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
         ZStack {
             VideoView(player: player)
             Button(action: player.togglePlayPause) {
-                Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
             VideoView(player: player)
             HStack(spacing: 20) {
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-4.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-4.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-5.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-5.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-6.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-6.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
                         .frame(width: 30)
                 }
                 Button(action: player.togglePlayPause) {
-                    Image(systemName: player.isRunning ? "pause.circle.fill" : "play.circle.fill")
+                    Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 50)

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-1.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-1.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-2.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-3.swift
@@ -29,7 +29,7 @@ struct ContentView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-4.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-4.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-5.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-5.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
     @ViewBuilder
     private func playbackButton() -> some View {
         Button(action: player.togglePlayPause) {
-            Image(systemName: player.isRunning ? "pause.circle" : "play.circle")
+            Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 60)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -118,7 +118,7 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// A Boolean value indicating whether playback is currently playing.
-    public var isRunning: Bool {
+    public var shouldPlay: Bool {
         rate != 0
     }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -117,7 +117,7 @@ public final class Player: ObservableObject, Equatable {
         }
     }
 
-    /// A Boolean value indicating whether the player should play content when possible.
+    /// A Boolean value whether the player should play content when possible.
     public var shouldPlay: Bool {
         get {
             queuePlayer.rate != 0

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -117,9 +117,19 @@ public final class Player: ObservableObject, Equatable {
         }
     }
 
-    /// A Boolean value indicating whether playback is currently playing.
+    /// A Boolean value indicating whether the player should play content when possible.
     public var shouldPlay: Bool {
-        rate != 0
+        get {
+            queuePlayer.rate != 0
+        }
+        set {
+            if newValue {
+                queuePlayer.rate = queuePlayer.defaultRate
+            }
+            else {
+                queuePlayer.rate = 0
+            }
+        }
     }
 
     let queuePlayer = QueuePlayer()


### PR DESCRIPTION
# Description

Following discussions with the team this PR renames the `isRunning` property as `shouldPlay` to make the API more consistent and intuitive.

Since `should` property usually provide a choice in iOS APIs the property has been made mutable.

# Changes made

- Rename `isRunning` as `shouldPlay`.
- Make the property mutable to control the playback rate.
- Implement `play`, `pause` and `togglePlayPause` as convenience methods changing the `shouldPlay` value. These methods might feel redundant but are common and still useful, most notably as actions.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
