### PR TITLE
Fix assertion raised when formatting invalid times

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -469,12 +469,12 @@ private struct TimeSlider: View {
 
     private var formattedElapsedTime: String? {
         guard streamType == .onDemand else { return nil }
-        return Self.formattedTime((progressTracker.time - progressTracker.timeRange.start).seconds, duration: progressTracker.timeRange.duration.seconds)
+        return Self.formattedTime((progressTracker.time - progressTracker.timeRange.start), duration: progressTracker.timeRange.duration)
     }
 
     private var formattedTotalTime: String? {
         guard streamType == .onDemand else { return nil }
-        return Self.formattedTime(progressTracker.timeRange.duration.seconds, duration: progressTracker.timeRange.duration.seconds)
+        return Self.formattedTime(progressTracker.timeRange.duration, duration: progressTracker.timeRange.duration)
     }
 
     private var isVisible: Bool {
@@ -504,12 +504,13 @@ private struct TimeSlider: View {
         .onReceive(player: player, assign: \.streamType, to: $streamType)
     }
 
-    private static func formattedTime(_ time: TimeInterval, duration: TimeInterval) -> String {
-        if duration < 60 * 60 {
-            return shortFormatter.string(from: time)!
+    private static func formattedTime(_ time: CMTime, duration: CMTime) -> String? {
+        guard time.isValid, duration.isValid else { return nil }
+        if duration.seconds < 60 * 60 {
+            return shortFormatter.string(from: time.seconds)!
         }
         else {
-            return longFormatter.string(from: time)!
+            return longFormatter.string(from: time.seconds)!
         }
     }
 


### PR DESCRIPTION
# Description

This PR fixes an assertion raised in debug builds, following changes made in #847.

# Changes made

- Check that times are valid before attempting to format values in seconds derived from them.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
