### PR TITLE
Fix replay behavior with unconsumed failed items

### DIFF
--- a/Demo/Sources/Examples/ExamplesViewModel.swift
+++ b/Demo/Sources/Examples/ExamplesViewModel.swift
@@ -86,7 +86,8 @@ final class ExamplesViewModel: ObservableObject {
 
     let cornerCaseMedias = Template.medias(from: [
         URNTemplate.expired,
-        URNTemplate.unknown
+        URNTemplate.unknown,
+        URLTemplate.unauthorized
     ])
 
     @Published private(set) var protectedMedias = [Media]()

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -133,6 +133,10 @@ enum URLTemplate {
         title: "Unknown URL",
         type: .url("http://localhost:8123/simple/unavailable/master.m3u8")
     )
+    static let unauthorized = Template(
+        title: "Unauthorized URL",
+        type: .url("https://httpbin.org/status/403")
+    )
     static let bitmovinOnDemandMultipleTracks = Template(
         title: "Multiple subtitles and audio tracks",
         image: "https://durian.blender.org/wp-content/uploads/2010/06/05.8b_comp_000272.jpg",

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -131,10 +131,12 @@ enum URLTemplate {
     )
     static let unknown = Template(
         title: "Unknown URL",
+        description: "Content that does not exist",
         type: .url("http://localhost:8123/simple/unavailable/master.m3u8")
     )
     static let unauthorized = Template(
         title: "Unauthorized URL",
+        description: "Content which cannot be accessed",
         type: .url("https://httpbin.org/status/403")
     )
     static let bitmovinOnDemandMultipleTracks = Template(

--- a/Sources/Player/Player+Replay.swift
+++ b/Sources/Player/Player+Replay.swift
@@ -9,7 +9,13 @@ public extension Player {
     ///
     /// - Returns: `true` if possible.
     func canReplay() -> Bool {
-        !storedItems.isEmpty && queuePlayer.items().isEmpty
+        guard !storedItems.isEmpty else { return false }
+        if let lastItem = queuePlayer.items().last {
+            return lastItem.error != nil
+        }
+        else {
+            return true
+        }
     }
 
     /// Replays the content from the start, resuming playback automatically.

--- a/Sources/Streams/Stream.swift
+++ b/Sources/Streams/Stream.swift
@@ -117,4 +117,10 @@ public extension Stream {
         url: URL(string: "custom://arbitrary.server/some.m3u8")!,
         duration: .indefinite
     )
+
+    /// An unauthorized stream.
+    static let unauthorized: Self = .init(
+        url: URL(string: "https://httpbin.org/status/403")!,
+        duration: .indefinite
+    )
 }

--- a/Tests/PlayerTests/Player/ReplayChecksTests.swift
+++ b/Tests/PlayerTests/Player/ReplayChecksTests.swift
@@ -26,8 +26,15 @@ final class ReplayChecksTests: TestCase {
         expect(player.canReplay()).toEventually(beTrue())
     }
 
-    func testWithOneBadItem() {
+    func testWithOneBadItemConsumed() {
+        // This item is consumed by the player when failing.
         let player = Player(item: .simple(url: Stream.unavailable.url))
+        expect(player.canReplay()).toEventually(beTrue())
+    }
+
+    func testWithOneBadItemNotConsumed() {
+        // This item is not consumed by the player when failing (for an unknown reason).
+        let player = Player(item: .simple(url: Stream.unauthorized.url))
         expect(player.canReplay()).toEventually(beTrue())
     }
 


### PR DESCRIPTION
# Description

This PR fixes an issue with unconsumed failed items sometimes remaining in the queue (for an unknown reason). 

# Context

Some URLs, e.g. https://httpbin.org/status/403, namely lead to a state where the player has failed to play but the item is not consumed (and thus we still have a failed item in the queue). This leads to `canReplay()` incorrectly reporting `false`, as can be seen with our custom player layout:

| Expected result (and result after fix) | Actual result |
|--------|--------|
| ![Expected](https://github.com/SRGSSR/pillarbox-apple/assets/170201/c07b3ca5-001c-4364-b3e4-de63847c2eb9) | ![Actual](https://github.com/SRGSSR/pillarbox-apple/assets/170201/9801fbb6-3012-448f-8f07-7081c8081528) | 

Remark: The issue can also be reproduced when delivering some MP4s with our local test server.

# Investigations

We knew that `AVPlayer` does not consume failed items but the fact that this sometimes also happens with `AVQueuePlayer` is new.

You can compare behaviors with the following sample code (just uncomment the option you want to test) and what is logged to the console:

```swift
import AVKit
import SwiftUI

struct ContentView: View {
    @State private var player = AVPlayer(url: URL(string: "https://httpbin.org/status/403")!)
    // @State private var player = AVPlayer(url: URL(string: "http://localhost:8123/simple/unavailable/master.m3u8")!)
    // @State private var player = AVQueuePlayer(url: URL(string: "https://httpbin.org/status/403")!)
    // @State private var player = AVQueuePlayer(url: URL(string: "http://localhost:8123/simple/unavailable/master.m3u8")!)

    var body: some View {
        VideoPlayer(player: player)
            .onAppear(perform: player.play)
            .onReceive(player.publisher(for: \.currentItem)) { item in
                print("--> current item: \(item)")
            }
    }
}

#Preview {
    ContentView()
}
```

# Changes made

- Add above sample both in the demo as well as in test streams.
- Fix the behavior by checking if a last unconsumed item is still in the queue.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
