### PR TITLE
Display artwork image for audio

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -201,10 +201,23 @@ private struct MainView: View {
     }
 
     @ViewBuilder
+    private func audioArtwork() -> some View {
+        if let image = player.metadata.image {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        else {
+            image(name: "music.note.tv.fill")
+        }
+    }
+
+    @ViewBuilder
     private func video() -> some View {
         ZStack {
             if player.mediaType == .audio {
-                image(name: "music.note.tv.fill")
+               audioArtwork()
             }
             else if player.isExternalPlaybackActive {
                 image(name: "tv")

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -68,6 +68,10 @@ private struct MainView: View {
         player.metadata.subtitle
     }
 
+    private var image: UIImage? {
+        player.metadata.image
+    }
+
     private func magnificationGesture() -> some Gesture {
         MagnificationGesture()
             .onChanged { scale in
@@ -201,23 +205,18 @@ private struct MainView: View {
     }
 
     @ViewBuilder
-    private func audioArtwork() -> some View {
-        if let image = player.metadata.image {
-            Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        else {
-            image(name: "music.note.tv.fill")
-        }
+    private func artwork(for image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     @ViewBuilder
     private func video() -> some View {
         ZStack {
-            if player.mediaType == .audio {
-               audioArtwork()
+            if player.mediaType == .audio, let image {
+               artwork(for: image)
             }
             else if player.isExternalPlaybackActive {
                 image(name: "tv")
@@ -231,7 +230,7 @@ private struct MainView: View {
                     .supportsPictureInPicture(supportsPictureInPicture)
             }
         }
-        .animation(.easeIn(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive)
+        .animation(.easeIn(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive, image)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -224,7 +224,7 @@ private struct MainView: View {
     @ViewBuilder
     private func controls() -> some View {
         ZStack {
-            Color(white: 0, opacity: 0.3)
+            Color(white: 0, opacity: 0.5)
                 .opacity(isUserInterfaceHidden || (isInteracting && !areControlsAlwaysVisible) ? 0 : 1)
                 .ignoresSafeArea()
             ControlsView(player: player, progressTracker: progressTracker)

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -63,6 +63,12 @@ extension View {
             .animation(animation, value: v2)
     }
 
+    func animation<V1, V2, V3>(_ animation: Animation?, values v1: V1, _ v2: V2, _ v3: V3) -> some View where V1: Equatable, V2: Equatable, V3: Equatable {
+        self.animation(animation, value: v1)
+            .animation(animation, value: v2)
+            .animation(animation, value: v3)
+    }
+
     func tracked(name: String, levels: [String] = []) -> some View {
         tracked(
             comScore: .init(name: name),


### PR DESCRIPTION
# Description

This PR updates the custom player UI to display an artwork image, if available, when audio is played.

| Before | After |
|--------|--------|
| ![Before](https://github.com/SRGSSR/pillarbox-apple/assets/170201/5aee06b3-af4d-45c8-a85d-7d509144ee78) | ![After](https://github.com/SRGSSR/pillarbox-apple/assets/170201/a1d922e3-94cf-4dd8-af5e-34bcba2b6dd6) | 

# Changes made

- Display image when available.
- Remove audio image placeholder when no image is available.
- Slightly increase control overlay opacity.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
