### PR TITLE
Display chapters in iOS demo

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -10,9 +10,9 @@
 		0E011D1A2B2DF9BE00DAAD3D /* MediaCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E011D192B2DF9BE00DAAD3D /* MediaCardView.swift */; };
 		0E4128BD2AFB7F2A00D67759 /* InlineSystemPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4128BC2AFB7F2A00D67759 /* InlineSystemPlayerView.swift */; };
 		0E4128BF2AFB959B00D67759 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4128BE2AFB959B00D67759 /* PlayerViewModel.swift */; };
+		0E46D3012BD2754400133AE2 /* ChaptersPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E46D3002BD2754400133AE2 /* ChaptersPlayerView.swift */; };
 		0E48F3FC2B2DBAD4001982BB /* CustomNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E48F3FB2B2DBAD4001982BB /* CustomNavigationLink.swift */; };
 		0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B995B29D43E4200D0276D /* OptInView.swift */; };
-		0E9E742C2BD15065003DD0E7 /* ChaptersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */; };
 		0EB94A1F2B5AE29000FF3175 /* HighSpeedView~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB94A1E2B5AE29000FF3175 /* HighSpeedView~ios.swift */; };
 		0ECC5AD52A517A4C0064E701 /* PlaybackSlider~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECC5AD42A517A4C0064E701 /* PlaybackSlider~ios.swift */; };
 		0EDFF0DB2B0740DA005030B4 /* SourceCodeViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */; };
@@ -98,9 +98,9 @@
 		0E011D192B2DF9BE00DAAD3D /* MediaCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCardView.swift; sourceTree = "<group>"; };
 		0E4128BC2AFB7F2A00D67759 /* InlineSystemPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSystemPlayerView.swift; sourceTree = "<group>"; };
 		0E4128BE2AFB959B00D67759 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
+		0E46D3002BD2754400133AE2 /* ChaptersPlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChaptersPlayerView.swift; sourceTree = "<group>"; };
 		0E48F3FB2B2DBAD4001982BB /* CustomNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationLink.swift; sourceTree = "<group>"; };
 		0E6B995B29D43E4200D0276D /* OptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInView.swift; sourceTree = "<group>"; };
-		0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaptersView.swift; sourceTree = "<group>"; };
 		0EB94A1E2B5AE29000FF3175 /* HighSpeedView~ios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HighSpeedView~ios.swift"; sourceTree = "<group>"; };
 		0ECC5AD42A517A4C0064E701 /* PlaybackSlider~ios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaybackSlider~ios.swift"; sourceTree = "<group>"; };
 		0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceCodeViewable.swift; sourceTree = "<group>"; };
@@ -326,7 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				6FCB9DDD29E024E900961B69 /* BlurredView.swift */,
-				0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */,
+				0E46D3002BD2754400133AE2 /* ChaptersPlayerView.swift */,
 				6F59E86229CF31E10093E6FB /* LinkView.swift */,
 				6FAD51102B331A2C0078FE08 /* Multi */,
 				0E6B995B29D43E4200D0276D /* OptInView.swift */,
@@ -651,7 +651,6 @@
 				6F59E89329CF31E20093E6FB /* LinkView.swift in Sources */,
 				6F59E89529CF31E20093E6FB /* CopyButton.swift in Sources */,
 				6F985D792B18CCC9000A1483 /* PinchToZoomTutorial~ios.swift in Sources */,
-				0E9E742C2BD15065003DD0E7 /* ChaptersView.swift in Sources */,
 				6F59E8A229CF31E20093E6FB /* Logger.swift in Sources */,
 				6F59E89229CF31E20093E6FB /* WrappedViewModel.swift in Sources */,
 				0E48F3FC2B2DBAD4001982BB /* CustomNavigationLink.swift in Sources */,
@@ -678,6 +677,7 @@
 				6FCB9DDE29E024E900961B69 /* BlurredView.swift in Sources */,
 				6F59E89129CF31E20093E6FB /* WrappedView.swift in Sources */,
 				6F59E88629CF31E20093E6FB /* ContentListView.swift in Sources */,
+				0E46D3012BD2754400133AE2 /* ChaptersPlayerView.swift in Sources */,
 				6FC5D6A22A6FA8D20012BC89 /* Modal.swift in Sources */,
 				6F59E89B29CF31E20093E6FB /* SystemPlayerView.swift in Sources */,
 				6F59E87B29CF31E10093E6FB /* DemoApp.swift in Sources */,

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0E4128BF2AFB959B00D67759 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4128BE2AFB959B00D67759 /* PlayerViewModel.swift */; };
 		0E48F3FC2B2DBAD4001982BB /* CustomNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E48F3FB2B2DBAD4001982BB /* CustomNavigationLink.swift */; };
 		0E6B995C29D43E4200D0276D /* OptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6B995B29D43E4200D0276D /* OptInView.swift */; };
+		0E9E742C2BD15065003DD0E7 /* ChaptersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */; };
 		0EB94A1F2B5AE29000FF3175 /* HighSpeedView~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB94A1E2B5AE29000FF3175 /* HighSpeedView~ios.swift */; };
 		0ECC5AD52A517A4C0064E701 /* PlaybackSlider~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECC5AD42A517A4C0064E701 /* PlaybackSlider~ios.swift */; };
 		0EDFF0DB2B0740DA005030B4 /* SourceCodeViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */; };
@@ -99,6 +100,7 @@
 		0E4128BE2AFB959B00D67759 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
 		0E48F3FB2B2DBAD4001982BB /* CustomNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationLink.swift; sourceTree = "<group>"; };
 		0E6B995B29D43E4200D0276D /* OptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptInView.swift; sourceTree = "<group>"; };
+		0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaptersView.swift; sourceTree = "<group>"; };
 		0EB94A1E2B5AE29000FF3175 /* HighSpeedView~ios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HighSpeedView~ios.swift"; sourceTree = "<group>"; };
 		0ECC5AD42A517A4C0064E701 /* PlaybackSlider~ios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaybackSlider~ios.swift"; sourceTree = "<group>"; };
 		0EDFF0DA2B0740DA005030B4 /* SourceCodeViewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceCodeViewable.swift; sourceTree = "<group>"; };
@@ -323,9 +325,10 @@
 		6F59E85429CF31E10093E6FB /* Showcase */ = {
 			isa = PBXGroup;
 			children = (
-				6FAD51102B331A2C0078FE08 /* Multi */,
 				6FCB9DDD29E024E900961B69 /* BlurredView.swift */,
+				0E9E742B2BD15065003DD0E7 /* ChaptersView.swift */,
 				6F59E86229CF31E10093E6FB /* LinkView.swift */,
+				6FAD51102B331A2C0078FE08 /* Multi */,
 				0E6B995B29D43E4200D0276D /* OptInView.swift */,
 				6F59E85629CF31E10093E6FB /* Playlist */,
 				6F59E85A29CF31E10093E6FB /* ShowcaseView.swift */,
@@ -648,6 +651,7 @@
 				6F59E89329CF31E20093E6FB /* LinkView.swift in Sources */,
 				6F59E89529CF31E20093E6FB /* CopyButton.swift in Sources */,
 				6F985D792B18CCC9000A1483 /* PinchToZoomTutorial~ios.swift in Sources */,
+				0E9E742C2BD15065003DD0E7 /* ChaptersView.swift in Sources */,
 				6F59E8A229CF31E20093E6FB /* Logger.swift in Sources */,
 				6F59E89229CF31E20093E6FB /* WrappedViewModel.swift in Sources */,
 				0E48F3FC2B2DBAD4001982BB /* CustomNavigationLink.swift in Sources */,

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -104,7 +104,7 @@ private struct ContentCell: View {
                     type: .urn(media.urn, server: serverSetting.server),
                     isMonoscopic: media.isMonoscopic
                 )
-                router.presented = .player(media: media)
+                router.presented = .chapters(media: media)
             }
 #if os(iOS)
             .swipeActions { CopyButton(text: media.urn) }

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -104,7 +104,7 @@ private struct ContentCell: View {
                     type: .urn(media.urn, server: serverSetting.server),
                     isMonoscopic: media.isMonoscopic
                 )
-                router.presented = .chapters(media: media)
+                router.presented = .chaptersPlayer(media: media)
             }
 #if os(iOS)
             .swipeActions { CopyButton(text: media.urn) }

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -104,7 +104,11 @@ private struct ContentCell: View {
                     type: .urn(media.urn, server: serverSetting.server),
                     isMonoscopic: media.isMonoscopic
                 )
+#if os(iOS)
                 router.presented = .chaptersPlayer(media: media)
+#else
+                router.presented = .player(media: media)
+#endif
             }
 #if os(iOS)
             .swipeActions { CopyButton(text: media.urn) }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -122,7 +122,7 @@ private struct MainView: View {
 
     @ViewBuilder
     private func bottomBar() -> some View {
-        VStack {
+        VStack(spacing: 0) {
             if isFullScreen {
                 HStack(alignment: .bottom) {
                     metadata()
@@ -140,7 +140,7 @@ private struct MainView: View {
         .opacity(isUserInterfaceHidden ? 0 : 1)
         .animation(.linear(duration: 0.2), values: isUserInterfaceHidden, isInteracting)
         .padding(.horizontal)
-        .padding(.vertical, isFullScreen ? 30 : nil)
+        .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -140,7 +140,7 @@ private struct MainView: View {
         .opacity(isUserInterfaceHidden ? 0 : 1)
         .animation(.linear(duration: 0.2), values: isUserInterfaceHidden, isInteracting)
         .padding(.horizontal)
-        .padding(.vertical, isFullScreen ? 60 : nil)
+        .padding(.vertical, isFullScreen ? 30 : nil)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -168,7 +168,8 @@ private struct MainView: View {
             }
         }
         .opacity(isUserInterfaceHidden ? 0 : 1)
-        .padding()
+        .padding(.horizontal)
+        .padding(.vertical, layoutInfo.isFullScreen ? nil : 0)
         .preventsTouchPropagation()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -123,7 +123,7 @@ private struct MainView: View {
     @ViewBuilder
     private func bottomBar() -> some View {
         VStack {
-            if layoutInfo.isFullScreen {
+            if isFullScreen {
                 HStack(alignment: .bottom) {
                     metadata()
                     bottomButtons()
@@ -131,7 +131,7 @@ private struct MainView: View {
             }
             HStack(spacing: 20) {
                 TimeBar(player: player, visibilityTracker: visibilityTracker, isInteracting: $isInteracting)
-                if !layoutInfo.isFullScreen {
+                if !isFullScreen {
                     bottomButtons()
                 }
             }
@@ -140,7 +140,7 @@ private struct MainView: View {
         .opacity(isUserInterfaceHidden ? 0 : 1)
         .animation(.linear(duration: 0.2), values: isUserInterfaceHidden, isInteracting)
         .padding(.horizontal)
-        .padding(.vertical, layoutInfo.isFullScreen ? 60 : nil)
+        .padding(.vertical, isFullScreen ? 60 : nil)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -168,10 +168,9 @@ private struct MainView: View {
             }
         }
         .opacity(isUserInterfaceHidden ? 0 : 1)
-        .padding(.horizontal)
-        .padding(.vertical, layoutInfo.isFullScreen ? nil : 0)
+        .topBarStyle()
         .preventsTouchPropagation()
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     @ViewBuilder
@@ -595,6 +594,7 @@ private struct ErrorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .topBarStyle()
         }
     }
 }
@@ -628,6 +628,7 @@ struct PlaybackView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .overlay(alignment: .topLeading) {
                         CloseButton()
+                            .topBarStyle()
                     }
             }
         }
@@ -676,6 +677,13 @@ extension PlaybackView {
         var view = self
         view.supportsPictureInPicture = supportsPictureInPicture
         return view
+    }
+}
+
+private extension View {
+    func topBarStyle() -> some View {
+        padding(.horizontal)
+            .frame(minHeight: 60)
     }
 }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -683,7 +683,7 @@ extension PlaybackView {
 private extension View {
     func topBarStyle() -> some View {
         padding(.horizontal)
-            .frame(minHeight: 60)
+            .frame(minHeight: 35)
     }
 }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -123,9 +123,9 @@ private struct MainView: View {
     @ViewBuilder
     private func bottomBar() -> some View {
         VStack(spacing: 0) {
-            if isFullScreen {
-                HStack(alignment: .bottom) {
-                    metadata()
+            HStack(alignment: .bottom) {
+                metadata()
+                if isFullScreen {
                     bottomButtons()
                 }
             }

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -22,6 +22,8 @@ struct SimplePlayerView: View {
         }
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .padding(.horizontal)
+                .frame(minHeight: 35)
         }
         .onAppear(perform: play)
         .onReceive(player: player, assign: \.isBusy, to: $isBusy)

--- a/Demo/Sources/Router/RouterDestination.swift
+++ b/Demo/Sources/Router/RouterDestination.swift
@@ -22,6 +22,7 @@ enum RouterDestination: Identifiable, Hashable {
     case link(media: Media)
     case wrapped(media: Media)
     case transition(media: Media)
+    case chapters(media: Media)
 
     case stories
     case playlist(templates: [Template])
@@ -61,6 +62,8 @@ enum RouterDestination: Identifiable, Hashable {
             return "playlist"
         case .contentList:
             return "contentList"
+        case .chapters:
+            return "chapters"
 #if os(iOS)
         case .webView:
             return "webView"
@@ -112,6 +115,8 @@ enum RouterDestination: Identifiable, Hashable {
             PlaylistView(templates: templates)
         case let .contentList(configuration: configuration):
             ContentListView(configuration: configuration)
+        case let .chapters(media: media):
+            ChaptersView(media: media)
 #if os(iOS)
         case let .webView(url: url):
             WebView(url: url)

--- a/Demo/Sources/Router/RouterDestination.swift
+++ b/Demo/Sources/Router/RouterDestination.swift
@@ -13,6 +13,7 @@ enum RouterDestination: Identifiable, Hashable {
     case inlineSystemPlayer(media: Media)
     case simplePlayer(media: Media)
     case optInPlayer(media: Media)
+    case chaptersPlayer(media: Media)
 
     case vanillaPlayer(item: AVPlayerItem)
 
@@ -22,7 +23,6 @@ enum RouterDestination: Identifiable, Hashable {
     case link(media: Media)
     case wrapped(media: Media)
     case transition(media: Media)
-    case chapters(media: Media)
 
     case stories
     case playlist(templates: [Template])
@@ -44,6 +44,8 @@ enum RouterDestination: Identifiable, Hashable {
             return "optInPlayer"
         case .vanillaPlayer:
             return "vanillaPlayer"
+        case .chaptersPlayer:
+            return "chaptersPlayer"
         case .blurred:
             return "blurred"
         case .twins:
@@ -62,8 +64,6 @@ enum RouterDestination: Identifiable, Hashable {
             return "playlist"
         case .contentList:
             return "contentList"
-        case .chapters:
-            return "chapters"
 #if os(iOS)
         case .webView:
             return "webView"
@@ -115,8 +115,8 @@ enum RouterDestination: Identifiable, Hashable {
             PlaylistView(templates: templates)
         case let .contentList(configuration: configuration):
             ContentListView(configuration: configuration)
-        case let .chapters(media: media):
-            ChaptersView(media: media)
+        case let .chaptersPlayer(media: media):
+            ChaptersPlayerView(media: media)
 #if os(iOS)
         case let .webView(url: url):
             WebView(url: url)

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -27,6 +27,8 @@ struct BlurredView: View {
         .background(.black)
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .padding(.horizontal)
+                .frame(minHeight: 35)
         }
         .onAppear(perform: play)
         .onForeground(perform: player.play)

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -44,7 +44,7 @@ private struct ChapterView: View {
     }
 }
 
-struct ChaptersView: View {
+struct ChaptersPlayerView: View {
     private let player = Player()
     @State private var layout: PlaybackView.Layout = .minimized
     @State private var chapters: [ChapterMetadata] = []
@@ -103,10 +103,10 @@ struct ChaptersView: View {
     }
 }
 
-extension ChaptersView: SourceCodeViewable {
+extension ChaptersPlayerView: SourceCodeViewable {
     static let filePath = #file
 }
 
 #Preview {
-    ChaptersView(media: Media(from: URNTemplate.onDemandHorizontalVideo))
+    ChaptersPlayerView(media: Media(from: URNTemplate.onDemandHorizontalVideo))
 }

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -9,6 +9,7 @@ import PillarboxPlayer
 import SwiftUI
 
 private struct ChapterView: View {
+    private static let width: CGFloat = 200
     let chapter: ChapterMetadata
 
     var body: some View {
@@ -39,7 +40,7 @@ private struct ChapterView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
             }
         }
-        .frame(width: 200, height: 200 * 9 / 16)
+        .frame(width: Self.width, height: Self.width * 9 / 16)
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 }
@@ -49,6 +50,7 @@ struct ChaptersPlayerView: View {
     @State private var layout: PlaybackView.Layout = .minimized
     @State private var chapters: [ChapterMetadata] = []
     @StateObject private var progressTracker = ProgressTracker(interval: .init(value: 1, timescale: 1))
+
     private var effectiveLayout: Binding<PlaybackView.Layout> {
         !chapters.isEmpty ? $layout : .constant(.inline)
     }

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -63,6 +63,7 @@ struct ChaptersView: View {
     var body: some View {
         VStack {
             PlaybackView(player: player, layout: $layout)
+                .supportsPictureInPicture()
             if layout != .maximized {
                 chaptersView()
             }

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -37,7 +37,8 @@ struct ChaptersView: View {
 
     private var currentChapter: ChapterMetadata? {
         chapters.first { chapter in
-            chapter.timeRange.containsTime(player.time)
+            guard let time = progressTracker.time else { return false }
+            return chapter.timeRange.containsTime(time)
         }
     }
 

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -21,6 +21,7 @@ private struct ChapterView: View {
                         .aspectRatio(contentMode: .fill)
                 }
             }
+            .animation(.defaultLinear, value: chapter.image)
             .overlay {
                 LinearGradient(
                     gradient: Gradient(colors: [.black.opacity(0.7), .clear]),

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -4,13 +4,21 @@
 //  License information is available from the LICENSE file.
 //
 
+import PillarboxPlayer
 import SwiftUI
 
 struct ChaptersView: View {
+    private let player = Player()
     let media: Media
 
     var body: some View {
-        EmptyView()
+        PlaybackView(player: player)
+            .onAppear(perform: play)
+    }
+
+    private func play() {
+        player.append(media.playerItem())
+        player.play()
     }
 }
 

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+struct ChaptersView: View {
+    let media: Media
+
+    var body: some View {
+        EmptyView()
+    }
+}
+
+extension ChaptersView: SourceCodeViewable {
+    static let filePath = #file
+}

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -12,11 +12,21 @@ private struct ChapterView: View {
     let chapter: ChapterMetadata
 
     var body: some View {
-        VStack {
-            if let image = chapter.image {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
+        ZStack(alignment: .bottom) {
+            ZStack {
+                Color(white: 1, opacity: 0.2)
+                if let image = chapter.image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                }
+            }
+            .overlay {
+                LinearGradient(
+                    gradient: Gradient(colors: [.black.opacity(0.7), .clear]),
+                    startPoint: .bottom,
+                    endPoint: .top
+                )
             }
             if let title = chapter.title {
                 Text(title)
@@ -24,9 +34,11 @@ private struct ChapterView: View {
                     .font(.footnote)
                     .fontWeight(.semibold)
                     .lineLimit(2)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
             }
         }
-        .frame(width: 200)
+        .frame(width: 200, height: 200 * 9 / 16)
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 }
@@ -81,7 +93,6 @@ struct ChaptersView: View {
             .padding(.horizontal)
         }
         .scrollIndicators(.hidden)
-        ._debugBodyCounter(color: .green)
     }
 }
 

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -33,6 +33,8 @@ private struct ChapterView: View {
 
 struct ChaptersView: View {
     private let player = Player()
+
+    @State private var layout: PlaybackView.Layout = .minimized
     @State private var chapters: [ChapterMetadata] = []
     @StateObject private var progressTracker = ProgressTracker(interval: .init(value: 1, timescale: 1))
 
@@ -47,9 +49,12 @@ struct ChaptersView: View {
 
     var body: some View {
         VStack {
-            PlaybackView(player: player)
-            chaptersView()
+            PlaybackView(player: player, layout: $layout)
+            if layout != .maximized {
+                chaptersView()
+            }
         }
+        .animation(.defaultLinear, value: layout)
         .background(.black)
         .bind(progressTracker, to: player)
         .onReceive(player.$metadata, assign: \.chapters, to: $chapters)

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -64,7 +64,7 @@ struct ChaptersView: View {
             HStack(spacing: 15) {
                 ForEach(chapters, id: \.timeRange) { chapter in
                     Button(action: {
-                        player.seek(to: chapter.timeRange.start)
+                        player.seek(at(chapter.timeRange.start))
                     }) {
                         ChapterView(chapter: chapter)
                             .saturation(currentChapter == chapter ? 1 : 0)

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import CoreMedia
 import PillarboxPlayer
 import SwiftUI
 
@@ -65,7 +66,7 @@ struct ChaptersView: View {
             HStack(spacing: 15) {
                 ForEach(chapters, id: \.timeRange) { chapter in
                     Button(action: {
-                        player.seek(at(chapter.timeRange.start))
+                        player.seek(at(chapter.timeRange.start + CMTime(value: 1, timescale: 10)))
                     }) {
                         ChapterView(chapter: chapter)
                             .saturation(currentChapter == chapter ? 1 : 0)

--- a/Demo/Sources/Showcase/ChaptersView.swift
+++ b/Demo/Sources/Showcase/ChaptersView.swift
@@ -7,13 +7,51 @@
 import PillarboxPlayer
 import SwiftUI
 
+private struct ChapterView: View {
+    let chapter: ChapterMetadata
+
+    var body: some View {
+        VStack {
+            if let image = chapter.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+            if let title = chapter.title {
+                Text(title)
+                    .foregroundStyle(.white)
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .lineLimit(2)
+            }
+        }
+        .frame(width: 200)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+}
+
 struct ChaptersView: View {
     private let player = Player()
+    @State private var chapters: [ChapterMetadata] = []
+
     let media: Media
 
     var body: some View {
-        PlaybackView(player: player)
-            .onAppear(perform: play)
+        VStack {
+            PlaybackView(player: player)
+            ScrollView(.horizontal) {
+                HStack(spacing: 20) {
+                    ForEach(chapters, id: \.timeRange) { chapter in
+                        ChapterView(chapter: chapter)
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .scrollIndicators(.hidden)
+        }
+        .background(.black)
+        .onReceive(player.$metadata, assign: \.chapters, to: $chapters)
+        .onAppear(perform: play)
     }
 
     private func play() {
@@ -24,4 +62,8 @@ struct ChaptersView: View {
 
 extension ChaptersView: SourceCodeViewable {
     static let filePath = #file
+}
+
+#Preview {
+    ChaptersView(media: Media(from: URNTemplate.onDemandHorizontalVideo))
 }

--- a/Demo/Sources/Showcase/LinkView.swift
+++ b/Demo/Sources/Showcase/LinkView.swift
@@ -27,6 +27,8 @@ struct LinkView: View {
         }
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .padding(.horizontal)
+                .frame(minHeight: 35)
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)

--- a/Demo/Sources/Showcase/Multi/MultiView.swift
+++ b/Demo/Sources/Showcase/Multi/MultiView.swift
@@ -28,6 +28,8 @@ struct MultiView: View {
                 routePickerView()
                 PiPButton()
             }
+            .padding(.horizontal)
+            .frame(minHeight: 35)
         }
         .onAppear {
             model.media1 = media1

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -70,6 +70,13 @@ struct ShowcaseView: View {
                 destination: .stories
             )
             .sourceCode(of: StoriesView.self)
+
+            cell(
+                title: "Chapters",
+                subtitle: "A visual way to handle chapters",
+                destination: .chapters(media: Media(from: URNTemplate.onDemandHorizontalVideo))
+            )
+            .sourceCode(of: ChaptersView.self)
         }
     }
 
@@ -235,13 +242,6 @@ struct ShowcaseView: View {
                 destination: .player(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS, startTime: .init(value: 10 * 60, timescale: 1)))
             )
             .sourceCode(of: PlayerView.self)
-
-            cell(
-                title: "Video URN - 12h45",
-                subtitle: "Content with chapters",
-                destination: .chapters(media: Media(from: URNTemplate.onDemandHorizontalVideo))
-            )
-            .sourceCode(of: ChaptersView.self)
         }
     }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -74,9 +74,9 @@ struct ShowcaseView: View {
             cell(
                 title: "Chapters",
                 subtitle: "A visual way to handle chapters",
-                destination: .chapters(media: Media(from: URNTemplate.onDemandHorizontalVideo))
+                destination: .chaptersPlayer(media: Media(from: URNTemplate.onDemandHorizontalVideo))
             )
-            .sourceCode(of: ChaptersView.self)
+            .sourceCode(of: ChaptersPlayerView.self)
         }
     }
 

--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -235,6 +235,13 @@ struct ShowcaseView: View {
                 destination: .player(media: Media(from: URLTemplate.appleBasic_16_9_TS_HLS, startTime: .init(value: 10 * 60, timescale: 1)))
             )
             .sourceCode(of: PlayerView.self)
+
+            cell(
+                title: "Video URN - 12h45",
+                subtitle: "Content with chapters",
+                destination: .chapters(media: Media(from: URNTemplate.onDemandHorizontalVideo))
+            )
+            .sourceCode(of: ChaptersView.self)
         }
     }
 

--- a/Demo/Sources/Showcase/TwinsView.swift
+++ b/Demo/Sources/Showcase/TwinsView.swift
@@ -40,6 +40,8 @@ struct TwinsView: View {
         }
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .padding(.horizontal)
+                .frame(minHeight: 35)
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)

--- a/Demo/Sources/Showcase/Wrapped/WrappedView.swift
+++ b/Demo/Sources/Showcase/Wrapped/WrappedView.swift
@@ -28,6 +28,8 @@ struct WrappedView: View {
         }
         .overlay(alignment: .topLeading) {
             CloseButton()
+                .padding(.horizontal)
+                .frame(minHeight: 35)
         }
         .onAppear(perform: play)
         .onForeground(perform: resume)

--- a/Demo/Sources/Views/HighSpeedView~ios.swift
+++ b/Demo/Sources/Views/HighSpeedView~ios.swift
@@ -18,7 +18,7 @@ private struct HighSpeedCapsule: View {
             .padding(.vertical, 5)
             .foregroundStyle(.white)
             .background(.black.opacity(0.7))
-            .clipShape(Capsule())
+            .clipShape(.capsule)
     }
 }
 

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -72,7 +72,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             }
         }
         .frame(height: progressTracker.isInteracting ? 16 : 8)
-        .clipShape(Capsule())
+        .clipShape(.capsule)
         .animation(.easeInOut(duration: 0.4), value: progressTracker.isInteracting)
         .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
     }

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -25,7 +25,14 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
             progressBar()
             maximumValueLabel()
         }
-        .frame(height: 8)
+        .preventsTouchPropagation()
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .updating($gestureValue) { value, state, _ in
+                    state = value
+                }
+        )
+        .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
         .frame(maxWidth: .infinity)
     }
 
@@ -61,12 +68,6 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                     .animation(.linear(duration: 0.5), value: buffer)
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
             }
-            .gesture(
-                DragGesture(minimumDistance: 0)
-                    .updating($gestureValue) { value, state, _ in
-                        state = value
-                    }
-            )
             .onChange(of: gestureValue) { value in
                 updateProgress(for: value, in: geometry)
             }
@@ -74,7 +75,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         .frame(height: progressTracker.isInteracting ? 16 : 8)
         .clipShape(.capsule)
         .animation(.easeInOut(duration: 0.4), value: progressTracker.isInteracting)
-        .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
+        .frame(height: 30)
     }
 
     private func updateProgress(for value: DragGesture.Value?, in geometry: GeometryProxy) {

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -32,8 +32,8 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                     state = value
                 }
         )
-        .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
         .frame(maxWidth: .infinity)
+        .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
     }
 
     init(


### PR DESCRIPTION
# Description

Self-explanatory.

# Changes made

- The `PlaybackSlider` has been improved.
- A `ChaptersPlayerView` has been introduced.
- The global player layout has been improved.

# Illustrations

| iPhone | iPad |
|--------|--------|
| ![iphone](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/1f9df0b5-1f38-45ce-ad45-f50eb92d18e8) | ![ipad](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/992f83ef-1c7a-40ec-a1f5-7296177a9458) |


# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
