### PR TITLE
Add Swift Package Index documentation links

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,9 +4,9 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [
-        PillarboxAnalytics,
-        PillarboxCircumspect,
-        PillarboxCore,
+        PillarboxPlayer,
         PillarboxCoreBusiness,
-        PillarboxPlayer
+        PillarboxAnalytics,
+        PillarboxCore,
+        PillarboxCircumspect,
       ]

--- a/README.md
+++ b/README.md
@@ -76,15 +76,46 @@ With the expressiveness of SwiftUI, our rich playback API and the set of compone
 
 The library is suitable for applications running on iOS 16, tvOS 16 and above. The project is meant to be compiled with the latest versions of Xcode and of the Swift compiler.
 
-# Contributing
-
-If you want to contribute to the project have a look at our [contributing guide](docs/CONTRIBUTING.md).
-
 # Integration
 
 The library can be integrated using [Swift Package Manager](https://swift.org/package-manager) directly [within Xcode](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). You can also declare the library as a dependency of another one directly in the associated `Package.swift` manifest.
 
 If you want your application to run on Silicon Macs as an iPad application you must add `-weak_framework MediaPlayer` to your target _Other Linker Flags_ setting.
+
+# Documentation
+
+Pillarbox documentation includes articles, tutorials and an API reference to help you learn more about available features and how to integrate them into your application.
+
+> [!TIP]
+> If you discover errors in the documentation or if some documentation is missing please file a dedicated [issue](https://github.com/SRGSSR/pillarbox-apple/issues/new/choose). You can also directly submit documentation improvements via [pull requests](https://github.com/SRGSSR/pillarbox-apple/compare).
+
+## DocC documentation
+
+Documentation is available as a [DocC](https://developer.apple.com/documentation/docc) documentation catalog. This catalog must be built by opening the project with Xcode and selecting _Product_ > _Build Documentation_. You can then access it right from within the Xcode documentation window.
+
+## Online documentation
+
+Documentation for each major product provided by Pillarbox can also be found online on [Swift Package Index](https://swiftpackageindex.com/SRGSSR/pillarbox-apple):
+
+- [Player](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxplayer): Create engaging audio and video playback experiences.
+- [Analytics](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxanalytics): Measure app usage according to SRG SSR requirements.
+- [CoreBusiness](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcorebusiness): Play SRG SSR content with the Player framework.
+
+Documentation is also available for companion products:
+
+- [Core](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcore): Essential tools used when implementing Pillarbox.
+- [Circumspect](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcircumpsect): A [Nimble](https://github.com/Quick/Nimble)-based framework for testing Combine publishers.
+
+> [!TIP]
+> Documentation available from the above links opens for the latest tag. Use Swift Package Index navigation top bar to quickly switch another tag or to `main`.
+
+## Miscellaneous documentation
+
+Further documentation is also available by following the links below:
+
+- [Known issues](docs/KNOWN_ISSUES.md)
+- [Development setup](docs/DEVELOPMENT_SETUP.md)
+- [Continuous integration](docs/CONTINUOUS_INTEGRATION.md)
 
 # Plugins
 
@@ -100,19 +131,9 @@ If you are using Xcode Cloud this can be achieved with a [custom build script](h
 
 If your project is built with `xcodebuild` directly the same effect can be achieved by passing the `-skipPackagePluginValidation` option.
 
-# Getting started
+# Contributing
 
-To learn more about integration of Pillarbox into your project please have a look at our generated Xcode documentation.
-
-# Documentation
-
-Documentation is available as a [DocC](https://developer.apple.com/documentation/docc) documentation catalog. This catalog must be built by opening the project with Xcode and selecting _Product_ > _Build Documentation_. You can then access it right from within the Xcode documentation window.
-
-Further documentation is also available by following the links below:
-
-- [Known issues](docs/KNOWN_ISSUES.md)
-- [Development setup](docs/DEVELOPMENT_SETUP.md)
-- [Continuous integration](docs/CONTINUOUS_INTEGRATION.md)
+If you want to contribute to the project have a look at our [contributing guide](docs/CONTRIBUTING.md).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Documentation is available as a [DocC](https://developer.apple.com/documentation
 Documentation for each major product provided by Pillarbox can also be found online on [Swift Package Index](https://swiftpackageindex.com/SRGSSR/pillarbox-apple):
 
 - [Player](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxplayer): Create engaging audio and video playback experiences.
-- [Analytics](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxanalytics): Measure app usage according to SRG SSR requirements.
 - [CoreBusiness](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcorebusiness): Play SRG SSR content with the Player framework.
+- [Analytics](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxanalytics): Measure app usage according to SRG SSR requirements.
 
 Documentation is also available for companion products:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Documentation is also available for companion products:
 - [Circumspect](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcircumspect): A [Nimble](https://github.com/Quick/Nimble)-based framework for testing Combine publishers.
 
 > [!TIP]
-> Documentation available from the above links opens for the latest tag. Use Swift Package Index navigation top bar to quickly switch another tag or to `main`.
+> Documentation available from the above links opens for the latest tag. Use Swift Package Index navigation top bar to quickly switch to another tag or `main`.
 
 ## Miscellaneous documentation
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ From left to right:
 
 # Compatibility
 
-The library is suitable for applications running on iOS 16, tvOS 16 and above. The project is meant to be compiled with the latest versions of Xcode and of the Swift compiler.
+The library is suitable for applications running on iOS 16, tvOS 16 and above.
 
 # Integration
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Pillarbox is the iOS and tvOS modern reactive SRG SSR player ecosystem implement
 - Analytics and QoS integration.
 - User interface layout in SwiftUI.
 
-Its robust player provides all essential playback features you might expect:
+# Features
+
+Pillarbox robust player provides all essential playback features you might expect:
 
 - Audio and video (standard / monoscopic 360°) playback.
 - Support for on-demand and live streams (with or without DVR).
@@ -42,35 +44,6 @@ From left to right:
 - Screenshot 4: [Player with associated playlist](Demo/Sources/Showcase/Playlist/PlaylistView.swift).
 - Screenshot 5: [Stories](Demo/Sources/Showcase/Stories/StoriesView.swift).
 - Screenshot 6: [Custom chapter navigation](Demo/Sources/Players/PlayerView.swift).
-
-# Code example
-
-With Pillarbox creating a custom video player user interface has never been easier. Simply instantiate a `Player` and start building your user interface in SwiftUI right away:
-
-```swift
-import PillarboxPlayer
-import SwiftUI
-
-struct PlayerView: View {
-    @StateObject private var player = Player(
-        item: .simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
-    )
-
-    var body: some View {
-        ZStack {
-            VideoView(player: player)
-            Button(action: player.togglePlayPause) {
-                Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
-                    .resizable()
-                    .frame(width: 80, height: 80)
-            }
-        }
-        .onAppear(perform: player.play)
-    }
-}
-```
-
-With the expressiveness of SwiftUI, our rich playback API and the set of components at your disposal you will have a full-fledged player user interface in no time.
 
 # Compatibility
 
@@ -130,6 +103,35 @@ defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -b
 If you are using Xcode Cloud this can be achieved with a [custom build script](https://developer.apple.com/documentation/xcode/writing-custom-build-scripts).
 
 If your project is built with `xcodebuild` directly the same effect can be achieved by passing the `-skipPackagePluginValidation` option.
+
+# Code example
+
+With Pillarbox creating a custom video player user interface has never been easier. Simply instantiate a `Player` and start building your user interface in SwiftUI right away:
+
+```swift
+import PillarboxPlayer
+import SwiftUI
+
+struct PlayerView: View {
+    @StateObject private var player = Player(
+        item: .simple(url: URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!)
+    )
+
+    var body: some View {
+        ZStack {
+            VideoView(player: player)
+            Button(action: player.togglePlayPause) {
+                Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
+                    .resizable()
+                    .frame(width: 80, height: 80)
+            }
+        }
+        .onAppear(perform: player.play)
+    }
+}
+```
+
+With the expressiveness of SwiftUI, our rich playback API and the set of components at your disposal you will have a full-fledged player user interface in no time.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Documentation for each major product provided by Pillarbox can also be found onl
 Documentation is also available for companion products:
 
 - [Core](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcore): Essential tools used when implementing Pillarbox.
-- [Circumspect](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcircumpsect): A [Nimble](https://github.com/Quick/Nimble)-based framework for testing Combine publishers.
+- [Circumspect](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxcircumspect): A [Nimble](https://github.com/Quick/Nimble)-based framework for testing Combine publishers.
 
 > [!TIP]
 > Documentation available from the above links opens for the latest tag. Use Swift Package Index navigation top bar to quickly switch another tag or to `main`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Pillarbox is the iOS and tvOS modern reactive SRG SSR player ecosystem implement
 - Analytics and QoS integration.
 - User interface layout in SwiftUI.
 
+> [!IMPORTANT]
+> Even though Pillarbox offers features that are specific to our company, its player is fully generic and can be used to play any kind of content.
+
 # Features
 
 Pillarbox robust player provides all essential playback features you might expect:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pillarbox is the iOS and tvOS modern reactive SRG SSR player ecosystem implement
 
 # Features
 
-Pillarbox robust player provides all essential playback features you might expect:
+Pillarbox player provides all essential playback features you might expect:
 
 - Audio and video (standard / monoscopic 360°) playback.
 - Support for on-demand and live streams (with or without DVR).


### PR DESCRIPTION
# Description

This PR adds links to documentation hosted on Swift Package Index website. It also improves the overall documentation structure of the main readme file.

This improvement was suggested [elsewhere](https://github.com/SRGSSR/pillarbox-apple/issues/813#issuecomment-2027995399).

# Changes made

- Add documentation links.
- Better separate offline and online documentation information.
- Reorder sections to move more important documentation higher in the page.
- Add remark about Pillarbox usage outside SRG SSR.
- Remove Xcode / Swift version information, implicitly tied to the Swift Package manifest version.
- Make Swift Package Index display PillarboxPlayer documentation [by default](https://swiftpackageindex.com/swiftpackageindex/spimanifest/~/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
