### PR TITLE
Display time ranges on custom slider

### DIFF
--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -72,7 +72,7 @@ enum URLTemplate {
         imageUrl: "https://www.rts.ch/2023/05/01/10/22/10253916.image/16x9",
         type: .url("https://rts-vod-amd.akamaized.net/ch/13986102/d13bcd9d-7030-3f5a-b28c-f9abfa6795b8/master.m3u8"),
         timeRanges: [
-            .init(kind: .credits(.opening), start: .init(value: 3, timescale: 1), end: .init(value: 7, timescale: 1)),
+            .init(kind: .credits(.opening), start: .zero, end: .init(value: 9, timescale: 1)),
             .init(kind: .credits(.closing), start: .init(value: 163, timescale: 1), end: .init(value: 183_680, timescale: 1000))
         ]
     )
@@ -82,7 +82,7 @@ enum URLTemplate {
         imageUrl: kAppleImageUrl,
         type: .url("https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8"),
         timeRanges: [
-            .init(kind: .blocked, start: .init(value: 0, timescale: 1), end: .init(value: 300, timescale: 1)),
+            .init(kind: .blocked, start: .zero, end: .init(value: 300, timescale: 1)),
             .init(kind: .blocked, start: .init(value: 600, timescale: 1), end: .init(value: 900, timescale: 1)),
             .init(kind: .blocked, start: .init(value: 700, timescale: 1), end: .init(value: 1200, timescale: 1))
         ]

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -538,6 +538,7 @@ private struct TimeSlider: View {
             maximumValueLabel: {
                 label(withText: formattedTotalTime)
             },
+            timeRanges: player.metadata.timeRanges,
             onDragging: {
                 if UserDefaults.standard.seekBehavior == .deferred {
                     visibilityTracker.reset()

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -20,6 +20,10 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @State private var initialProgress: Float = 0
     @State private var buffer: Float = 0
 
+    private var blockedTimeRanges: [TimeRange] {
+        timeRanges.filter { $0.kind == .blocked }
+    }
+
     var body: some View {
         HStack {
             minimumValueLabel()
@@ -62,6 +66,13 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     }
 
     @ViewBuilder
+    private func blockedRectangles(width: CGFloat) -> some View {
+        ForEach(blockedTimeRanges, id: \.self) { timeRange in
+            add(timeRange: timeRange, width: width, color: .red)
+        }
+    }
+
+    @ViewBuilder
     private func add(timeRange: TimeRange, width: CGFloat, color: Color) -> some View {
         if progressTracker.timeRange.isValid {
             let duration = progressTracker.timeRange.duration.seconds
@@ -79,9 +90,8 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                 rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(buffer))
                     .animation(.linear(duration: 0.5), value: buffer)
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
-                ForEach(timeRanges.filter { $0.kind == .blocked }, id: \.self) { timeRange in
-                    add(timeRange: timeRange, width: geometry.size.width, color: .red)
-                }
+
+                blockedRectangles(width: geometry.size.width)
             }
             .onChange(of: gestureValue) { value in
                 updateProgress(for: value, in: geometry)

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -12,6 +12,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
+    let timeRanges: [TimeRange]
     let onEditingChanged: (Bool) -> Void
     let onDragging: () -> Void
 
@@ -40,22 +41,33 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
         progressTracker: ProgressTracker,
         @ViewBuilder minimumValueLabel: @escaping () -> ValueLabel,
         @ViewBuilder maximumValueLabel: @escaping () -> ValueLabel,
+        timeRanges: [TimeRange],
         onEditingChanged: @escaping (Bool) -> Void = { _ in },
         onDragging: @escaping () -> Void = {}
     ) {
         self.progressTracker = progressTracker
         self.minimumValueLabel = minimumValueLabel
         self.maximumValueLabel = maximumValueLabel
+        self.timeRanges = timeRanges
         self.onEditingChanged = onEditingChanged
         self.onDragging = onDragging
     }
 
     @ViewBuilder
-    private func rectangle(opacity: Double = 1, width: CGFloat? = nil) -> some View {
+    private func rectangle(opacity: Double = 1, width: CGFloat? = nil, color: Color = .white) -> some View {
         Rectangle()
-            .foregroundColor(.white)
+            .foregroundColor(color)
             .opacity(opacity)
             .frame(width: width)
+    }
+
+    @ViewBuilder
+    private func add(timeRange: TimeRange, width: CGFloat, color: Color) -> some View {
+        if progressTracker.timeRange.isValid {
+            let duration = progressTracker.timeRange.duration.seconds
+            rectangle(opacity: 0.4, width: width * CGFloat(timeRange.end.seconds - timeRange.start.seconds) / CGFloat(duration), color: color)
+                .offset(x: width * CGFloat(timeRange.start.seconds) / CGFloat(duration))
+        }
     }
 
     @ViewBuilder
@@ -67,6 +79,9 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                 rectangle(opacity: 0.3, width: geometry.size.width * CGFloat(buffer))
                     .animation(.linear(duration: 0.5), value: buffer)
                 rectangle(width: geometry.size.width * CGFloat(progressTracker.progress))
+                ForEach(timeRanges.filter { $0.kind == .blocked }, id: \.self) { timeRange in
+                    add(timeRange: timeRange, width: geometry.size.width, color: .red)
+                }
             }
             .onChange(of: gestureValue) { value in
                 updateProgress(for: value, in: geometry)
@@ -99,7 +114,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
 extension PlaybackSlider where ValueLabel == EmptyView {
     init(progressTracker: ProgressTracker) {
-        self.init(progressTracker: progressTracker, minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() })
+        self.init(progressTracker: progressTracker, minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() }, timeRanges: [])
     }
 }
 


### PR DESCRIPTION
# Description

Self-explanatory.

# Changes made

- The `PlaybackSlider` takes into account time ranges.

| Blocked | Skips |
|--------|--------|
| ![blocked](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/c40903f0-6455-4e75-89cb-65aef036f8ab) | ![credits](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/a888eded-5f76-4273-a8c8-d1c45cf6a945) |


# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
