### PR TITLE
Remove superfluous icon

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -10,22 +10,15 @@ import SwiftUI
 // Behavior: h-exp, v-exp
 private struct MediaCell: View {
     let media: Media
-    let isPlaying: Bool
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(media.title)
-                if let description = media.description {
-                    Text(description)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
+        VStack(alignment: .leading) {
+            Text(media.title)
+            if let description = media.description {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
             }
-            Spacer()
-            Image(systemName: "play.circle")
-                .frame(maxWidth: 30, maxHeight: 30)
-                .opacity(isPlaying ? 1 : 0)
         }
     }
 }
@@ -160,7 +153,7 @@ struct PlaylistView: View {
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)
                 List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
-                    MediaCell(media: media, isPlaying: media == model.currentMedia)
+                    MediaCell(media: media)
                 }
             }
         }


### PR DESCRIPTION
# Description

This PR removes the superfluous icon designating the item being played in playlists. This icon is namely redundant with the cell selection.

| Before | After |
|--------|--------|
| ![before](https://github.com/SRGSSR/pillarbox-apple/assets/170201/2de5df1e-27af-4c94-b33e-966b59da6f58) | ![after](https://github.com/SRGSSR/pillarbox-apple/assets/170201/c9e6aacb-891b-4e9a-856c-9e54357c7461) |

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
