### PR TITLE
Avoid unnecessary thread creation by item trackers

### DIFF
--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -14,7 +14,7 @@ import UIKit
 ///
 /// Analytics have to be properly started for the tracker to collect data, see `Analytics.start(with:)`.
 public final class ComScoreTracker: PlayerItemTracker {
-    private var streamingAnalytics = ComScoreStreamingAnalytics()
+    private lazy var streamingAnalytics = ComScoreStreamingAnalytics()
     private var metadata: [String: String] = [:]
     private weak var player: Player?
 

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -15,7 +15,7 @@ import PillarboxPlayer
 ///
 /// Analytics have to be properly started for the tracker to collect data, see `Analytics.start(with:)`.
 public final class CommandersActTracker: PlayerItemTracker {
-    private var streamingAnalytics = CommandersActStreamingAnalytics()
+    private lazy var streamingAnalytics = CommandersActStreamingAnalytics()
     private var metadata: [String: String] = [:]
     private weak var player: Player?
 


### PR DESCRIPTION
# Description

This PR makes comScore Act streaming analytics instance creation lazy to avoid upfront thread creation explosion, especially visible in long playlists. The same strategy has been applied for Commanders Act, though in this case there was no real issue since we are managing everything ourselves (and all events are funneled through the same Commanders Act instance in the end).

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
