### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,9 @@ let package = Package(
                 .product(name: "TCServerSide", package: "iOSV5")
             ],
             path: "Sources/Analytics",
+            resources: [
+                .process("Resources")
+            ],
             linkerSettings: [
                 .linkedFramework("AdSupport")
             ],

--- a/Sources/Analytics/Analytics.docc/PillarboxAnalytics.md
+++ b/Sources/Analytics/Analytics.docc/PillarboxAnalytics.md
@@ -34,9 +34,11 @@ The PillarboxAnalytics framework always links against [AdSupport](https://develo
 
 > Important: SRG SSR apps must not implement [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency). This ensures that the IDFA can never be read unintentionally.
 
-### App Privacy details
+### App privacy details
 
-When submitting an app to the App Store you must provide [App Privacy details](https://developer.apple.com/app-store/app-privacy-details/). The PillarboxAnalytics framework collects Identifiers (User ID) and usage data (Product Interaction) but never linked to a user.
+When submitting an app to the App Store you must provide [App privacy details](https://developer.apple.com/app-store/app-privacy-details/) that accurately reflect which data is collected by your app and to what purpose.
+
+To help you fill all required information Xcode organizer provides a way to generate a [consolidated privacy report for your app](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests#4239187). This report automatically contains privacy details associated with Pillarbox and its 3rd party dependencies.
 
 ### Validation
 

--- a/Sources/Analytics/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Analytics/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
# Description

This PR adds a privacy manifest to the Analytics package to more previsely declare what this package does, in addition to privacy reports provided by 3rd party dependencies.

No privacy manifest was added to other packages since they do not collect any data.

Remark: comScore 6.12.0, containing an App privacy manifest, cannot be integrated yet, see #788. App privacy reports therefore still miss the associated information, but I am confident that a fix will be provided by comScore soon. The documentation therefore reflects the intended situation, hopefully before we deliver version 1.0.0.

# Changes made

- Add privacy manifest to the Analytics package.
- Update Analytics documentation with details about privacy report generation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
