### PR TITLE
Fix Control Center metadata sometimes disappearing after item deletion

### DIFF
--- a/Sources/Core/ReplaySubject.swift
+++ b/Sources/Core/ReplaySubject.swift
@@ -13,10 +13,8 @@ import Foundation
 /// any relevant completion.
 public final class ReplaySubject<Output, Failure>: Subject where Failure: Error {
     private let buffer: LimitedBuffer<Output>
-
     private var subscriptions: [ReplaySubscription<Output, Failure>] = []
     private var completion: Subscribers.Completion<Failure>?
-
     private let lock = NSRecursiveLock()
 
     /// Creates a subject able to buffer the provided number of values.
@@ -31,7 +29,10 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
             guard self.completion == nil else { return }
             buffer.append(value)
             subscriptions.forEach { subscription in
-                subscription.send(value)
+                subscription.append(value)
+            }
+            subscriptions.forEach { subscription in
+                subscription.send()
             }
         }
     }
@@ -54,7 +55,8 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
         withLock(lock) {
             let subscription = ReplaySubscription(subscriber: subscriber, values: buffer.values)
             buffer.values.forEach { value in
-                subscription.send(value)
+                subscription.append(value)
+                subscription.send()
             }
             subscriber.receive(subscription: subscription)
             if let completion {

--- a/Sources/Core/ReplaySubject.swift
+++ b/Sources/Core/ReplaySubject.swift
@@ -19,7 +19,10 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
 
     private let lock = NSRecursiveLock()
 
-    init(bufferSize: Int) {
+    /// Creates a subject able to buffer the provided number of values.
+    ///
+    /// - Parameter bufferSize: The buffer size.
+    public init(bufferSize: Int) {
         buffer = .init(size: bufferSize)
     }
 

--- a/Sources/Player/Extensions/AVQueuePlayer.swift
+++ b/Sources/Player/Extensions/AVQueuePlayer.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+extension AVQueuePlayer {
+    func replaceItems(with items: [AVPlayerItem]) {
+        guard self.items() != items else { return }
+
+        if let firstItem = items.first {
+            if firstItem !== self.items().first {
+                remove(firstItem)
+                // TODO: Workaround to fix incorrect recovery from failed MP3 playback (FB13650115). Remove when fixed.
+                if self.items().first?.error != nil {
+                    removeAllItems()
+                }
+                // End of workaround
+                replaceCurrentItem(with: firstItem)
+            }
+            removeAll(from: 1)
+            if items.count > 1 {
+                append(Array(items.suffix(from: 1)))
+            }
+        }
+        else {
+            removeAllItems()
+        }
+    }
+
+    private func removeAll(from index: Int) {
+        assert(index > 0, "The current item must not be removed")
+        guard items().count > index else { return }
+        items().suffix(from: index).forEach { remove($0) }
+    }
+
+    private func append(_ items: [AVPlayerItem]) {
+        items.forEach { insert($0, after: nil) }
+    }
+}

--- a/Sources/Player/Extensions/Notification.Name.swift
+++ b/Sources/Player/Extensions/Notification.Name.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum SeekKey: String {
+    case time
+}
+
+extension Notification.Name {
+    static let willSeek = Notification.Name("QueuePlayerWillSeekNotification")
+    static let didSeek = Notification.Name("QueuePlayerDidSeekNotification")
+}

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -182,7 +182,6 @@ extension AVQueuePlayer {
         items().suffix(from: index).forEach { remove($0) }
     }
 
-    @objc
     private func append(_ items: [AVPlayerItem]) {
         items.forEach { insert($0, after: nil) }
     }

--- a/Sources/Player/Internal/QueuePlayer.swift
+++ b/Sources/Player/Internal/QueuePlayer.swift
@@ -7,24 +7,6 @@
 import AVFoundation
 import DequeModule
 
-enum SeekKey: String {
-    case time
-}
-
-struct Seek: Equatable {
-    let time: CMTime
-    let toleranceBefore: CMTime
-    let toleranceAfter: CMTime
-    let isSmooth: Bool
-    let completionHandler: (Bool) -> Void
-
-    private let id = UUID()
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
 class QueuePlayer: AVQueuePlayer {
     static let notificationCenter = NotificationCenter()
 
@@ -150,44 +132,4 @@ class QueuePlayer: AVQueuePlayer {
         mediaSelectionCriteria[mediaCharacteristic] = criteria
         super.setMediaSelectionCriteria(criteria, forMediaCharacteristic: mediaCharacteristic)
     }
-}
-
-extension AVQueuePlayer {
-    func replaceItems(with items: [AVPlayerItem]) {
-        guard self.items() != items else { return }
-
-        if let firstItem = items.first {
-            if firstItem !== self.items().first {
-                remove(firstItem)
-                // TODO: Workaround to fix incorrect recovery from failed MP3 playback (FB13650115). Remove when fixed.
-                if self.items().first?.error != nil {
-                    removeAllItems()
-                }
-                // End of workaround
-                replaceCurrentItem(with: firstItem)
-            }
-            removeAll(from: 1)
-            if items.count > 1 {
-                append(Array(items.suffix(from: 1)))
-            }
-        }
-        else {
-            removeAllItems()
-        }
-    }
-
-    private func removeAll(from index: Int) {
-        assert(index > 0, "The current item must not be removed")
-        guard items().count > index else { return }
-        items().suffix(from: index).forEach { remove($0) }
-    }
-
-    private func append(_ items: [AVPlayerItem]) {
-        items.forEach { insert($0, after: nil) }
-    }
-}
-
-extension Notification.Name {
-    static let willSeek = Notification.Name("QueuePlayerWillSeekNotification")
-    static let didSeek = Notification.Name("QueuePlayerDidSeekNotification")
 }

--- a/Sources/Player/Types/Seek.swift
+++ b/Sources/Player/Types/Seek.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import CoreMedia
+
+struct Seek: Equatable {
+    let time: CMTime
+    let toleranceBefore: CMTime
+    let toleranceAfter: CMTime
+    let isSmooth: Bool
+    let completionHandler: (Bool) -> Void
+
+    private let id = UUID()
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Tests/CoreTests/ReplaySubjectTests.swift
+++ b/Tests/CoreTests/ReplaySubjectTests.swift
@@ -130,4 +130,32 @@ final class ReplaySubjectTests: XCTestCase {
             }
         }
     }
+
+    func testRecursiveReplayDeliveryOrder() {
+        let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+        var cancellables = Set<AnyCancellable>()
+
+        var values: [String] = []
+
+        subject.sink { i in
+            values.append("A\(i)")
+        }
+        .store(in: &cancellables)
+
+        subject.sink { i in
+            values.append("B\(i)")
+            if i == 1 {
+                subject.send(2)
+            }
+        }
+        .store(in: &cancellables)
+
+        subject.sink { i in
+            values.append("C\(i)")
+        }
+        .store(in: &cancellables)
+
+        subject.send(1)
+        expect(values).to(equalDiff(["A1", "B1", "A2", "B2", "C1", "C2"]))
+    }
 }

--- a/Tests/CoreTests/ReplaySubjectTests.swift
+++ b/Tests/CoreTests/ReplaySubjectTests.swift
@@ -131,7 +131,7 @@ final class ReplaySubjectTests: XCTestCase {
         }
     }
 
-    func testRecursiveReplayDeliveryOrder() {
+    func testDeliveryOrderInRecursiveScenario() {
         let subject = ReplaySubject<Int, Never>(bufferSize: 1)
         var cancellables = Set<AnyCancellable>()
 


### PR DESCRIPTION
# Description

This PR fixes an issue with Control Center metadata sometimes disappearing after item deletion, e.g. after reshuffling the item after the current one with another down in a playlist, then deleting the current item.

The issue was located in our `ReplaySubject` implementation (similar implementations like CombineExt or Entwine have the same issue). See #785 for an explanation of the issue and how to solve it.

# Changes made

- Fix `ReplaySubject` implementation to support in-order value processing in multicast configurations where some subscriber might trigger a new publisher emission on the same thread.
- Make `ReplaySubject` public (just an oversight).
- Extracted `QueuePlayer`-related types into separate files (general improvement).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
