### PR TITLE
Fix Swift Package Index documentation generation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,5 +4,9 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [
-        PillarboxAnalytics, PillarboxCircumspect, PillarboxCore, PillarboxCoreBusiness, PillarboxPlayer
+        PillarboxAnalytics,
+        PillarboxCircumspect,
+        PillarboxCore,
+        PillarboxCoreBusiness,
+        PillarboxPlayer
       ]

--- a/.spi.yml
+++ b/.spi.yml
@@ -4,5 +4,5 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [
-        Analytics, Circumspect, Core, CoreBusiness, Player
+        PillarboxAnalytics, PillarboxCircumspect, PillarboxCore, PillarboxCoreBusiness, PillarboxPlayer
       ]


### PR DESCRIPTION
# Description

Fix PR fixes Swift Package Index documentation generation after we recently renamed package products.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
