### PR TITLE
Enable advanced Picture in Picture and Control Center integration for the chapter-supporting player

### DIFF
--- a/Demo/Sources/Players/ChaptersPlayerView.swift
+++ b/Demo/Sources/Players/ChaptersPlayerView.swift
@@ -121,6 +121,7 @@ struct ChaptersPlayerView: View {
         .bind(progressTracker, to: model.player)
         .onReceive(model.player.$metadata, assign: \.chapters, to: $chapters)
         .onAppear(perform: play)
+        .tracked(name: "chapters-player")
     }
 
     private func play() {

--- a/Demo/Sources/Players/ChaptersPlayerView.swift
+++ b/Demo/Sources/Players/ChaptersPlayerView.swift
@@ -111,6 +111,7 @@ private struct ChaptersList: View {
         .scrollIndicators(.hidden)
         .scrollClipDisabled17()
         .bind(progressTracker, to: player)
+        ._debugBodyCounter(color: .purple)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/ChaptersPlayerView.swift
+++ b/Demo/Sources/Players/ChaptersPlayerView.swift
@@ -33,7 +33,7 @@ private struct ChapterCell: View {
         .frame(width: Self.width, height: Self.width * 9 / 16)
         .clipShape(RoundedRectangle(cornerRadius: 5))
         .saturation(isHighlighted ? 1 : 0)
-        .scaleEffect17(isHighlighted ? 1.05 : 1)
+        .scaleEffect17(isHighlighted ? 1.07 : 1)
         .animation(.defaultLinear, value: isHighlighted)
     }
 

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -47,7 +47,7 @@ final class Router: ObservableObject {
 extension Router: PictureInPictureDelegate {
     func pictureInPictureWillStart() {
         switch presented {
-        case .player, .systemPlayer, .playlist, .multi:
+        case .player, .systemPlayer, .chaptersPlayer, .playlist, .multi:
             previousPresented = presented
             presented = nil
         case .inlineSystemPlayer:


### PR DESCRIPTION
# Description

This PR enables advanced Picture in Picture and Control Center integration for the chapter-supporting player. This was initially omitted but felt awkward when navigating SRG SSR content from a demo user perspective.

# Changes made

- Enable advanced PiP for the player supporting chapters.
- Enable Control Center integration for the player supporting chapters.
- Revisit the implementation to have correct animations during PiP restoration. Instead of manual state registration it suffices to split the view into subviews with local `Player` observation. 
- Track the player view.
- Make highlighted chapters slightly more prominent.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
