### PR TITLE
Fix tvOS Control Center

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -180,7 +180,13 @@ public final class Player: ObservableObject, Equatable {
     ///   - configuration: The configuration to apply to the player.
     public init(items: [PlayerItem] = [], configuration: PlayerConfiguration = .init()) {
         storedItems = Deque(items)
+
+        // TODO: Check the behavior in the future tvOS versions, see https://github.com/SRGSSR/pillarbox-apple/issues/826
+#if os(tvOS)
+        nowPlayingSession = MPNowPlayingSession(players: [AVPlayer()])
+#else
         nowPlayingSession = MPNowPlayingSession(players: [queuePlayer])
+#endif
         self.configuration = configuration
 
         configurePlayer()


### PR DESCRIPTION
# Description

Self-explanatory.

# Changes made

- A dummy player is used on tvOS for the now playing session.

| tvOS Control Center |
|--------|
| ![tvos-control-center](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/84d6d636-4439-45a3-8357-969910912cb5) | 

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
