### PR TITLE
Return invalid times and ranges consistently with other player APIs

### DIFF
--- a/Demo/Sources/Players/ChaptersPlayerView.swift
+++ b/Demo/Sources/Players/ChaptersPlayerView.swift
@@ -98,10 +98,7 @@ private struct ChaptersList: View {
     }
 
     private var currentChapter: Chapter? {
-        chapters.first { chapter in
-            guard let time = progressTracker.time else { return false }
-            return chapter.timeRange.containsTime(time)
-        }
+        chapters.first { $0.timeRange.containsTime(progressTracker.time) }
     }
 
     var body: some View {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -468,15 +468,13 @@ private struct TimeSlider: View {
     @State private var streamType: StreamType = .unknown
 
     private var formattedElapsedTime: String? {
-        guard streamType == .onDemand, let time = progressTracker.time, let timeRange = progressTracker.timeRange else {
-            return nil
-        }
-        return Self.formattedTime((time - timeRange.start).seconds, duration: timeRange.duration.seconds)
+        guard streamType == .onDemand else { return nil }
+        return Self.formattedTime((progressTracker.time - progressTracker.timeRange.start).seconds, duration: progressTracker.timeRange.duration.seconds)
     }
 
     private var formattedTotalTime: String? {
-        guard streamType == .onDemand, let timeRange = progressTracker.timeRange else { return nil }
-        return Self.formattedTime(timeRange.duration.seconds, duration: timeRange.duration.seconds)
+        guard streamType == .onDemand else { return nil }
+        return Self.formattedTime(progressTracker.timeRange.duration.seconds, duration: progressTracker.timeRange.duration.seconds)
     }
 
     private var isVisible: Bool {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -111,6 +111,8 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// The current time.
+    ///
+    /// Returns `.invalid` when the time is unknown.
     public var time: CMTime {
         queuePlayer.currentTime().clamped(to: seekableTimeRange)
     }

--- a/Sources/Player/Types/PlayerProperties.swift
+++ b/Sources/Player/Types/PlayerProperties.swift
@@ -122,6 +122,8 @@ extension PlayerProperties {
 
 public extension PlayerProperties {
     /// The time range within which it is possible to seek.
+    ///
+    /// Returns `.invalid` when the time range is unknown.
     var seekableTimeRange: CMTimeRange {
         timeProperties.seekableTimeRange
     }

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -90,10 +90,9 @@ public final class ProgressTracker: ObservableObject {
 
     /// The time corresponding to the current progress.
     ///
-    /// The returned value might be different from the player current time when interaction takes place.
-    ///
-    /// Non-`nil` returned times are guaranteed to be valid.
-    public var time: CMTime? {
+    /// Returns `.invalid` when the time range is unknown. The returned value might be different from the player current
+    /// time when interaction takes place.
+    public var time: CMTime {
         time(forProgress: _progress)
     }
 
@@ -112,10 +111,9 @@ public final class ProgressTracker: ObservableObject {
 
     /// The current time range.
     ///
-    /// Non-`nil` returned ranges are guaranteed to be valid.
-    public var timeRange: CMTimeRange? {
-        guard let timeRange = player?.seekableTimeRange, timeRange.isValidAndNotEmpty else { return nil }
-        return timeRange
+    /// Returns `.invalid` when the time range is unknown.
+    public var timeRange: CMTimeRange {
+        player?.seekableTimeRange ?? .invalid
     }
 
     /// Creates a progress tracker updating its progress at the specified interval.
@@ -166,7 +164,8 @@ public final class ProgressTracker: ObservableObject {
     }
 
     private func seek(to progress: Float, optimal: Bool) {
-        guard let player, let time = time(forProgress: progress) else { return }
+        guard let player else { return }
+        let time = time(forProgress: progress)
         if optimal {
             player.seek(to: time)
         }
@@ -175,8 +174,8 @@ public final class ProgressTracker: ObservableObject {
         }
     }
 
-    private func time(forProgress progress: Float?) -> CMTime? {
-        guard let timeRange, let progress else { return nil }
+    private func time(forProgress progress: Float?) -> CMTime {
+        guard let progress else { return .invalid }
         return timeRange.start + CMTimeMultiplyByFloat64(timeRange.duration, multiplier: Float64(progress))
     }
 

--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerTimeTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerTimeTests.swift
@@ -16,7 +16,7 @@ final class ProgressTrackerTimeTests: TestCase {
     func testUnbound() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectAtLeastEqualPublished(
-            values: [nil],
+            values: [.invalid],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates()
         )
@@ -25,7 +25,7 @@ final class ProgressTrackerTimeTests: TestCase {
     func testEmptyPlayer() {
         let progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 4))
         expectAtLeastEqualPublished(
-            values: [nil],
+            values: [.invalid],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates()
         ) {
@@ -38,7 +38,7 @@ final class ProgressTrackerTimeTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expectAtLeastEqualPublished(
-            values: [nil, .zero],
+            values: [.invalid, .zero],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates()
         ) {
@@ -52,13 +52,13 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         expectPublished(
             values: [
-                nil,
+                .invalid,
                 .zero,
                 CMTime(value: 1, timescale: 4),
                 CMTime(value: 1, timescale: 2),
                 CMTime(value: 3, timescale: 4),
                 CMTime(value: 1, timescale: 1),
-                nil
+                .invalid
             ],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
@@ -76,7 +76,7 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         expectAtLeastPublished(
             values: [
-                nil,
+                .invalid,
                 CMTime(value: 17, timescale: 1),
                 CMTime(value: 17, timescale: 1),
                 CMTime(value: 17, timescale: 1),
@@ -97,11 +97,11 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.time).toEventuallyNot(beNil())
+        expect(progressTracker.time).toEventuallyNot(equal(.invalid))
 
         let time = progressTracker.time
         expectAtLeastEqualPublished(
-            values: [time, nil],
+            values: [time, .invalid],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates()
         ) {
@@ -115,11 +115,11 @@ final class ProgressTrackerTimeTests: TestCase {
         let player = Player(item: item)
         progressTracker.player = player
         player.play()
-        expect(progressTracker.time).toEventuallyNot(beNil())
+        expect(progressTracker.time).toEventuallyNot(equal(.invalid))
 
         let time = progressTracker.time
         expectAtLeastEqualPublished(
-            values: [time, nil],
+            values: [time, .invalid],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates()
         ) {
@@ -142,7 +142,7 @@ final class ProgressTrackerTimeTests: TestCase {
         }
 
         expectAtLeastPublished(
-            values: [nil, time],
+            values: [.invalid, time],
             from: progressTracker.changePublisher(at: \.time)
                 .removeDuplicates(),
             to: beClose(within: 0.1)


### PR DESCRIPTION
# Description

This PR improves API consistency between `ProgressTracker` and `Player` when requesting time or time range information. 

# Changes made

- Return `.invalid` times and ranges from `ProgressTracker` instead of `nil` when unknown.
- Update documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
