### PR TITLE
Update SwiftLint to version 0.54.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,9 @@ clean-imports:
 	@echo "Cleaning imports..."
 	@mkdir -p .build
 	@xcodebuild -scheme Pillarbox -destination generic/platform=ios > ./.build/xcodebuild.log
-	@swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
+	@mint run swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
 	@xcodebuild -scheme Pillarbox-demo -project ./Demo/Pillarbox-demo.xcodeproj -destination generic/platform=iOS > ./.build/xcodebuild.log
-	@swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
+	@mint run swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
 	@echo "... done.\n"
 
 .PHONY: find-dead-code

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,1 @@
+realm/SwiftLint@0.54.0

--- a/Scripts/check-quality.sh
+++ b/Scripts/check-quality.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "... checking Swift code..."
 if [ $# -eq 0 ]; then
-  swiftlint --quiet --strict
+  mint run swiftlint --quiet --strict
 elif [[ "$1" == "only-changes" ]]; then
   git diff --staged --name-only | grep ".swift$" | xargs swiftlint lint --quiet --strict
 fi

--- a/Scripts/fix-quality.sh
+++ b/Scripts/fix-quality.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-swiftlint --fix && swiftlint
+mint run swiftlint --fix && mint run swiftlint

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -26,12 +26,12 @@ The continuous integration agents must have the following tools installed:
 - [gem](https://rubygems.org)
 - [bundler](https://bundler.io)
 - [ffmpeg](https://ffmpeg.org)
-- [swiftlint](https://github.com/realm/SwiftLint)
+- [mint](https://github.com/yonaskolb/Mint)
 - [shellcheck](https://www.shellcheck.net)
 - [xcodes](https://github.com/RobotsAndPencils/xcodes)
 - [yamllint](https://github.com/adrienverge/yamllint)
 
-ffmpeg, swiftlint, shellcheck and yamllint can easily be installed with [Homebrew](https://brew.sh).
+ffmpeg, mint, shellcheck and yamllint can easily be installed with [Homebrew](https://brew.sh).
 
 ## TeamCity configuration
 

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -26,12 +26,13 @@ The continuous integration agents must have the following tools installed:
 - [gem](https://rubygems.org)
 - [bundler](https://bundler.io)
 - [ffmpeg](https://ffmpeg.org)
+- [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
 - [mint](https://github.com/yonaskolb/Mint)
 - [shellcheck](https://www.shellcheck.net)
 - [xcodes](https://github.com/RobotsAndPencils/xcodes)
 - [yamllint](https://github.com/adrienverge/yamllint)
 
-ffmpeg, mint, shellcheck and yamllint can easily be installed with [Homebrew](https://brew.sh).
+Most of these tools can easily be installed with [Homebrew](https://brew.sh).
 
 ## TeamCity configuration
 

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -13,10 +13,10 @@ The following tools are required for the best possible development experience:
 - [ffmpeg](https://ffmpeg.org)
 - [gem](https://rubygems.org)
 - [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
+- [mint](https://github.com/yonaskolb/Mint)
 - [Periphery](https://github.com/peripheryapp/periphery)
 - [Python](https://www.python.org)
 - [shellcheck](https://www.shellcheck.net)
-- [swiftlint](https://github.com/realm/SwiftLint)
 - [xcodes](https://github.com/RobotsAndPencils/xcodes)
 - [yamllint](https://github.com/adrienverge/yamllint)
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,7 +4,7 @@
 # Quality check
 #================================================================
 
-PATH="$(which swiftlint):$(which ruby):$PATH"
+PATH="$(which mint):$(which ruby):$PATH"
 
 if Scripts/check-quality.sh only-changes; then
 	echo "✅ Quality checked"


### PR DESCRIPTION
# Description

This PR integrates SwiftLint using Mint, as described in the related issue. This makes it possible to pin SwiftLint to a specific version, avoiding conflicts with other projects and ensuring that the rules correctly match.

# Changes made

- Add `Mintfile` for version pinning.
- Update build scripts to run SwiftLint through Mint.
- Update development environment setup documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
