### PR TITLE
Use common Commanders Act unique identifier between v4 and v5

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "c80f2e0465f3e7f4a0e26125c535a059c785cb8a",
-        "version" : "5.4.3"
+        "revision" : "1350bca4163cfdd62d1508068601817d86d9f4a5",
+        "version" : "5.4.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "c80f2e0465f3e7f4a0e26125c535a059c785cb8a",
-        "version" : "5.4.3"
+        "revision" : "1350bca4163cfdd62d1508068601817d86d9f4a5",
+        "version" : "5.4.4"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "437d2a6d35b835adaae2a0cac49efe02ef4e0f35",
-        "version" : "13.1.2"
+        "revision" : "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
+        "version" : "13.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.11.0")),
-        .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.1")),
+        .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.4")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0")),

--- a/Sources/Analytics/CommandersAct/CommandersActContext.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActContext.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// The context labels associated with a Commanders Act hit.
+///
+/// Mainly used for development-oriented purposes (e.g. unit testing).
+public struct CommandersActContext: Decodable {
+    /// The device information.
+    public let device: CommandersActDevice
+}
+
+extension CommandersActContext {
+    enum CodingKeys: String, CodingKey {
+        case device
+    }
+}

--- a/Sources/Analytics/CommandersAct/CommandersActDevice.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActDevice.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// The device labels associated with a Commanders Act hit.
+///
+/// Mainly used for development-oriented purposes (e.g. unit testing).
+public struct CommandersActDevice: Decodable {
+    /// The SDK identifier.
+    public let sdk_id: String
+}
+
+extension CommandersActDevice {
+    enum CodingKeys: String, CodingKey {
+        case sdk_id
+    }
+}

--- a/Sources/Analytics/CommandersAct/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActLabels.swift
@@ -31,6 +31,12 @@ public struct CommandersActLabels: Decodable {
     /// The value of `consent_services`.
     public let consent_services: String?
 
+    /// The Commanders Act contextual information.
+    public let context: CommandersActContext
+
+    /// The Commanders Act user information.
+    public let user: CommandersActUser
+
     // MARK: Page view labels
 
     /// The value of `navigation_property_type`.
@@ -122,6 +128,7 @@ private extension CommandersActLabels {
         case _media_timeshift = "media_timeshift"
         case _media_volume = "media_volume"
         case _media_subtitles_on = "media_subtitles_on"
+        case context
         case event_name
         case listener_session_id
         case media_title
@@ -147,5 +154,6 @@ private extension CommandersActLabels {
         case media_player_version
         case media_subtitle_selection
         case media_audio_track
+        case user
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -30,6 +30,11 @@ final class CommandersActService {
         serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
         serverSide.addPermanentData("navigation_device", withValue: Self.device())
         serverSide.enableRunningInBackground()
+
+        // Use the legacy V4 identifier as unique identifier in V5.
+        TCDevice.sharedInstance().sdkID = TCPredefinedVariables.sharedInstance().uniqueIdentifier()
+        TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
+
         self.serverSide = serverSide
     }
 

--- a/Sources/Analytics/CommandersAct/CommandersActUser.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActUser.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// The user labels associated with a Commanders Act hit.
+///
+/// Mainly used for development-oriented purposes (e.g. unit testing).
+public struct CommandersActUser: Decodable {
+    /// The consistent anonymous id.
+    public let consistent_anonymous_id: String
+}
+
+extension CommandersActUser {
+    enum CodingKeys: String, CodingKey {
+        case consistent_anonymous_id
+    }
+}

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -8,6 +8,7 @@
 
 import Nimble
 import PillarboxCircumspect
+import TCServerSide
 
 final class CommandersActEventTests: CommandersActTestCase {
     func testMergingWithGlobals() {
@@ -56,6 +57,18 @@ final class CommandersActEventTests: CommandersActTestCase {
                 name: "name",
                 labels: ["media_player_display": "value"]
             ))
+        }
+    }
+
+    func testUniqueIdentifier() {
+        let identifier = TCPredefinedVariables.sharedInstance().uniqueIdentifier()
+        expectAtLeastHits(
+            .custom(name: "name") { labels in
+                expect(labels.context.device.sdk_id).to(equal(identifier))
+                expect(labels.user.consistent_anonymous_id).to(equal(identifier))
+            }
+        ) {
+            Analytics.shared.sendEvent(commandersAct: .init(name: "name"))
         }
     }
 


### PR DESCRIPTION
# Description

This PR uses the same unique identifier between v4 and v5, ensuring users are identified correctly between app updates to v5.

# Changes made

- Override SDK identifier.
- Update to Commanders Act SDK 5.4.4 so that required APIs are available.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
