### PR TITLE
Use new API for localization

### DIFF
--- a/Sources/CoreBusiness/DataProvider/Errors.swift
+++ b/Sources/CoreBusiness/DataProvider/Errors.swift
@@ -17,14 +17,14 @@ enum TokenError: Error {
 }
 
 struct DataError: LocalizedError {
-    static let noResourceAvailable = Self(errorDescription: NSLocalizedString(
-        "No playable resources could be found.",
+    static let noResourceAvailable = Self(errorDescription: String(
+        localized: "No playable resources could be found.",
         bundle: .module,
         comment: "Generic error message returned when no playable resources could be found"
     ))
 
-    static let malformedData = Self(errorDescription: NSLocalizedString(
-        "The data is invalid.",
+    static let malformedData = Self(errorDescription: String(
+        localized: "The data is invalid.",
         bundle: .module,
         comment: "Generic error message returned when data is invalid"
     ))

--- a/Sources/CoreBusiness/Extensions/HTTPURLResponse.swift
+++ b/Sources/CoreBusiness/Extensions/HTTPURLResponse.swift
@@ -21,7 +21,7 @@ extension HTTPURLResponse {
             return description.capitalizingFirstLetter()
         }
         else {
-            return NSLocalizedString("Unknown error.", bundle: .module, comment: "Generic error message")
+            return String(localized: "Unknown error.", bundle: .module, comment: "Generic error message")
         }
     }
 }

--- a/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
@@ -37,50 +37,50 @@ public extension MediaComposition {
         public var description: String {
             switch self {
             case .ageRating12:
-                return NSLocalizedString(
-                    "To protect children this content is only available between 8PM and 6AM.",
+                return String(
+                    localized: "To protect children this content is only available between 8PM and 6AM.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .ageRating18:
-                return NSLocalizedString(
-                    "To protect children this content is only available between 10PM and 5AM.",
+                return String(
+                    localized: "To protect children this content is only available between 10PM and 5AM.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .commercial:
-                return NSLocalizedString(
-                    "This commercial content is not available.",
+                return String(
+                    localized: "This commercial content is not available.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .endDate:
-                return NSLocalizedString(
-                    "This content is not available anymore.",
+                return String(
+                    localized: "This content is not available anymore.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .geoblocked:
-                return NSLocalizedString(
-                    "This content is not available outside Switzerland.",
+                return String(
+                    localized: "This content is not available outside Switzerland.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .legal:
-                return NSLocalizedString(
-                    "This content is not available due to legal restrictions.",
+                return String(
+                    localized: "This content is not available due to legal restrictions.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .startDate:
-                return NSLocalizedString(
-                    "This content is not available yet.",
+                return String(
+                    localized: "This content is not available yet.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
             case .unknown:
-                return NSLocalizedString(
-                    "This content is not available.",
+                return String(
+                    localized: "This content is not available.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )

--- a/Sources/Player/MediaSelection/MediaSelectionOption.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionOption.swift
@@ -25,9 +25,9 @@ public enum MediaSelectionOption: Hashable {
     public var displayName: String {
         switch self {
         case .automatic:
-            return NSLocalizedString("Auto (Recommended)", bundle: .module, comment: "Subtitle selection option")
+            return String(localized: "Auto (Recommended)", bundle: .module, comment: "Subtitle selection option")
         case .off:
-            return NSLocalizedString("Off", bundle: .module, comment: "Subtitle selection option")
+            return String(localized: "Off", bundle: .module, comment: "Subtitle selection option")
         case let .on(option):
             return option.displayName
         }

--- a/Sources/Player/UserInterface/AVPlayerViewControllerSpeedCoordinator.swift
+++ b/Sources/Player/UserInterface/AVPlayerViewControllerSpeedCoordinator.swift
@@ -62,7 +62,7 @@ private extension AVPlayerViewControllerSpeedCoordinator {
         }
         return [
             UIMenu(
-                title: NSLocalizedString("Playback Speed", bundle: .module, comment: "Playback speed menu title"),
+                title: String(localized: "Playback Speed", bundle: .module, comment: "Playback speed menu title"),
                 image: UIImage(systemName: "speedometer"),
                 options: [.singleSelection],
                 children: speedActions


### PR DESCRIPTION
# Description

Self-explanatory.

# Changes made

- Uses `String` instead of `NSLocalizedString`

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
