### PR TITLE
Disable high speed gesture for monoscopic content

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -79,7 +79,7 @@ private struct MainView: View {
             TapGesture()
                 .onEnded { _ in visibilityTracker.reset() }
         )
-        .supportsHighSpeed(for: player)
+        .supportsHighSpeed(!isMonoscopic, for: player)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Views/HighSpeedView~ios.swift
+++ b/Demo/Sources/Views/HighSpeedView~ios.swift
@@ -85,9 +85,16 @@ private struct HighSpeedView<Content>: View where Content: View {
 }
 
 extension View {
-    func supportsHighSpeed(for player: Player) -> some View {
-        HighSpeedView(player: player) {
-            self
+    func supportsHighSpeed(_ supported: Bool = true, for player: Player) -> some View {
+        Group {
+            if supported {
+                HighSpeedView(player: player) {
+                    self
+                }
+            }
+            else {
+                self
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

The recently added high speed gesture (#746) conflicts with pan gestures used to navigate 360° content, since for such content contact of the finger with the screen is usually long and will inadvertently trigger high speed playback.

# Changes made

- Add parameter to enable the high speed gesture (default is `true`).

Note that we could do better by having high speed gesture still triggered when long pressing withouth moving (what YouTube does). The implementation is likely a bit trickier.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
