### PR TITLE
Avoid starting from an incorrect position in terms of analytics

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -48,12 +48,12 @@ public final class CommandersActTracker: PlayerItemTracker {
             streamingAnalytics.notify(.seek)
         }
         else {
-            switch properties.playbackState {
-            case .playing:
+            switch (properties.playbackState, properties.isBuffering) {
+            case (.playing, false):
                 streamingAnalytics.notify(.play)
-            case .paused:
+            case (.paused, false):
                 streamingAnalytics.notify(.pause)
-            case .ended:
+            case (.ended, false):
                 streamingAnalytics.notify(.eof)
             default:
                 break

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -222,7 +222,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
 
         expectAtLeastHits(
             .play { labels in
-                expect(labels.ns_st_po).to(equal(100))
+                expect(labels.ns_st_po).to(beCloseTo(100, within: 0.5))
             }
         ) {
             player.play()

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -208,4 +208,24 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             player.play()
         }
     }
+
+    func testOnDemandStartAtGivenPosition() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ) { item in
+            item.seek(at(.init(value: 100, timescale: 1)))
+        })
+
+        expectAtLeastHits(
+            .play { labels in
+                expect(labels.ns_st_po).to(equal(100))
+            }
+        ) {
+            player.play()
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerPositionTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerPositionTests.swift
@@ -126,4 +126,24 @@ final class CommandersActTrackerPositionTests: CommandersActTestCase {
             player = nil
         }
     }
+
+    func testOnDemandStartAtGivenPosition() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                CommandersActTracker.adapter { _ in .test }
+            ]
+        ) { item in
+            item.seek(at(.init(value: 100, timescale: 1)))
+        })
+
+        expectAtLeastHits(
+            .play { labels in
+                expect(labels.media_position).to(equal(100))
+            }
+        ) {
+            player.play()
+        }
+    }
 }


### PR DESCRIPTION
# Description

This PR resolves the issue associated with starting at an incorrect position in terms of analytics when a specific time is provided.

# Changes made

- Added some tests
- Triggered no event when buffering occurs.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
