### PR TITLE
Fix incorrect time position after disabling and enabling Control Center integration

### DIFF
--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -11,10 +11,14 @@ import SwiftUI
 struct OptInView: View {
     let media: Media
 
-    @StateObject private var player = Player(configuration: .standard)
+    @StateObject private var player = {
+        let player = Player(configuration: .standard)
+        player.isTrackingEnabled = false
+        return player
+    }()
 
-    @State private var isActive = true
-    @State private var supportsPictureInPicture = true
+    @State private var isActive = false
+    @State private var supportsPictureInPicture = false
     @State private var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
 
     var body: some View {
@@ -40,8 +44,8 @@ struct OptInView: View {
                 }
             }
         }
-        .onChange(of: isActive) { newValue in
-            if newValue {
+        .onChange(of: isActive) { isActive in
+            if isActive {
                 player.becomeActive()
             }
             else {
@@ -66,7 +70,6 @@ struct OptInView: View {
 
     private func play() {
         player.append(media.playerItem())
-        player.becomeActive()
         player.play()
     }
 }

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -61,6 +61,23 @@ extension Player {
             }
             .eraseToAnyPublisher()
     }
+
+    func nowPlayingInfoPublisher() -> AnyPublisher<NowPlayingInfo, Never> {
+        $isActive
+            .map { [weak self] isActive in
+                guard let self, isActive else { return Just(NowPlayingInfo()).eraseToAnyPublisher() }
+                return Publishers.CombineLatest(
+                    nowPlayingInfoMetadataPublisher(),
+                    nowPlayingInfoPlaybackPublisher()
+                )
+                .map { nowPlayingInfoMetadata, nowPlayingInfoPlayback in
+                    nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new }
+                }
+                .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
 }
 
 private extension Player {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -316,11 +316,12 @@ private extension Player {
     }
 
     func configureControlCenterRemoteCommandUpdatePublisher() {
-        Publishers.CombineLatest(
+        Publishers.CombineLatest3(
             queuePublisher,
-            propertiesPublisher
+            propertiesPublisher,
+            $isActive
         )
-        .sink { [weak self] queue, properties in
+        .sink { [weak self] queue, properties, _ in
             guard let self else { return }
             let areSkipsEnabled = queue.elements.count <= 1 && properties.streamType != .live
             let hasError = queue.error != nil

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -31,7 +31,7 @@ public final class Player: ObservableObject, Equatable {
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
-    @Published private var isActive = false {
+    @Published var isActive = false {
         didSet {
             if isActive {
                 nowPlayingSession.becomeActiveIfPossible()
@@ -307,18 +307,12 @@ private extension Player {
 
 private extension Player {
     func configureControlCenterMetadataUpdatePublisher() {
-        Publishers.CombineLatest3(
-            nowPlayingInfoMetadataPublisher(),
-            nowPlayingInfoPlaybackPublisher(),
-            $isActive
-        )
-        .receiveOnMainThread()
-        .sink { [weak self] nowPlayingInfoMetadata, nowPlayingInfoPlayback, isActive in
-            guard let self else { return }
-            let nowPlayingInfo = isActive ? nowPlayingInfoMetadata.merging(nowPlayingInfoPlayback) { _, new in new } : [:]
-            updateControlCenter(nowPlayingInfo: nowPlayingInfo)
-        }
-        .store(in: &cancellables)
+        nowPlayingInfoPublisher()
+            .receiveOnMainThread()
+            .sink { [weak self] nowPlayingInfo in
+                self?.updateControlCenter(nowPlayingInfo: nowPlayingInfo)
+            }
+            .store(in: &cancellables)
     }
 
     func configureControlCenterRemoteCommandUpdatePublisher() {

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerDvrPropertiesTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerDvrPropertiesTests.swift
@@ -89,11 +89,11 @@ final class ComScoreTrackerDvrPropertiesTests: ComScoreTestCase {
                 expect(labels.ns_st_ldw).to(equal(Stream.dvr.duration.seconds))
             },
             .play { labels in
-                expect(labels.ns_st_ldo).to(beCloseTo(4, within: 2))
+                expect(labels.ns_st_ldo).to(beCloseTo(10, within: 3))
                 expect(labels.ns_st_ldw).to(equal(Stream.dvr.duration.seconds))
             }
         ) {
-            player.seek(at(player.time - CMTime(value: 4, timescale: 1)))
+            player.seek(at(player.time - CMTime(value: 10, timescale: 1)))
         }
     }
 }

--- a/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import MediaPlayer
+import PillarboxCircumspect
+import PillarboxStreams
+
+final class NowPlayingInfoPublisherTests: TestCase {
+    func testEmpty() {
+        let player = Player()
+        expectAtLeastSimilarPublished(
+            values: [[:]],
+            from: player.nowPlayingInfoPublisher()
+        )
+    }
+
+    func testActive() {
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: AssetMetadataMock(title: "title")))
+        expectAtLeastSimilarPublished(
+            values: [[:], [MPMediaItemPropertyTitle: "title"]],
+            from: player.nowPlayingInfoPublisher()
+        ) {
+            player.isActive = true
+        }
+
+        expectAtLeastSimilarPublished(
+            values: [[MPMediaItemPropertyTitle: "title"], [:]],
+            from: player.nowPlayingInfoPublisher()
+        ) {
+            player.isActive = false
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR allows us to fix an incorrect time position in the Control Center.

# Changes made

- A `nowPlayingInfoPublisher` has been introduced.
- The **Remote Command Center** is also updated when `isActive` property is changed.
- The opt-in demo has been updated so that all testable behaviors are initially disabled (or with default values).
- The tolerance of `testDvrAwayFromLiveEdge:(ns_st_ldo)` has been increased.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
