### PR TITLE
Update SwiftLint to version 0.51.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,6 +32,7 @@ disabled_rules:
   - no_grouping_extension
   - no_magic_numbers
   - nslocalizedstring_require_bundle
+  - one_declaration_per_file
   - required_deinit
   - sorted_enum_cases
   - statement_position
@@ -134,6 +135,7 @@ opt_in_rules:
   - return_value_from_void_function
   - self_binding
   - self_in_property_initialization
+  - shorthand_argument
   - shorthand_optional_binding
   - single_test_class
   - sorted_first_last

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -567,6 +567,7 @@ private struct TimeSlider: View {
                 label(withText: formattedTotalTime)
             },
             timeRanges: player.metadata.timeRanges,
+            // swiftlint:disable:next trailing_closure
             onDragging: {
                 if UserDefaults.standard.seekBehavior == .deferred {
                     visibilityTracker.reset()

--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,1 @@
-realm/SwiftLint@0.54.0
+realm/SwiftLint@0.55.1

--- a/Sources/CoreBusiness/ResourceLoading/ContentKeySessionDelegate.swift
+++ b/Sources/CoreBusiness/ResourceLoading/ContentKeySessionDelegate.swift
@@ -35,7 +35,7 @@ final class ContentKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
         let (certificateData, _) = try await session.httpData(from: certificateUrl)
         let contentKeyRequestData = try await keyRequest.makeStreamingContentKeyRequestData(
             forApp: certificateData,
-            contentIdentifier: "content_id".data(using: .utf8)
+            contentIdentifier: Data("content_id".utf8 )
         )
         guard let contentKeyContextRequest = Self.contentKeyContextRequest(
             from: keyRequest.identifier,


### PR DESCRIPTION
# Description

This PR updates SwiftLint to version 0.51.1. Even though SwiftLint is back on Homebrew staying on Mint allows us to finely control which version we use and adjust rules accordingly.

# Changes made

- Update SwiftLint version.
- Update rules.
- Fix newly reported issues in code (one of them is a false positive to report).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
