### PR TITLE
Fix undesired seek in overlapping time ranges

### DIFF
--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -24,7 +24,7 @@ struct AssetContent {
     func update(item: AVPlayerItem) {
         item.externalMetadata = metadata.externalMetadata
 #if os(tvOS)
-        item.interstitialTimeRanges = CMTimeRange.flatten(metadata.blockedTimeRanges).map { timeRange in
+        item.interstitialTimeRanges = metadata.blockedTimeRanges.map { timeRange in
             .init(timeRange: timeRange)
         }
         item.navigationMarkerGroups = [

--- a/Sources/Player/Types/PlayerMetadata.swift
+++ b/Sources/Player/Types/PlayerMetadata.swift
@@ -45,9 +45,7 @@ public struct PlayerMetadata: Equatable {
     /// Time ranges associated with the content.
     public let timeRanges: [TimeRange]
 
-    var blockedTimeRanges: [CMTimeRange] {
-        timeRanges.filter { $0.kind == .blocked }.map { .init(start: $0.start, end: $0.end) }
-    }
+    let blockedTimeRanges: [CMTimeRange]
 
     var episodeDescription: String? {
         switch episodeInformation {
@@ -116,6 +114,11 @@ public struct PlayerMetadata: Equatable {
         self.episodeInformation = episodeInformation
         self.chapters = chapters
         self.timeRanges = timeRanges
+        self.blockedTimeRanges = Self.flattenedBlockedTimeRanges(from: timeRanges)
+    }
+
+    private static func flattenedBlockedTimeRanges(from timeRanges: [TimeRange]) -> [CMTimeRange] {
+        CMTimeRange.flatten(timeRanges.filter { $0.kind == .blocked }.map { .init(start: $0.start, end: $0.end) })
     }
 }
 

--- a/Tests/PlayerTests/Player/BlockedTimeRangeTests.swift
+++ b/Tests/PlayerTests/Player/BlockedTimeRangeTests.swift
@@ -14,7 +14,7 @@ import PillarboxStreams
 private let kBlockedTimeRange = CMTimeRange(start: .init(value: 20, timescale: 1), end: .init(value: 60, timescale: 1))
 private let kOverlappingBlockedTimeRange = CMTimeRange(start: .init(value: 50, timescale: 1), end: .init(value: 100, timescale: 1))
 
-private struct MockMetadataWithBlockedTimeRange: AssetMetadata {
+private struct MetadataWithBlockedTimeRange: AssetMetadata {
     var playerMetadata: PlayerMetadata {
         .init(timeRanges: [
             .init(kind: .blocked, start: kBlockedTimeRange.start, end: kBlockedTimeRange.end)
@@ -22,7 +22,7 @@ private struct MockMetadataWithBlockedTimeRange: AssetMetadata {
     }
 }
 
-private struct MockMetadataWithOverlappingBlockedTimeRanges: AssetMetadata {
+private struct MetadataWithOverlappingBlockedTimeRanges: AssetMetadata {
     var playerMetadata: PlayerMetadata {
         .init(timeRanges: [
             .init(kind: .blocked, start: kBlockedTimeRange.start, end: kBlockedTimeRange.end),
@@ -33,7 +33,7 @@ private struct MockMetadataWithOverlappingBlockedTimeRanges: AssetMetadata {
 
 final class BlockedTimeRangeTests: TestCase {
     func testSeekInBlockedTimeRange() {
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange()))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MetadataWithBlockedTimeRange()))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.seek(at(.init(value: 30, timescale: 1)))
         expect(kBlockedTimeRange.containsTime(player.time)).toNever(beTrue(), until: .seconds(2))
@@ -41,7 +41,7 @@ final class BlockedTimeRangeTests: TestCase {
     }
 
     func testSeekInOverlappingBlockedTimeRange() {
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithOverlappingBlockedTimeRanges()))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MetadataWithOverlappingBlockedTimeRanges()))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.seek(at(.init(value: 30, timescale: 1)))
         expect(kOverlappingBlockedTimeRange.containsTime(player.time)).toNever(beTrue(), until: .seconds(2))
@@ -50,14 +50,14 @@ final class BlockedTimeRangeTests: TestCase {
 
     func testBlockedTimeRangeTraversal() {
         let configuration = PlayerItemConfiguration(position: at(.init(value: 29, timescale: 1)))
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange(), configuration: configuration))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MetadataWithBlockedTimeRange(), configuration: configuration))
         player.play()
         expect(player.time).toEventually(beGreaterThan(kBlockedTimeRange.end))
     }
 
     func testOnDemandStartInBlockedTimeRange() {
         let configuration = PlayerItemConfiguration(position: at(.init(value: 30, timescale: 1)))
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange(), configuration: configuration))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MetadataWithBlockedTimeRange(), configuration: configuration))
         expect(player.time).toEventually(equal(kBlockedTimeRange.end))
     }
 }

--- a/Tests/PlayerTests/Player/BlockedTimeRangeTests.swift
+++ b/Tests/PlayerTests/Player/BlockedTimeRangeTests.swift
@@ -12,8 +12,9 @@ import PillarboxCircumspect
 import PillarboxStreams
 
 private let kBlockedTimeRange = CMTimeRange(start: .init(value: 20, timescale: 1), end: .init(value: 60, timescale: 1))
+private let kOverlappingBlockedTimeRange = CMTimeRange(start: .init(value: 50, timescale: 1), end: .init(value: 100, timescale: 1))
 
-private struct MockMetadata: AssetMetadata {
+private struct MockMetadataWithBlockedTimeRange: AssetMetadata {
     var playerMetadata: PlayerMetadata {
         .init(timeRanges: [
             .init(kind: .blocked, start: kBlockedTimeRange.start, end: kBlockedTimeRange.end)
@@ -21,25 +22,42 @@ private struct MockMetadata: AssetMetadata {
     }
 }
 
+private struct MockMetadataWithOverlappingBlockedTimeRanges: AssetMetadata {
+    var playerMetadata: PlayerMetadata {
+        .init(timeRanges: [
+            .init(kind: .blocked, start: kBlockedTimeRange.start, end: kBlockedTimeRange.end),
+            .init(kind: .blocked, start: kOverlappingBlockedTimeRange.start, end: kOverlappingBlockedTimeRange.end)
+        ])
+    }
+}
+
 final class BlockedTimeRangeTests: TestCase {
     func testSeekInBlockedTimeRange() {
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadata()))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange()))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.seek(at(.init(value: 30, timescale: 1)))
         expect(kBlockedTimeRange.containsTime(player.time)).toNever(beTrue(), until: .seconds(2))
         expect(player.time).to(equal(kBlockedTimeRange.end))
     }
 
+    func testSeekInOverlappingBlockedTimeRange() {
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithOverlappingBlockedTimeRanges()))
+        expect(player.streamType).toEventually(equal(.onDemand))
+        player.seek(at(.init(value: 30, timescale: 1)))
+        expect(kOverlappingBlockedTimeRange.containsTime(player.time)).toNever(beTrue(), until: .seconds(2))
+        expect(player.time).to(equal(kOverlappingBlockedTimeRange.end))
+    }
+
     func testBlockedTimeRangeTraversal() {
         let configuration = PlayerItemConfiguration(position: at(.init(value: 29, timescale: 1)))
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadata(), configuration: configuration))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange(), configuration: configuration))
         player.play()
         expect(player.time).toEventually(beGreaterThan(kBlockedTimeRange.end))
     }
 
     func testOnDemandStartInBlockedTimeRange() {
         let configuration = PlayerItemConfiguration(position: at(.init(value: 30, timescale: 1)))
-        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadata(), configuration: configuration))
+        let player = Player(item: .simple(url: Stream.onDemand.url, metadata: MockMetadataWithBlockedTimeRange(), configuration: configuration))
         expect(player.time).toEventually(equal(kBlockedTimeRange.end))
     }
 }


### PR DESCRIPTION
# Description

This PR fixes #861.

# Changes made

- Add test reproducing the issue.
- Fix the issue by applying the same flattening approach as for interstitials. To avoid repeatedly performing the same work, flattening is made once and the result cached.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
