### PR TITLE
Improved tvOS playlist experience

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -150,12 +150,14 @@ struct PlaylistView: View {
             PlaybackView(player: model.player, layout: $layout)
                 .monoscopic(model.isMonoscopic)
                 .supportsPictureInPicture()
+#if os(iOS)
             if layout != .maximized {
                 Toolbar(player: model.player, model: model)
                 List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
                     MediaCell(media: media)
                 }
             }
+#endif
         }
         .animation(.defaultLinear, value: layout)
         .onAppear {

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -52,7 +52,7 @@ extension AVPlayerItem {
         playerItems(from: items.prefix(length).map(\.content), reload: reload)
     }
 
-    static func playerItems(from contents: [AssetContent], reload: Bool = false) -> [AVPlayerItem] {
+    private static func playerItems(from contents: [AssetContent], reload: Bool = false) -> [AVPlayerItem] {
         contents.map { $0.playerItem(reload: reload) }
     }
 


### PR DESCRIPTION
# Description

This PR improves the tvOS playlist experience by removing the associated item list, not really usable on tvOS.

# Changes made

- Remove playlist item display on tvOS.
- Improve encapsulation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
