### PR TITLE
Update links for web player and demo

### DIFF
--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -364,7 +364,14 @@ struct ShowcaseView: View {
     private func webViewSection() -> some View {
         if settingBundle.showsHiddenFeatures {
             CustomSection("Web") {
-                cell(title: "Pillarbox Demo", destination: .webView(url: "https://srgssr.github.io/pillarbox-web/"))
+                cell(
+                    title: "Player",
+                    destination: .webView(url: "https://srgssr.github.io/pillarbox-web/")
+                )
+                cell(
+                    title: "Demo",
+                    destination: .webView(url: "https://srgssr.github.io/pillarbox-web-demo/")
+                )
             }
             .sourceCode(of: WebView.self)
         }


### PR DESCRIPTION
# Description

This PR updates web links so that both the [player](https://srgssr.github.io/pillarbox-web/) as well as its [demo](https://srgssr.github.io/pillarbox-web-demo/), recently moved, can be opened from the Showcase hidden section.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
