### PR TITLE
Remove chapters with non-matching media type

### DIFF
--- a/Sources/CoreBusiness/Model/Chapter.swift
+++ b/Sources/CoreBusiness/Model/Chapter.swift
@@ -22,6 +22,7 @@ public extension MediaComposition {
             case date
             case description
             case imageUrl
+            case mediaType
             case title
             case urn
             case fullLengthUrn
@@ -46,6 +47,9 @@ public extension MediaComposition {
 
         /// The content type.
         public let contentType: ContentType
+
+        /// The media type.
+        public let mediaType: MediaType
 
         /// The publication date.
         public let date: Date

--- a/Sources/CoreBusiness/Model/MediaComposition.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition.swift
@@ -20,7 +20,7 @@ public struct MediaComposition: Decodable {
 
     /// The available chapters.
     public var chapters: [Chapter] {
-        _chapters.filter { $0.fullLengthUrn == chapterUrn }
+        _chapters.filter { $0.fullLengthUrn == chapterUrn && $0.mediaType == mainChapter.mediaType }
     }
 
     /// The related show.

--- a/Sources/CoreBusiness/Model/MediaType.swift
+++ b/Sources/CoreBusiness/Model/MediaType.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+public extension MediaComposition {
+    /// Media types.
+    enum MediaType: String, Decodable {
+        /// Audio.
+        case audio = "AUDIO"
+
+        /// Video.
+        case video = "VIDEO"
+    }
+}


### PR DESCRIPTION
# Description

Some RTS Forum video episodes (e.g. `urn:rts:video:14827796`) are [delivered](https://il.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/urn:rts:video:14827796?vector=appplay&onlyChapters=true) with the corresponding full-length audio as part of the chapter list, with `fullLengthMarkin` and `fullLengthMarkOut` both set to zero. The resulting behavior is awkward:

![IMG_2519](https://github.com/SRGSSR/pillarbox-apple/assets/170201/2b20cdcd-6bc3-44de-8488-83c26fc88b91)

Though this could be seen as a backend or metadata issue, the media composition is flexible enough to allow such use cases. Letterbox also currently supports such use cases, though the user experience might be awkward (tapping on the audio content makes the context switch to the audio-only context).

For the moment I think we sadly have to fix the issue client-side. This is what this PR does by parsing the media type and ensuring chapters all have the same media type as the main content.

# Changes made

- Update parsing to extract media type from metadata.
- Update condition used to associate chapters with the content being played.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
