### PR TITLE
Support standard actions at item playback end

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -40,13 +40,19 @@
         }
       }
     },
-    "Active" : {
+    "Action at item end" : {
+
+    },
+    "Active (Control Center)" : {
 
     },
     "Add" : {
 
     },
     "Add a stream to the playlist" : {
+
+    },
+    "Advance" : {
 
     },
     "Android" : {
@@ -127,7 +133,13 @@
     "Mode" : {
 
     },
+    "None" : {
+
+    },
     "Opt-in features" : {
+
+    },
+    "Pause" : {
 
     },
     "Pauses" : {

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -43,7 +43,7 @@
     "Action at item end" : {
 
     },
-    "Active (Control Center)" : {
+    "Active (AirPlay / Control Center)" : {
 
     },
     "Add" : {

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -20,6 +20,7 @@ struct OptInView: View {
     @State private var isActive = false
     @State private var supportsPictureInPicture = false
     @State private var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy = .automatic
+    @State private var actionAtItemEnd: AVPlayer.ActionAtItemEnd = .advance
 
     var body: some View {
         VStack {
@@ -28,12 +29,13 @@ struct OptInView: View {
                 .background(.black)
             List {
                 Toggle(isOn: $isActive) {
-                    Text("Active")
+                    Text("Active (in Control Center)")
                 }
                 Toggle(isOn: $supportsPictureInPicture) {
                     Text("Picture in Picture")
                 }
                 audiovisualBackgroundPlaybackPolicyPicker()
+                actionAtItemEndPicker()
 
                 Section {
                     Toggle(isOn: $player.isTrackingEnabled) {
@@ -55,6 +57,9 @@ struct OptInView: View {
         .onChange(of: audiovisualBackgroundPlaybackPolicy) { newValue in
             player.audiovisualBackgroundPlaybackPolicy = newValue
         }
+        .onChange(of: actionAtItemEnd) { newValue in
+            player.actionAtItemEnd = newValue
+        }
         .onAppear(perform: play)
         .tracked(name: "tracking")
     }
@@ -65,6 +70,15 @@ struct OptInView: View {
             Text("Automatic").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.automatic)
             Text("Continues if possible").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.continuesIfPossible)
             Text("Pauses").tag(AVPlayerAudiovisualBackgroundPlaybackPolicy.pauses)
+        }
+    }
+
+    @ViewBuilder
+    private func actionAtItemEndPicker() -> some View {
+        Picker("Action at item end", selection: $actionAtItemEnd) {
+            Text("Advance").tag(AVPlayer.ActionAtItemEnd.advance)
+            Text("Pause").tag(AVPlayer.ActionAtItemEnd.pause)
+            Text("None").tag(AVPlayer.ActionAtItemEnd.none)
         }
     }
 

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -29,7 +29,7 @@ struct OptInView: View {
                 .background(.black)
             List {
                 Toggle(isOn: $isActive) {
-                    Text("Active (in Control Center)")
+                    Text("Active (AirPlay / Control Center)")
                 }
                 Toggle(isOn: $supportsPictureInPicture) {
                     Text("Picture in Picture")

--- a/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
@@ -34,7 +34,9 @@ final class StoriesViewModel: ObservableObject {
     }
 
     private static func player(for story: Story) -> Player {
-        Player(item: Media(from: story.template).playerItem(), configuration: .externalPlaybackDisabled)
+        let player = Player(item: Media(from: story.template).playerItem(), configuration: .externalPlaybackDisabled)
+        player.actionAtItemEnd = .pause
+        return player
     }
 
     private static func players(

--- a/Sources/Analytics/ComScore/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/ComScoreLabels.swift
@@ -57,6 +57,11 @@ public struct ComScoreLabels {
 
     // MARK: Streaming labels
 
+    /// The value of `ns_st_id` (media player session identifier).
+    public var ns_st_id: String? {
+        extract()
+    }
+
     /// The value of `ns_st_ev` (streaming event).
     public var ns_st_ev: String? {
         extract()

--- a/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
@@ -42,6 +42,7 @@ extension ComScoreStreamingAnalytics {
             notifyPause()
         case .ended:
             notifyEnd()
+            createPlaybackSession()
         default:
             break
         }

--- a/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
@@ -42,7 +42,6 @@ extension ComScoreStreamingAnalytics {
             notifyPause()
         case .ended:
             notifyEnd()
-            createPlaybackSession()
         default:
             break
         }

--- a/Sources/Analytics/CommandersAct/CommandersActStreamingAnalytics.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActStreamingAnalytics.swift
@@ -54,10 +54,10 @@ final class CommandersActStreamingAnalytics {
         guard event != lastEvent else { return }
 
         switch (lastEvent, event) {
-        case (.pause, .seek), (.pause, .eof), (.seek, .pause), (.seek, .eof), (.eof, _), (.stop, _):
+        case (.pause, .seek), (.pause, .eof), (.seek, .pause), (.seek, .eof), (.stop, _):
             break
-        case let (.none, event) where event != .play:
-            return
+        case let (.none, event) where event != .play, let (.eof, event) where event != .play:
+            break
         default:
             sendEvent(event)
         }

--- a/Sources/Analytics/CommandersAct/CommandersActStreamingAnalytics.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActStreamingAnalytics.swift
@@ -56,7 +56,7 @@ final class CommandersActStreamingAnalytics {
         switch (lastEvent, event) {
         case (.pause, .seek), (.pause, .eof), (.seek, .pause), (.seek, .eof), (.stop, _):
             break
-        case let (.none, event) where event != .play, let (.eof, event) where event != .play:
+        case (.none, _) where event != .play, (.eof, _) where event != .play:
             break
         default:
             sendEvent(event)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -108,6 +108,16 @@ public final class Player: ObservableObject, Equatable {
         queuePlayer
     }
 
+    /// The action that the player should perform when playback of an item ends.
+    public var actionAtItemEnd: AVPlayer.ActionAtItemEnd {
+        get {
+            queuePlayer.actionAtItemEnd
+        }
+        set {
+            queuePlayer.actionAtItemEnd = newValue
+        }
+    }
+
     /// A policy that determines how playback of audiovisual media continues when the app transitions
     /// to the background.
     public var audiovisualBackgroundPlaybackPolicy: AVPlayerAudiovisualBackgroundPlaybackPolicy {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -109,6 +109,8 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// The action that the player should perform when playback of an item ends.
+    ///
+    /// The default value is `.advance`.
     public var actionAtItemEnd: AVPlayer.ActionAtItemEnd {
         get {
             queuePlayer.actionAtItemEnd

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -113,7 +113,7 @@ extension AVPlayerItem {
     }
 
     private func endTimeNotificationPublisher() -> AnyPublisher<Bool, Never> {
-        NotificationCenter.default.weakPublisher(for: .AVPlayerItemDidPlayToEndTime, object: self)
+        NotificationCenter.default.weakPublisher(for: AVPlayerItem.didPlayToEndTimeNotification, object: self)
             .map { _ in true }
             .eraseToAnyPublisher()
     }
@@ -146,7 +146,7 @@ extension AVPlayerItem {
     }
 
     private func playbackErrorPublisher() -> AnyPublisher<Error, Never> {
-        NotificationCenter.default.weakPublisher(for: .AVPlayerItemFailedToPlayToEndTime, object: self)
+        NotificationCenter.default.weakPublisher(for: AVPlayerItem.didPlayToEndTimeNotification, object: self)
             .compactMap { notification in
                 guard let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error else {
                     return nil

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -109,6 +109,7 @@ extension AVPlayerItem {
     private func isEndedPublisher() -> AnyPublisher<Bool, Never> {
         Publishers.Merge(endTimeNotificationPublisher(), timebaseUpdateNotificationPublisher())
             .prepend(false)
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
 

--- a/Sources/Player/Types/CoreProperties.swift
+++ b/Sources/Player/Types/CoreProperties.swift
@@ -45,7 +45,7 @@ extension CoreProperties {
     }
 
     var playbackState: PlaybackState {
-        .init(itemStatus: itemProperties.status, rate: rate)
+        .init(itemStatus: itemStatus, rate: rate)
     }
 }
 

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -34,7 +34,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
         expectAtLeastHits(
             .play { labels in
                 expect(labels.ns_st_mp).to(equal("Pillarbox"))
-                expect(labels.ns_st_mv).notTo(beEmpty())
+                expect(labels.ns_st_mv).to(equal(PackageInfo.version))
                 expect(labels.cs_ucfr).to(beEmpty())
             }
         ) {

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -229,7 +229,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
         }
     }
 
-    func testSessionIdentifierUpdateAfterEnd() {
+    func testSessionRenewal() {
         let player = Player(item: .simple(
             url: Stream.shortOnDemand.url,
             metadata: AssetMetadataMock(),
@@ -254,6 +254,12 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             .play { labels in
                 expect(labels.ns_st_id).notTo(beNil())
                 expect(labels.ns_st_id).notTo(equal(ns_st_id))
+
+                // Other metadata must be preserved as well.
+                expect(labels.ns_st_mp).to(equal("Pillarbox"))
+                expect(labels.ns_st_mv).to(equal(PackageInfo.version))
+                expect(labels["media_title"]).to(equal("name"))
+                expect(labels.cs_ucfr).to(beEmpty())
             }
         ) {
             player.seek(to: .zero)

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -228,4 +228,36 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             player.play()
         }
     }
+
+    func testSessionIdentifierUpdateAfterEnd() {
+        let player = Player(item: .simple(
+            url: Stream.shortOnDemand.url,
+            metadata: AssetMetadataMock(),
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+        player.actionAtItemEnd = .pause
+
+        var ns_st_id: String?
+
+        expectAtLeastHits(
+            .play { labels in
+                ns_st_id = labels.ns_st_id
+            },
+            .end()
+        ) {
+            player.play()
+        }
+
+        expectAtLeastHits(
+            .play { labels in
+                expect(labels.ns_st_id).notTo(beNil())
+                expect(labels.ns_st_id).notTo(equal(ns_st_id))
+            }
+        ) {
+            player.seek(to: .zero)
+            player.play()
+        }
+    }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActStreamingAnalyticsStateTransitionTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActStreamingAnalyticsStateTransitionTests.swift
@@ -183,9 +183,9 @@ final class CommandersActStreamingAnalyticsStateTransitionTests: CommandersActTe
         let analytics = CommandersActStreamingAnalytics()
         analytics.notify(.play)
         analytics.notify(.eof)
-        expectNoHits(during: .milliseconds(500)) {
+        expectAtLeastHits(.play()) {
             analytics.notify(.play)
-            expect(analytics.lastEvent).to(equal(.eof))
+            expect(analytics.lastEvent).to(equal(.play))
         }
     }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -18,7 +18,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
         expectAtLeastHits(
             .play { labels in
                 expect(labels.media_player_display).to(equal("Pillarbox"))
-                expect(labels.media_player_version).notTo(beEmpty())
+                expect(labels.media_player_version).to(equal(PackageInfo.version))
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_title).to(equal("name"))
                 expect(labels.media_audio_track).to(equal("UND"))
@@ -52,7 +52,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
         expectAtLeastHits(
             .stop { labels in
                 expect(labels.media_player_display).to(equal("Pillarbox"))
-                expect(labels.media_player_version).notTo(beEmpty())
+                expect(labels.media_player_version).to(equal(PackageInfo.version))
                 expect(labels.media_volume).notTo(beNil())
                 expect(labels.media_title).to(equal("name"))
                 expect(labels.media_audio_track).to(equal("UND"))

--- a/Tests/PlayerTests/Asset/AssetCreationTests.swift
+++ b/Tests/PlayerTests/Asset/AssetCreationTests.swift
@@ -57,7 +57,7 @@ final class AssetCreationTests: TestCase {
         expect(asset.resource).to(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
         expect(asset.nowPlayingInfo()).notTo(beEmpty())
         expect(asset.playerItem().preferredForwardBufferDuration).to(equal(4))
-        expect(asset.playerItem().externalMetadata).toNot(beEmpty())
+        expect(asset.playerItem().externalMetadata).notTo(beEmpty())
     }
 
     func testCustomAssetWithoutConfiguration() {

--- a/Tests/PlayerTests/Publishers/QueuePlayerPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/QueuePlayerPublisherTests.swift
@@ -109,11 +109,10 @@ final class QueuePlayerPublisherTests: TestCase {
             player.actionAtItemEnd = .pause
             player.play()
         }
-        expectAtLeastEqualPublishedNext(
+        expectAtLeastEqualPublished(
             values: [.readyToPlay],
             from: Self.itemStatusPublisher(for: player)
         ) {
-            player.actionAtItemEnd = .pause
             player.seek(to: .zero)
         }
     }

--- a/Tests/PlayerTests/Publishers/QueuePlayerPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/QueuePlayerPublisherTests.swift
@@ -86,7 +86,7 @@ final class QueuePlayerPublisherTests: TestCase {
         )
     }
 
-    func testItemStatusLifeCycle() {
+    func testConsumedItemStatusLifeCycle() {
         let player = QueuePlayer(
             playerItem: .init(url: Stream.shortOnDemand.url)
         )
@@ -95,6 +95,26 @@ final class QueuePlayerPublisherTests: TestCase {
             from: Self.itemStatusPublisher(for: player)
         ) {
             player.play()
+        }
+    }
+
+    func testPausedItemStatusLifeCycle() {
+        let player = QueuePlayer(
+            playerItem: .init(url: Stream.shortOnDemand.url)
+        )
+        expectAtLeastEqualPublished(
+            values: [.unknown, .readyToPlay, .ended],
+            from: Self.itemStatusPublisher(for: player)
+        ) {
+            player.actionAtItemEnd = .pause
+            player.play()
+        }
+        expectAtLeastEqualPublishedNext(
+            values: [.readyToPlay],
+            from: Self.itemStatusPublisher(for: player)
+        ) {
+            player.actionAtItemEnd = .pause
+            player.seek(to: .zero)
         }
     }
 


### PR DESCRIPTION
# Description

This PR allows us to add a way to change the behavior of an item when it's ended.

# Changes made

- The property `actionAtItemEnd` has been introduced.
- A new analytics session is created when an item is ended, even if it's paused.
- The demo app has been updated:
   - The stories showcase is paused at the end.
   - An opt-in option has been added in the opt-in showcase.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
