### PR TITLE
Fix undesired animation

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -25,16 +25,16 @@ private struct MainView: View {
     @State private var selectedGravity: AVLayerVideoGravity = .resizeAspect
     @State private var isInteracting = false
 
-    private var areControlsAlwaysVisible: Bool {
-        player.isExternalPlaybackActive || player.mediaType != .video
-    }
-
     private var prioritizesVideoDevices: Bool {
         player.mediaType == .video
     }
 
     private var shouldHideInterface: Bool {
-        isUserInterfaceHidden || (isInteracting && !areControlsAlwaysVisible)
+        isUserInterfaceHidden || (isInteracting && !shouldKeepControlsAlwaysVisible)
+    }
+
+    private var shouldKeepControlsAlwaysVisible: Bool {
+        player.isExternalPlaybackActive || player.mediaType != .video
     }
 
     var body: some View {
@@ -65,7 +65,7 @@ private struct MainView: View {
     }
 
     private var isUserInterfaceHidden: Bool {
-        visibilityTracker.isUserInterfaceHidden && !areControlsAlwaysVisible && !player.canReplay()
+        visibilityTracker.isUserInterfaceHidden && !shouldKeepControlsAlwaysVisible && !player.canReplay()
     }
 
     private var title: String? {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -213,6 +213,7 @@ private struct MainView: View {
                 .tint(.white)
         }
         .menuOrder(.fixed)
+        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -185,13 +185,14 @@ private struct MainView: View {
                 PiPButton()
                 routePickerView()
             }
+            .opacity(shouldHideInterface ? 0 : 1)
             Spacer()
             HStack(spacing: 20) {
                 LoadingIndicator(player: player)
                 VolumeButton(player: player)
+                    .opacity(shouldHideInterface ? 0 : 1)
             }
         }
-        .opacity(shouldHideInterface ? 0 : 1)
         .topBarStyle()
         .preventsTouchPropagation()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -26,7 +26,7 @@ private struct MainView: View {
     @State private var isInteracting = false
 
     private var areControlsAlwaysVisible: Bool {
-        player.isExternalPlaybackActive || player.mediaType == .audio
+        player.isExternalPlaybackActive || player.mediaType != .video
     }
 
     private var prioritizesVideoDevices: Bool {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -168,12 +168,13 @@ private struct MainView: View {
 
     @ViewBuilder
     private func bottomButtons() -> some View {
-        HStack(spacing: 20) {
-            LiveButton(player: player, progressTracker: progressTracker)
-            settingsMenu()
-            FullScreenButton(layout: $layout)
+        if !shouldHideInterface {
+            HStack(spacing: 20) {
+                LiveButton(player: player, progressTracker: progressTracker)
+                settingsMenu()
+                FullScreenButton(layout: $layout)
+            }
         }
-        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -44,7 +44,7 @@ private struct MainView: View {
             topBar()
         }
         .statusBarHidden(isFullScreen ? isUserInterfaceHidden : false)
-        .animation(.defaultLinear, value: isUserInterfaceHidden)
+        .animation(.defaultLinear, value: shouldHideInterface)
         .bind(visibilityTracker, to: player)
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -139,7 +139,7 @@ private struct MainView: View {
             skipButton()
             bottomControls()
         }
-        .animation(.linear(duration: 0.2), values: isUserInterfaceHidden, isInteracting)
+        .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
         .padding(.horizontal)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -173,6 +173,7 @@ private struct MainView: View {
             settingsMenu()
             FullScreenButton(layout: $layout)
         }
+        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder
@@ -213,7 +214,6 @@ private struct MainView: View {
                 .tint(.white)
         }
         .menuOrder(.fixed)
-        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -33,6 +33,10 @@ private struct MainView: View {
         player.mediaType == .video
     }
 
+    private var shouldHideInterface: Bool {
+        isUserInterfaceHidden || (isInteracting && !areControlsAlwaysVisible)
+    }
+
     var body: some View {
         ZStack {
             main()
@@ -126,7 +130,7 @@ private struct MainView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .foregroundStyle(.white)
-        .opacity(isInteracting ? 0 : 1)
+        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder
@@ -185,7 +189,7 @@ private struct MainView: View {
                 VolumeButton(player: player)
             }
         }
-        .opacity(isUserInterfaceHidden ? 0 : 1)
+        .opacity(shouldHideInterface ? 0 : 1)
         .topBarStyle()
         .preventsTouchPropagation()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -247,11 +251,10 @@ private struct MainView: View {
     private func controls() -> some View {
         ZStack {
             Color(white: 0, opacity: 0.5)
-                .opacity(isUserInterfaceHidden || (isInteracting && !areControlsAlwaysVisible) ? 0 : 1)
                 .ignoresSafeArea()
             ControlsView(player: player, progressTracker: progressTracker)
-                .opacity(isUserInterfaceHidden || isInteracting ? 0 : 1)
         }
+        .opacity(shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Tools/Constant.swift
+++ b/Demo/Sources/Tools/Constant.swift
@@ -9,7 +9,7 @@ import SwiftUI
 let kPageSize: UInt = 50
 
 extension Animation {
-    static let defaultLinear = Self.linear(duration: 0.2)
+    static let defaultLinear = linear(duration: 0.2)
 }
 
 func constant<T>(iOS: T, tvOS: T) -> T {


### PR DESCRIPTION
# Description

This PR allows us to fix an undesired animation on the metadata view.

# Changes made

- Renames some computed variables.
- Uses same logic for opacities.
- Hides bottom buttons when the UI should be hidden.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
