### PR TITLE
Disable automatic now playing info updates on iOS

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,7 +3,7 @@ default: true
 MD013: false
 
 MD024:
-  allow_different_nesting: true
+  siblings_only: true
 
 MD029:
   style: "ordered"

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -21,6 +21,9 @@ struct BasicSystemVideoView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let controller = AVPlayerViewController()
         controller.allowsPictureInPicturePlayback = false
+#if os(iOS)
+        controller.updatesNowPlayingInfoCenter = false
+#endif
         return controller
     }
 

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -43,6 +43,9 @@ struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let controller = PictureInPicture.shared.system.playerViewController ?? PlayerViewController()
         controller.allowsPictureInPicturePlayback = true
+#if os(iOS)
+        controller.updatesNowPlayingInfoCenter = false
+#endif
         PictureInPicture.shared.system.acquire(for: controller)
         return controller
     }


### PR DESCRIPTION
# Description

This PR disables automatic now playing info updates on iOS so that `becomeActive()` is required for proper Control Center integration on this platform.

# Changes made

- Disable `AVPlayerViewController` now playing info updates on iOS. The code is a bit redundant but factoring common `AVPlayerViewController` configuration would probably have lead to a clunky internal API concept anyway.
- Due to markdown-cli updates on CI agents the linting configuration had to be updated as well.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
