### PR TITLE
Apply current demo settings to player instances

### DIFF
--- a/Demo/Sources/Players/PlayerConfiguration.swift
+++ b/Demo/Sources/Players/PlayerConfiguration.swift
@@ -8,13 +8,19 @@ import Foundation
 import PillarboxPlayer
 
 extension PlayerConfiguration {
-    static let standard = Self(
-        usesExternalPlaybackWhileMirroring: !UserDefaults.standard.presenterModeEnabled,
-        smartNavigationEnabled: UserDefaults.standard.smartNavigationEnabled
-    )
+    static var standard: Self {
+        let userDefaults = UserDefaults.standard
+        return .init(
+            usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
+            smartNavigationEnabled: userDefaults.smartNavigationEnabled
+        )
+    }
 
-    static let externalPlaybackDisabled = Self(
-        allowsExternalPlayback: false,
-        smartNavigationEnabled: UserDefaults.standard.smartNavigationEnabled
-    )
+    static var externalPlaybackDisabled: Self {
+        let userDefaults = UserDefaults.standard
+        return .init(
+            allowsExternalPlayback: false,
+            smartNavigationEnabled: userDefaults.smartNavigationEnabled
+        )
+    }
 }


### PR DESCRIPTION
# Description

This PR fixes a regression recently introduced in the demo. Some settings changes, most notably how external playback behaves while mirroring or how playlists are navigated, were not applied anymore until the application was restarted.

# Changes made

- Fix player configuration to reflect current demo settings.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
