### PR TITLE
Add blocked time range URN example

### DIFF
--- a/Demo/Sources/Examples/ExamplesViewModel.swift
+++ b/Demo/Sources/Examples/ExamplesViewModel.swift
@@ -94,7 +94,8 @@ final class ExamplesViewModel: ObservableObject {
 
     let timeRangesMedias = Template.medias(from: [
         URLTemplate.timeRangesVideo,
-        URLTemplate.blockedTimeRangesVideo
+        URLTemplate.blockedTimeRangesVideo,
+        URNTemplate.blockedTimeRangesVideo
     ])
 
     @Published private(set) var protectedMedias = [Media]()

--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -297,6 +297,12 @@ enum URNTemplate {
         imageUrl: "https://www.rts.ch/2023/09/06/14/43/14253742.image/16x9",
         type: .urn("urn:rts:video:3608506")
     )
+    static let blockedTimeRangesVideo = Template(
+        title: "Puls - Gehirnerschütterung, Akutgeriatrie, Erlenpollen im Winter",
+        subtitle: "Content with a blocked time range",
+        imageUrl: "https://ws.srf.ch/asset/image/audio/3bc7c819-9f77-4b2f-bbb1-6787df21d7bc/WEBVISUAL/1641807822.jpg",
+        type: .urn("urn:srf:video:40ca0277-0e53-4312-83e2-4710354ff53e")
+    )
     static let dvrAudio = Template(
         title: "Couleur 3 (DVR)",
         subtitle: "DVR audio livestream",


### PR DESCRIPTION
# Description

This PR adds a URN-based example for blocked time ranges, the usual one we used in Letterbox.

# Changes made

- Add Puls example (`urn:srf:video:40ca0277-0e53-4312-83e2-4710354ff53e`). The other example we previously used (`urn:srf:video:d57f5c1c-080f-49a2-864e-4a1a83e41ae1`) is less relevant nowadays as it does not contain nested blocked segments anymore.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
