### PR TITLE
Fix monoscopic support in playlists

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -155,6 +155,7 @@ struct PlaylistView: View {
     var body: some View {
         VStack(spacing: 0) {
             PlaybackView(player: model.player, layout: $layout)
+                .monoscopic(model.isMonoscopic)
                 .supportsPictureInPicture()
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -84,6 +84,10 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
         medias.isEmpty
     }
 
+    var isMonoscopic: Bool {
+        currentMedia?.isMonoscopic ?? false
+    }
+
     var canReload: Bool {
         !templates.isEmpty
     }


### PR DESCRIPTION
# Description

This PR fixes monoscopic support in playlists.

# Changes made

Self-explanatory. Note that chaining from non-monoscopic to monoscopic content works well, but that a playback error occurs when chaining from monoscopic to non-monoscopic content, if the view is enabled for monoscopic display. Maybe our work on #178 will fix it, we'll open a new issue if this is not the case.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
