### PR TITLE
Avoid settings menu being closed when controls disappear

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -168,13 +168,12 @@ private struct MainView: View {
 
     @ViewBuilder
     private func bottomButtons() -> some View {
-        if !shouldHideInterface {
-            HStack(spacing: 20) {
-                LiveButton(player: player, progressTracker: progressTracker)
-                settingsMenu()
-                FullScreenButton(layout: $layout)
-            }
+        HStack(spacing: 20) {
+            LiveButton(player: player, progressTracker: progressTracker)
+            settingsMenu()
+            FullScreenButton(layout: $layout)
         }
+        .opacity(isFullScreen && shouldHideInterface ? 0 : 1)
     }
 
     @ViewBuilder


### PR DESCRIPTION
# Description

This PR fixes a minor regression introduced in #881, in which bottom buttons (including the settings menu button) were removed from the hierarchy with hidden controls.

Due to current limitations with SwiftUI `Menu` API (see #384) we currently cannot prevent controls from disappearing while the menu is open. As a result the change in #881 was closing the menu while the user was picking a speed or tracks during playback. To reproduce:

1. Open the demo nightly build 429.
2. Play the first SWI video example. Do not pause playback.
3. Open the settings menu and wait. The menu is dismissed when controls are hidden.

# Changes made

- Use opacity to hide bottom bar buttons while in full-screen layout.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
