### PR TITLE
Support desktop as navigation device

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -7,10 +7,16 @@
 import TCServerSide
 
 final class CommandersActService {
+    private static var isDesktopApp: Bool {
+        let processInfo = ProcessInfo.processInfo
+        return processInfo.isMacCatalystApp || processInfo.isiOSAppOnMac
+    }
+
     private var serverSide: ServerSide?
     private var vendor: Vendor?
 
     private static func device() -> String {
+        guard !isDesktopApp else { return "desktop" }
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:
             return "phone"


### PR DESCRIPTION
# Description

This PR adds support for `desktop` as navigation device. This value is sent in Commanders Act events for apps run on macOS, either with Catalyst or as iPad apps.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
