### PR TITLE
Align the loading indicator to the right when the UI is hidden

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -188,8 +188,10 @@ private struct MainView: View {
             Spacer()
             HStack(spacing: 20) {
                 LoadingIndicator(player: player)
-                VolumeButton(player: player)
-                    .opacity(shouldHideInterface ? 0 : 1)
+                    .animation(nil, value: shouldHideInterface)
+                if !shouldHideInterface {
+                    VolumeButton(player: player)
+                }
             }
         }
         .topBarStyle()


### PR DESCRIPTION
# Description

Self-explanatory.

# Changes made

| Bad alignment | Good alignment |
|--------|--------|
| ![bad](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/354c70a7-e035-441b-856e-a4ff0bad7bb0) | ![good](https://github.com/SRGSSR/pillarbox-apple/assets/3347810/f1d3cf46-8a6c-4ba1-933c-d765d165d13a)| 

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
