### PR TITLE
Avoid unnecessary Commanders Act seek / play transitions

### DIFF
--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -58,8 +58,8 @@ public final class ProgressTracker: ObservableObject {
                 pausePlaybackIfNeeded(with: player)
             }
             else {
-                resumePlaybackIfNeeded(with: player)
                 seek(to: progress, optimal: false)
+                resumePlaybackIfNeeded(with: player)
             }
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
@@ -6,6 +6,7 @@
 
 @testable import PillarboxAnalytics
 
+import CoreMedia
 import Nimble
 import PillarboxPlayer
 import PillarboxStreams
@@ -189,6 +190,24 @@ final class CommandersActTrackerTests: CommandersActTestCase {
 
         expectAtLeastHits(.play()) {
             player.isTrackingEnabled = true
+        }
+    }
+
+    func testCleanEventsDuringBriefProgressTrackerInteraction() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            trackerAdapters: [
+                CommandersActTracker.adapter()
+            ]
+        ))
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+
+        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
+        progressTracker.player = player
+        expectHits(.pause(), .play(), during: .seconds(1)) {
+            progressTracker.isInteracting = true
+            progressTracker.isInteracting = false
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
@@ -6,7 +6,6 @@
 
 @testable import PillarboxAnalytics
 
-import CoreMedia
 import Nimble
 import PillarboxPlayer
 import PillarboxStreams
@@ -190,24 +189,6 @@ final class CommandersActTrackerTests: CommandersActTestCase {
 
         expectAtLeastHits(.play()) {
             player.isTrackingEnabled = true
-        }
-    }
-
-    func testCleanEventsDuringBriefProgressTrackerInteraction() {
-        let player = Player(item: .simple(
-            url: Stream.onDemand.url,
-            trackerAdapters: [
-                CommandersActTracker.adapter()
-            ]
-        ))
-        player.play()
-        expect(player.playbackState).toEventually(equal(.playing))
-
-        let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
-        progressTracker.player = player
-        expectHits(.pause(), .play(), during: .seconds(1)) {
-            progressTracker.isInteracting = true
-            progressTracker.isInteracting = false
         }
     }
 }


### PR DESCRIPTION
# Description

This PR fixes superfluous Commanders Act seek / play transitions seen when briefly interacting with a progress tracker. Those could be easily be reproduced as follows:

1. Open a URN example from the demo, monitoring Commanders Act events with a proxy.
2. Touch down on the progress bar **without** moving the finger sideways.
3. Release the finger. A seek / play transition could be observed.

# Changes made

- Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
