### PR TITLE
Remove web player link

### DIFF
--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -365,10 +365,6 @@ struct ShowcaseView: View {
         if settingBundle.showsHiddenFeatures {
             CustomSection("Web") {
                 cell(
-                    title: "Player",
-                    destination: .webView(url: "https://srgssr.github.io/pillarbox-web/")
-                )
-                cell(
                     title: "Demo",
                     destination: .webView(url: "https://srgssr.github.io/pillarbox-web-demo/")
                 )


### PR DESCRIPTION
# Description

This PR removes the web player link. Its URL cannot be edited and the current content does not play anyway.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
