### PR TITLE
Improve chapter cell appearance

### DIFF
--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -188,7 +188,7 @@ struct SettingsView: View {
             Text("Made with ")
             Image(systemName: "heart.fill")
                 .foregroundColor(.red)
-                .pulseSymbolEffect()
+                .pulseSymbolEffect17()
             Text(" in Switzerland")
         }
         .frame(maxWidth: .infinity)

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -19,6 +19,7 @@ private struct ChapterView: View {
     }()
 
     let chapter: Chapter
+    let isHighlighted: Bool
 
     private var formattedDuration: String? {
         Self.durationFormatter.string(from: Double(chapter.timeRange.duration.seconds))
@@ -31,6 +32,9 @@ private struct ChapterView: View {
         }
         .frame(width: Self.width, height: Self.width * 9 / 16)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        .saturation(isHighlighted ? 1 : 0)
+        .scaleEffect17(isHighlighted ? 1.05 : 1)
+        .animation(.defaultLinear, value: isHighlighted)
     }
 
     @ViewBuilder
@@ -129,17 +133,18 @@ struct ChaptersPlayerView: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 15) {
                     ForEach(chapters, id: \.timeRange) { chapter in
-                        Button(action: {
+                        Button {
                             player.seek(at(chapter.timeRange.start + CMTime(value: 1, timescale: 10)))
-                        }) {
-                            ChapterView(chapter: chapter)
-                                .saturation(currentChapter == chapter ? 1 : 0)
+                        } label: {
+                            ChapterView(chapter: chapter, isHighlighted: chapter == currentChapter)
                         }
+                        .buttonStyle(PlainButtonStyle())
                     }
                 }
                 .padding(.horizontal)
             }
             .scrollIndicators(.hidden)
+            .scrollClipDisabled17()
         }
     }
 }

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -10,7 +10,19 @@ import SwiftUI
 
 private struct ChapterView: View {
     private static let width: CGFloat = 200
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.second, .minute]
+        formatter.zeroFormattingBehavior = .pad
+        return formatter
+    }()
+
     let chapter: Chapter
+
+    private var formattedDuration: String? {
+        Self.durationFormatter.string(from: Double(chapter.timeRange.duration.seconds))
+    }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -39,6 +51,9 @@ private struct ChapterView: View {
                 endPoint: .top
             )
         }
+        .overlay(alignment: .topTrailing) {
+            durationLabel()
+        }
     }
 
     @ViewBuilder
@@ -51,6 +66,20 @@ private struct ChapterView: View {
                 .lineLimit(2)
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        }
+    }
+
+    @ViewBuilder
+    private func durationLabel() -> some View {
+        if let formattedDuration {
+            Text(formattedDuration)
+                .font(.footnote)
+                .foregroundStyle(.white)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .background(Color(white: 0, opacity: 0.8))
+                .clipShape(RoundedRectangle(cornerRadius: 2))
+                .padding(8)
         }
     }
 }

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -14,34 +14,44 @@ private struct ChapterView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            ZStack {
-                Color(white: 1, opacity: 0.2)
-                if let image = chapter.image {
-                    Image(uiImage: image)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                }
-            }
-            .animation(.defaultLinear, value: chapter.image)
-            .overlay {
-                LinearGradient(
-                    gradient: Gradient(colors: [.black.opacity(0.7), .clear]),
-                    startPoint: .bottom,
-                    endPoint: .top
-                )
-            }
-            if let title = chapter.title {
-                Text(title)
-                    .foregroundStyle(.white)
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .lineLimit(2)
-                    .padding()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            }
+            imageView()
+            titleView()
         }
         .frame(width: Self.width, height: Self.width * 9 / 16)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    @ViewBuilder
+    private func imageView() -> some View {
+        ZStack {
+            Color(white: 1, opacity: 0.2)
+            if let image = chapter.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            }
+        }
+        .animation(.defaultLinear, value: chapter.image)
+        .overlay {
+            LinearGradient(
+                gradient: Gradient(colors: [.black.opacity(0.7), .clear]),
+                startPoint: .bottom,
+                endPoint: .top
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func titleView() -> some View {
+        if let title = chapter.title {
+            Text(title)
+                .foregroundStyle(.white)
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .lineLimit(2)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        }
     }
 }
 

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -134,7 +134,7 @@ struct ChaptersPlayerView: View {
                 HStack(spacing: 15) {
                     ForEach(chapters, id: \.timeRange) { chapter in
                         Button {
-                            player.seek(at(chapter.timeRange.start + CMTime(value: 1, timescale: 10)))
+                            player.seek(to: chapter)
                         } label: {
                             ChapterView(chapter: chapter, isHighlighted: chapter == currentChapter)
                         }

--- a/Demo/Sources/Showcase/ChaptersPlayerView.swift
+++ b/Demo/Sources/Showcase/ChaptersPlayerView.swift
@@ -73,7 +73,7 @@ private struct ChapterView: View {
     private func durationLabel() -> some View {
         if let formattedDuration {
             Text(formattedDuration)
-                .font(.footnote)
+                .font(.caption2)
                 .foregroundStyle(.white)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 2)

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -18,6 +18,40 @@ private struct PulseSymbolEffect: ViewModifier {
     }
 }
 
+private struct ScrollClipDisabled: ViewModifier {
+    let isDisabled: Bool
+
+    init(_ isDisabled: Bool) {
+        self.isDisabled = isDisabled
+    }
+
+    func body(content: Content) -> some View {
+        Group {
+            if #available(iOS 17.0, tvOS 17.0, *) {
+                content
+                    .scrollClipDisabled(isDisabled)
+            }
+            else {
+                content
+            }
+        }
+    }
+}
+
+private struct ScaleEffect: ViewModifier {
+    let scale: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, tvOS 17.0, *) {
+            content
+                .scaleEffect(scale)
+        }
+        else {
+            content
+        }
+    }
+}
+
 extension View {
     /// Prevents touch propagation to views located below the receiver.
     func preventsTouchPropagation() -> some View {
@@ -38,6 +72,14 @@ extension View {
 
     func pulseSymbolEffect() -> some View {
         modifier(PulseSymbolEffect())
+    }
+
+    func scrollClipDisabled17(_ disabled: Bool = true) -> some View {
+        modifier(ScrollClipDisabled(disabled))
+    }
+
+    func scaleEffect17(_ scale: CGFloat) -> some View {
+        modifier(ScaleEffect(scale: scale))
     }
 }
 

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-private struct PulseSymbolEffect: ViewModifier {
+private struct PulseSymbolEffect17: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 17.0, tvOS 17.0, *) {
             content
@@ -18,7 +18,7 @@ private struct PulseSymbolEffect: ViewModifier {
     }
 }
 
-private struct ScrollClipDisabled: ViewModifier {
+private struct ScrollClipDisabled17: ViewModifier {
     let isDisabled: Bool
 
     init(_ isDisabled: Bool) {
@@ -38,7 +38,7 @@ private struct ScrollClipDisabled: ViewModifier {
     }
 }
 
-private struct ScaleEffect: ViewModifier {
+private struct ScaleEffect17: ViewModifier {
     let scale: CGFloat
 
     func body(content: Content) -> some View {
@@ -70,16 +70,16 @@ extension View {
         )
     }
 
-    func pulseSymbolEffect() -> some View {
-        modifier(PulseSymbolEffect())
+    func pulseSymbolEffect17() -> some View {
+        modifier(PulseSymbolEffect17())
     }
 
     func scrollClipDisabled17(_ disabled: Bool = true) -> some View {
-        modifier(ScrollClipDisabled(disabled))
+        modifier(ScrollClipDisabled17(disabled))
     }
 
     func scaleEffect17(_ scale: CGFloat) -> some View {
-        modifier(ScaleEffect(scale: scale))
+        modifier(ScaleEffect17(scale: scale))
     }
 }
 

--- a/Sources/Player/Player+Seek.swift
+++ b/Sources/Player/Player+Seek.swift
@@ -89,4 +89,14 @@ public extension Player {
         let position = Self.optimalPosition(reaching: time, for: queuePlayer.currentItem)
         seek(position, smooth: true, completion: completion)
     }
+
+    /// Performs a precise seek to a chapter.
+    ///
+    /// - Parameters:
+    ///   - chapter: The chapter to reach.
+    ///   - completion: A completion called when seeking ends. The provided Boolean informs whether the seek could
+    ///     finish without being cancelled.
+    func seek(to chapter: Chapter, completion: @escaping (Bool) -> Void = { _ in }) {
+        seek(at(chapter.timeRange.start + CMTime(value: 1, timescale: 10)), completion: completion)
+    }
 }


### PR DESCRIPTION
# Description

This PR adds a duration label on chapter cells displayed in our chapter-supporting demo player. It also improves how the current chapter is displayed on iOS 17 and above.

| Duration | Cell highlight (iOS 17) |
|--------|--------|
| ![Duration](https://github.com/SRGSSR/pillarbox-apple/assets/170201/d9f1d428-d4c2-4b82-9888-2a2feea5b403) | ![Highlight](https://github.com/SRGSSR/pillarbox-apple/assets/170201/c9bfd4ed-3a31-4c1f-bd2a-88f3c9a7f376) |

# Changes made

- Add duration label.
- Add scale effect to the current chapter on iOS 17. This effect is only possible on iOS 17 since there is no API to disable scroll view clipping on earlier versions.

Some modifiers are meaningful only for iOS 17. I marked them explicitly with a common naming style. There is likely a more generic approach but for the moment I chose to keep things simple.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
