### PR TITLE
Fix capped times delivered by a progress tracker at the live edge

### DIFF
--- a/Tests/PlayerTests/ProgressTracker/ProgressTrackerProgressTests.swift
+++ b/Tests/PlayerTests/ProgressTracker/ProgressTrackerProgressTests.swift
@@ -136,4 +136,22 @@ final class ProgressTrackerProgressTests: TestCase {
             progressTracker.player = player
         }
     }
+
+    func testProgressForTimeInTimeRange() {
+        let timeRange = CMTimeRange(start: .zero, end: .init(value: 10, timescale: 1))
+        expect(ProgressTracker.progress(for: .init(value: 5, timescale: 1), in: timeRange)).to(equal(0.5))
+        expect(ProgressTracker.progress(for: .init(value: 15, timescale: 1), in: timeRange)).to(equal(1.5))
+    }
+
+    func testValidProgressInRange() {
+        expect(ProgressTracker.validProgress(nil, in: 0...1)).to(equal(0))
+        expect(ProgressTracker.validProgress(0.5, in: 0...1)).to(equal(0.5))
+        expect(ProgressTracker.validProgress(1.5, in: 0...1)).to(equal(1))
+    }
+
+    func testTimeForProgressInTimeRange() {
+        let timeRange = CMTimeRange(start: .zero, end: .init(value: 10, timescale: 1))
+        expect(ProgressTracker.time(forProgress: 0.5, in: timeRange)).to(equal(CMTime(value: 5, timescale: 1)))
+        expect(ProgressTracker.time(forProgress: 1.5, in: timeRange)).to(equal(CMTime(value: 15, timescale: 1)))
+    }
 }


### PR DESCRIPTION
# Description

This PR fixes incorrectly capped times delivered by a `ProgressTracker` at the live edge of a DVR livestream.

# Changes made

- Revisit implementation to store uncapped internal progress.
- Always expose progress in `0...1` publicly, but use internal uncapped progress for time construction.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
