### PR TITLE
Avoid sending several page views to the analytics

### DIFF
--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -14,8 +14,9 @@ struct ContentListsView: View {
 
     var body: some View {
         CustomList {
-            Self.content()
+            content()
         }
+        .tracked(name: "lists")
 #if os(iOS)
         .navigationTitle("Lists (\(selectedServerSetting.title))")
         .navigationBarTitleDisplayMode(.inline)
@@ -27,23 +28,21 @@ struct ContentListsView: View {
 #endif
     }
 
-    private static func content() -> some View {
-        Group {
-            section(for: .tvTopics, image: "tv", vendors: [.RSI, .RTR, .RTS, .SRF, .SWI])
-            section(for: .tvLatestMedias, image: "play.tv", vendors: [.RSI, .RTR, .RTS, .SRF, .SWI])
-            section(for: .tvLivestreams, image: "livephoto.play", vendors: [.RSI, .RTR, .RTS, .SRF])
-            section(for: .tvShows, image: "rectangle.on.rectangle.angled", vendors: [.RSI, .RTR, .RTS, .SRF])
-            section(for: .liveCenterVideos, image: "sportscourt", vendors: [.RSI, .RTS, .SRF])
-            section(for: .tvScheduledLivestreams, image: "globe", vendors: [.RSI, .RTR, .RTS, .SRF])
-            section(for: .radioLivestreams, image: "antenna.radiowaves.left.and.right", vendors: [.RSI, .RTR, .RTS, .SRF])
-            radioShows(image: "waveform")
-            latestAudiosSection(image: "music.note.list")
-        }
-        .tracked(name: "lists")
+    @ViewBuilder
+    private func content() -> some View {
+        section(for: .tvTopics, image: "tv", vendors: [.RSI, .RTR, .RTS, .SRF, .SWI])
+        section(for: .tvLatestMedias, image: "play.tv", vendors: [.RSI, .RTR, .RTS, .SRF, .SWI])
+        section(for: .tvLivestreams, image: "livephoto.play", vendors: [.RSI, .RTR, .RTS, .SRF])
+        section(for: .tvShows, image: "rectangle.on.rectangle.angled", vendors: [.RSI, .RTR, .RTS, .SRF])
+        section(for: .liveCenterVideos, image: "sportscourt", vendors: [.RSI, .RTS, .SRF])
+        section(for: .tvScheduledLivestreams, image: "globe", vendors: [.RSI, .RTR, .RTS, .SRF])
+        section(for: .radioLivestreams, image: "antenna.radiowaves.left.and.right", vendors: [.RSI, .RTR, .RTS, .SRF])
+        radioShows(image: "waveform")
+        latestAudiosSection(image: "music.note.list")
     }
 
     @ViewBuilder
-    private static func section(for list: ContentList, image: String? = nil, vendors: [SRGVendor]) -> some View {
+    private func section(for list: ContentList, image: String? = nil, vendors: [SRGVendor]) -> some View {
         let configurations = vendors.map { vendor in
             ContentList.Configuration(list: list, vendor: vendor)
         }
@@ -51,7 +50,7 @@ struct ContentListsView: View {
     }
 
     @ViewBuilder
-    private static func section(title: String, image: String? = nil, configurations: [ContentList.Configuration]) -> some View {
+    private func section(title: String, image: String? = nil, configurations: [ContentList.Configuration]) -> some View {
         CustomSection {
             ForEach(configurations) { configuration in
                 CustomNavigationLink(
@@ -74,7 +73,7 @@ struct ContentListsView: View {
     }
 
     @ViewBuilder
-    private static func radioShows(image: String) -> some View {
+    private func radioShows(image: String) -> some View {
         section(title: "Radio Shows", image: image, configurations: [
             .init(list: .radioShows(radioChannel: .RSIReteUno), vendor: .RSI),
             .init(list: .radioShows(radioChannel: .RSIReteDue), vendor: .RSI),
@@ -95,7 +94,7 @@ struct ContentListsView: View {
     }
 
     @ViewBuilder
-    private static func latestAudiosSection(image: String) -> some View {
+    private func latestAudiosSection(image: String) -> some View {
         section(title: "Latest Audios", image: image, configurations: [
             .init(list: .radioLatestMedias(radioChannel: .RSIReteUno), vendor: .RSI),
             .init(list: .radioLatestMedias(radioChannel: .RSIReteDue), vendor: .RSI),

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -84,7 +84,10 @@ struct ExamplesView: View {
     var body: some View {
         CustomList {
             content()
+                .scrollDismissesKeyboard(.immediately)
+                .animation(.defaultLinear, value: model.protectedMedias)
         }
+        .tracked(name: "examples")
 #if os(iOS)
         .navigationTitle("Examples")
         .refreshable { await model.refresh() }
@@ -95,15 +98,10 @@ struct ExamplesView: View {
 
     @ViewBuilder
     private func content() -> some View {
-        Group {
-            MediaEntryView()
-            srgSections()
-            thirdPartySections()
-            miscellaneousSections()
-        }
-        .scrollDismissesKeyboard(.immediately)
-        .animation(.defaultLinear, value: model.protectedMedias)
-        .tracked(name: "examples")
+        MediaEntryView()
+        srgSections()
+        thirdPartySections()
+        miscellaneousSections()
     }
 
     @ViewBuilder

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -84,6 +84,7 @@ struct SettingsView: View {
             content()
                 .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
+        .tracked(name: "settings")
 #if os(iOS)
         .navigationTitle("Settings")
 #else
@@ -106,16 +107,13 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func content() -> some View {
-        Group {
-            applicationSection()
-            playerSection()
-            debuggingSection()
+        applicationSection()
+        playerSection()
+        debuggingSection()
 #if os(iOS)
-            gitHubSection()
+        gitHubSection()
 #endif
-            versionSection()
-        }
-        .tracked(name: "settings")
+        versionSection()
     }
 
     @ViewBuilder

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -16,6 +16,7 @@ struct ShowcaseView: View {
         CustomList {
             content()
         }
+        .tracked(name: "showcase")
 #if os(iOS)
         .navigationTitle("Showcase")
 #else
@@ -25,21 +26,18 @@ struct ShowcaseView: View {
 
     @ViewBuilder
     private func content() -> some View {
-        Group {
-            layoutsSection()
-            playlistsSection()
-            embeddingsSection()
-            systemPlayerSection()
-            miscellaneousPlayerFeaturesSection()
-            customPictureInPictureSection()
-            systemPictureInPictureSection()
-            vanillaPlayerSection()
-            trackingSection()
+        layoutsSection()
+        playlistsSection()
+        embeddingsSection()
+        systemPlayerSection()
+        miscellaneousPlayerFeaturesSection()
+        customPictureInPictureSection()
+        systemPictureInPictureSection()
+        vanillaPlayerSection()
+        trackingSection()
 #if os(iOS)
-            webViewSection()
+        webViewSection()
 #endif
-        }
-        .tracked(name: "showcase")
     }
 
     @ViewBuilder

--- a/Demo/Sources/Views/CustomList.swift
+++ b/Demo/Sources/Views/CustomList.swift
@@ -35,7 +35,7 @@ struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
 }
 
 extension CustomList where Data == Never {
-    init(content: @escaping () -> Content) {
+    init(@ViewBuilder content: @escaping () -> Content) {
         self.content = { _ in content() }
         data = []
     }


### PR DESCRIPTION
# Description

This PR addresses an issue related to sending multiple page views.

# Changes Made

- Moved the `tracked` modifier higher up scope, to the root view.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
