### PR TITLE
Use version 6.11.0 to avoid archive issue

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
       "state" : {
-        "revision" : "2951e28ff65d1512727b854d9e64bc53bedfb6cf",
-        "version" : "6.12.0"
+        "revision" : "fef761279a592960243e67f2aea110c6fa097fd8",
+        "version" : "6.11.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.12.0")),
+        .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.11.0")),
         .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.6")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),


### PR DESCRIPTION
# Description

Self-explanatory. 
See also: https://github.com/comScore/Comscore-Swift-Package-Manager/issues/19

![comScore-issue](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/7a23f0a5-35cf-49e3-b756-5eb1489dc508)


# Changes made

- Switch version from **6.12.0** to **6.11.0**

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
