### PR TITLE
Improve server support in Core Business

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -37,7 +37,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         UserDefaults.standard.publisher(for: \.serverSetting)
             .receiveOnMainThread()
             .sink { serverSetting in
-                SRGDataProvider.current = SRGDataProvider(serviceURL: serverSetting.url)
+                SRGDataProvider.current = serverSetting.dataProvider
             }
             .store(in: &cancellables)
     }

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -15,7 +15,7 @@ private struct LoadedView: View {
     @EnvironmentObject private var router: Router
 
     @AppStorage(UserDefaults.serverSettingKey)
-    private var serverSetting: ServerSetting = .production
+    private var serverSetting: ServerSetting = .ilProduction
 
     var body: some View {
         CustomList(data: contents) { content in
@@ -66,7 +66,7 @@ private struct ContentCell: View {
     let content: ContentListViewModel.Content
 
     @AppStorage(UserDefaults.serverSettingKey)
-    private var serverSetting: ServerSetting = .production
+    private var serverSetting: ServerSetting = .ilProduction
 
     @EnvironmentObject private var router: Router
 

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -46,7 +46,7 @@ private struct LoadedView: View {
             return Template(
                 title: media.title,
                 subtitle: MediaDescription.subtitle(for: media),
-                type: .urn(media.urn),
+                type: .urn(media.urn, serverSetting: serverSetting),
                 isMonoscopic: media.isMonoscopic
             )
         }
@@ -101,7 +101,7 @@ private struct ContentCell: View {
             ) {
                 let media = Media(
                     title: title,
-                    type: .urn(media.urn),
+                    type: .urn(media.urn, serverSetting: serverSetting),
                     isMonoscopic: media.isMonoscopic
                 )
                 router.presented = .player(media: media)

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -46,7 +46,7 @@ private struct LoadedView: View {
             return Template(
                 title: media.title,
                 subtitle: MediaDescription.subtitle(for: media),
-                type: .urn(media.urn, server: serverSetting.server),
+                type: .urn(media.urn),
                 isMonoscopic: media.isMonoscopic
             )
         }
@@ -101,7 +101,7 @@ private struct ContentCell: View {
             ) {
                 let media = Media(
                     title: title,
-                    type: .urn(media.urn, server: serverSetting.server),
+                    type: .urn(media.urn),
                     isMonoscopic: media.isMonoscopic
                 )
                 router.presented = .player(media: media)

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 // Behavior: h-exp, v-exp
 struct ContentListsView: View {
     @AppStorage(UserDefaults.serverSettingKey)
-    private var selectedServerSetting: ServerSetting = .production
+    private var selectedServerSetting: ServerSetting = .ilProduction
 
     var body: some View {
         CustomList {

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -106,7 +106,7 @@ struct ExamplesView: View {
 
     @ViewBuilder
     private func srgSections() -> some View {
-        section(title: "SRG SSR streams (URLs)", medias: model.urlMedias)
+        section(title: "Various streams (URLs)", medias: model.urlMedias)
         section(title: "SRG SSR streams (URNs)", medias: model.urnMedias)
         if !model.protectedMedias.isEmpty {
             section(title: "Protected streams (URNs)", medias: model.protectedMedias)

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -16,7 +16,11 @@ struct Media: Hashable {
     enum `Type`: Hashable {
         case url(URL)
         case unbufferedUrl(URL)
-        case urn(String)
+        case urn(String, serverSetting: ServerSetting)
+
+        static func urn(_ urn: String) -> Self {
+            .urn(urn, serverSetting: .production)
+        }
     }
 
     let title: String
@@ -71,10 +75,10 @@ struct Media: Hashable {
                 preferredForwardBufferDuration: 1
             )
             return playerItem(for: url, configuration: configuration)
-        case let .urn(urn):
+        case let .urn(urn, serverSetting: serverSetting):
             return .urn(
                 urn,
-                server: .production,
+                server: serverSetting.server,
                 trackerAdapters: [
                     DemoTracker.adapter { metadata in
                         DemoTracker.Metadata(title: metadata.mediaComposition.mainChapter.title)

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -19,7 +19,7 @@ struct Media: Hashable {
         case urn(String, serverSetting: ServerSetting)
 
         static func urn(_ urn: String) -> Self {
-            .urn(urn, serverSetting: .production)
+            .urn(urn, serverSetting: .ilProduction)
         }
     }
 

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -16,11 +16,7 @@ struct Media: Hashable {
     enum `Type`: Hashable {
         case url(URL)
         case unbufferedUrl(URL)
-        case urn(String, server: Server)
-
-        static func urn(_ urn: String) -> Self {
-            .urn(urn, server: .production)
-        }
+        case urn(String)
     }
 
     let title: String
@@ -75,10 +71,10 @@ struct Media: Hashable {
                 preferredForwardBufferDuration: 1
             )
             return playerItem(for: url, configuration: configuration)
-        case let .urn(urn, server: server):
+        case let .urn(urn):
             return .urn(
                 urn,
-                server: server,
+                server: .production,
                 trackerAdapters: [
                     DemoTracker.adapter { metadata in
                         DemoTracker.Metadata(title: metadata.mediaComposition.mainChapter.title)

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -17,9 +17,9 @@ enum ServerSetting: Int, CaseIterable {
     case ilStageCH
     case ilTestCH
 
-    case productionWW
-    case stageWW
-    case testWW
+    case ilProductionWW
+    case ilStageWW
+    case ilTestWW
 
     case samProduction
     case samStage
@@ -41,11 +41,11 @@ enum ServerSetting: Int, CaseIterable {
             return "IL Stage - CH"
         case .ilTestCH:
             return "IL Test - CH"
-        case .productionWW:
+        case .ilProductionWW:
             return "IL Production - WW"
-        case .stageWW:
+        case .ilStageWW:
             return "IL Stage - WW"
-        case .testWW:
+        case .ilTestWW:
             return "IL Test - WW"
         case .samProduction:
             return "SAM Production"
@@ -66,11 +66,11 @@ enum ServerSetting: Int, CaseIterable {
 
     private var baseUrl: URL {
         switch self {
-        case .ilProduction, .ilProductionCH, .productionWW:
+        case .ilProduction, .ilProductionCH, .ilProductionWW:
             return SRGIntegrationLayerProductionServiceURL()
-        case .ilStage, .ilStageCH, .stageWW:
+        case .ilStage, .ilStageCH, .ilStageWW:
             return SRGIntegrationLayerStagingServiceURL()
-        case .ilTest, .ilTestCH, .testWW:
+        case .ilTest, .ilTestCH, .ilTestWW:
             return SRGIntegrationLayerTestServiceURL()
         case .samProduction:
             return SRGIntegrationLayerProductionServiceURL().appending(component: "sam")
@@ -94,7 +94,7 @@ enum ServerSetting: Int, CaseIterable {
         switch self {
         case .ilProductionCH, .ilStageCH, .ilTestCH:
             return [URLQueryItem(name: "forceLocation", value: "CH")]
-        case .productionWW, .stageWW, .testWW:
+        case .ilProductionWW, .ilStageWW, .ilTestWW:
             return [URLQueryItem(name: "forceLocation", value: "WW")]
         case .samProduction, .samStage, .samTest:
             return [URLQueryItem(name: "forceSAM", value: "true")]

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -36,17 +36,17 @@ enum ServerSetting: Int, CaseIterable {
         case .test:
             return "Test"
         case .productionCH:
-            return "Production (CH)"
+            return "Production - CH"
         case .stageCH:
-            return "Stage (CH)"
+            return "Stage - CH"
         case .testCH:
-            return "Test (CH)"
+            return "Test - CH"
         case .productionWW:
-            return "Production (WW)"
+            return "Production - WW"
         case .stageWW:
-            return "Stage (WW)"
+            return "Stage - WW"
         case .testWW:
-            return "Test (WW)"
+            return "Test - WW"
         case .samProduction:
             return "SAM Production"
         case .samStage:

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -104,6 +104,6 @@ enum ServerSetting: Int, CaseIterable {
     }
 
     var server: Server {
-        .custom(baseUrl: baseUrl, queryItems: queryItems)
+        .init(baseUrl: baseUrl, queryItems: queryItems)
     }
 }

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -9,13 +9,13 @@ import SRGDataProvider
 
 @objc
 enum ServerSetting: Int, CaseIterable {
-    case production
-    case stage
-    case test
+    case ilProduction
+    case ilStage
+    case ilTest
 
-    case productionCH
-    case stageCH
-    case testCH
+    case ilProductionCH
+    case ilStageCH
+    case ilTestCH
 
     case productionWW
     case stageWW
@@ -29,24 +29,24 @@ enum ServerSetting: Int, CaseIterable {
 
     var title: String {
         switch self {
-        case .production:
-            return "Production"
-        case .stage:
-            return "Stage"
-        case .test:
-            return "Test"
-        case .productionCH:
-            return "Production - CH"
-        case .stageCH:
-            return "Stage - CH"
-        case .testCH:
-            return "Test - CH"
+        case .ilProduction:
+            return "IL Production"
+        case .ilStage:
+            return "IL Stage"
+        case .ilTest:
+            return "IL Test"
+        case .ilProductionCH:
+            return "IL Production - CH"
+        case .ilStageCH:
+            return "IL Stage - CH"
+        case .ilTestCH:
+            return "IL Test - CH"
         case .productionWW:
-            return "Production - WW"
+            return "IL Production - WW"
         case .stageWW:
-            return "Stage - WW"
+            return "IL Stage - WW"
         case .testWW:
-            return "Test - WW"
+            return "IL Test - WW"
         case .samProduction:
             return "SAM Production"
         case .samStage:
@@ -66,11 +66,11 @@ enum ServerSetting: Int, CaseIterable {
 
     private var baseUrl: URL {
         switch self {
-        case .production, .productionCH, .productionWW:
+        case .ilProduction, .ilProductionCH, .productionWW:
             return SRGIntegrationLayerProductionServiceURL()
-        case .stage, .stageCH, .stageWW:
+        case .ilStage, .ilStageCH, .stageWW:
             return SRGIntegrationLayerStagingServiceURL()
-        case .test, .testCH, .testWW:
+        case .ilTest, .ilTestCH, .testWW:
             return SRGIntegrationLayerTestServiceURL()
         case .samProduction:
             return SRGIntegrationLayerProductionServiceURL().appending(component: "sam")
@@ -92,7 +92,7 @@ enum ServerSetting: Int, CaseIterable {
 
     private var queryItems: [URLQueryItem] {
         switch self {
-        case .productionCH, .stageCH, .testCH:
+        case .ilProductionCH, .ilStageCH, .ilTestCH:
             return [URLQueryItem(name: "forceLocation", value: "CH")]
         case .productionWW, .stageWW, .testWW:
             return [URLQueryItem(name: "forceLocation", value: "WW")]

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -12,6 +12,19 @@ enum ServerSetting: Int, CaseIterable {
     case production
     case stage
     case test
+
+    case productionCH
+    case stageCH
+    case testCH
+
+    case productionWW
+    case stageWW
+    case testWW
+
+    case samProduction
+    case samStage
+    case samTest
+
     case mmf
 
     var title: String {
@@ -22,34 +35,75 @@ enum ServerSetting: Int, CaseIterable {
             return "Stage"
         case .test:
             return "Test"
+        case .productionCH:
+            return "Production (CH)"
+        case .stageCH:
+            return "Stage (CH)"
+        case .testCH:
+            return "Test (CH)"
+        case .productionWW:
+            return "Production (WW)"
+        case .stageWW:
+            return "Stage (WW)"
+        case .testWW:
+            return "Test (WW)"
+        case .samProduction:
+            return "SAM Production"
+        case .samStage:
+            return "SAM Stage"
+        case .samTest:
+            return "SAM Test"
         case .mmf:
             return "MMF"
         }
     }
 
-    var url: URL {
+    var dataProvider: SRGDataProvider {
+        let dataProvider = SRGDataProvider(serviceURL: baseUrl)
+        dataProvider.globalParameters = globalParameters
+        return dataProvider
+    }
+
+    private var baseUrl: URL {
         switch self {
-        case .production:
+        case .production, .productionCH, .productionWW:
             return SRGIntegrationLayerProductionServiceURL()
-        case .stage:
+        case .stage, .stageCH, .stageWW:
             return SRGIntegrationLayerStagingServiceURL()
-        case .test:
+        case .test, .testCH, .testWW:
             return SRGIntegrationLayerTestServiceURL()
+        case .samProduction:
+            return SRGIntegrationLayerProductionServiceURL().appending(component: "sam")
+        case .samStage:
+            return SRGIntegrationLayerStagingServiceURL().appending(component: "sam")
+        case .samTest:
+            return SRGIntegrationLayerTestServiceURL().appending(component: "sam")
         case .mmf:
             return URL(string: Bundle.main.infoDictionary?["MMFServiceURL"] as! String)!
         }
     }
 
-    var server: Server {
+    private var globalParameters: [String: String] {
+        .init(uniqueKeysWithValues: queryItems.compactMap { item in
+            guard let value = item.value else { return nil }
+            return (item.name, value)
+        })
+    }
+
+    private var queryItems: [URLQueryItem] {
         switch self {
-        case .production:
-            return .production
-        case .stage:
-            return .stage
-        case .test:
-            return .test
-        case .mmf:
-            return .custom(baseUrl: url)
+        case .productionCH, .stageCH, .testCH:
+            return [URLQueryItem(name: "forceLocation", value: "CH")]
+        case .productionWW, .stageWW, .testWW:
+            return [URLQueryItem(name: "forceLocation", value: "WW")]
+        case .samProduction, .samStage, .samTest:
+            return [URLQueryItem(name: "forceSAM", value: "true")]
+        default:
+            return []
         }
+    }
+
+    var server: Server {
+        .custom(baseUrl: baseUrl, queryItems: queryItems)
     }
 }

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -49,7 +49,7 @@ enum ServerSetting: Int, CaseIterable {
         case .test:
             return .test
         case .mmf:
-            return .mmf
+            return .custom(baseUrl: url)
         }
     }
 }

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -45,7 +45,7 @@ extension UserDefaults {
     }
 
     @objc dynamic var serverSetting: ServerSetting {
-        .init(rawValue: integer(forKey: Self.serverSettingKey)) ?? .production
+        .init(rawValue: integer(forKey: Self.serverSettingKey)) ?? .ilProduction
     }
 
     func registerDefaults() {
@@ -53,7 +53,7 @@ extension UserDefaults {
             Self.presenterModeEnabledKey: false,
             Self.seekBehaviorSettingKey: SeekBehaviorSetting.immediate.rawValue,
             Self.smartNavigationEnabledKey: true,
-            Self.serverSettingKey: ServerSetting.production.rawValue
+            Self.serverSettingKey: ServerSetting.ilProduction.rawValue
         ])
     }
 }

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -9,25 +9,8 @@ import Foundation
 import UIKit
 
 final class DataProvider {
-    enum ImageWidth: Int {
-        case width240 = 240
-        case width320 = 320
-        case width480 = 480
-        case width720 = 720
-        case width960 = 960
-        case width1920 = 1920
-    }
-
-    let server: Server
+    private let server: Server
     private let session: URLSession
-
-    private var vector: String {
-#if os(iOS)
-        return "appplay"
-#else
-        return "tvplay"
-#endif
-    }
 
     init(server: Server = .production) {
         self.server = server
@@ -51,21 +34,11 @@ final class DataProvider {
     }
 
     func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
-        session.dataTaskPublisher(for: mediaCompositionUrl(for: urn))
+        session.dataTaskPublisher(for: server.request(for: urn))
             .mapHttpErrors()
             .map(\.data)
             .decode(type: MediaComposition.self, decoder: Self.decoder())
             .eraseToAnyPublisher()
-    }
-
-    func mediaCompositionUrl(for urn: String) -> URL {
-        let url = server.url.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
-        components.queryItems = [
-            URLQueryItem(name: "onlyChapters", value: "true"),
-            URLQueryItem(name: "vector", value: vector)
-        ]
-        return components.url ?? url
     }
 
     func playableMediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
@@ -79,23 +52,7 @@ final class DataProvider {
             .eraseToAnyPublisher()
     }
 
-    func scaledImageUrl(_ url: URL, width: ImageWidth) -> URL {
-        guard var components = URLComponents(
-            url: server.url.appending(path: "images/"),
-            resolvingAgainstBaseURL: false
-        ) else {
-            return url
-        }
-        components.queryItems = [
-            URLQueryItem(name: "imageUrl", value: url.absoluteString),
-            URLQueryItem(name: "format", value: "jpg"),
-            URLQueryItem(name: "width", value: String(width.rawValue))
-        ]
-        if let scaledUrl = components.url {
-            return scaledUrl
-        }
-        else {
-            return url
-        }
+    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
+        server.resizedImageUrl(url, width: width)
     }
 }

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -34,7 +34,7 @@ final class DataProvider {
     }
 
     func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
-        session.dataTaskPublisher(for: server.request(for: urn))
+        session.dataTaskPublisher(for: server.request(forUrn: urn))
             .mapHttpErrors()
             .map(\.data)
             .decode(type: MediaComposition.self, decoder: Self.decoder())

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -34,7 +34,7 @@ final class DataProvider {
     }
 
     func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaComposition, Error> {
-        session.dataTaskPublisher(for: server.request(forUrn: urn))
+        session.dataTaskPublisher(for: server.mediaCompositionRequest(forUrn: urn))
             .mapHttpErrors()
             .map(\.data)
             .decode(type: MediaComposition.self, decoder: Self.decoder())

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -33,7 +33,7 @@ public struct Server {
         self.requestBuilder = requestBuilder
         self.resizedImageUrlBuilder = resizedImageUrlBuilder
     }
-    
+
     /// Custom environment.
     ///
     /// - Parameters:

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -41,8 +41,8 @@ public struct Server {
     ///     URL and unique identifier (URN).
     ///   - resizedImageUrlBuilder: A closure building a resized URL for an input URL and width.
     ///
-    /// Use custom servers to connect to services which can pose as SRG SSR servers and deliver the same playback
-    /// metadata format (and image scaling capability if possible).
+    /// Useful for servers which can pose as SRG SSR servers and deliver the same playback metadata format (and
+    /// image resizing capabilities if possible).
     public static func custom(
         requestBuilder: @escaping (String) -> URLRequest,
         resizedImageUrlBuilder: @escaping (URL, ImageWidth) -> URL
@@ -52,10 +52,12 @@ public struct Server {
 
     /// Custom environment.
     ///
-    /// - Parameter baseUrl: The base URL of the server.
+    /// - Parameters:
+    ///   - baseUrl: The base URL of the server.
+    ///   - queryItems: Additional query items to use.
     ///
-    /// Use custom servers to connect to services which can exactly pose as SRG SSR servers and deliver the same playback
-    /// metadata format and image scaling. All required services must be implemented for the same base URL.
+    /// Useful for servers which can exactly pose as SRG SSR servers and deliver the same playback metadata format and
+    /// image scaling capabilities.
     public static func custom(baseUrl: URL, queryItems: [URLQueryItem] = []) -> Self {
         .custom { urn in
             standardRequest(forUrn: urn, baseUrl: baseUrl, queryItems: queryItems)

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -60,13 +60,13 @@ public struct Server {
     /// image scaling capabilities.
     public static func custom(baseUrl: URL, queryItems: [URLQueryItem] = []) -> Self {
         .custom { urn in
-            standardRequest(forUrn: urn, baseUrl: baseUrl, queryItems: queryItems)
+            request(forUrn: urn, baseUrl: baseUrl, queryItems: queryItems)
         } resizedImageUrlBuilder: { url, width in
-            standardResizedImageUrl(url, width: width, baseUrl: baseUrl, queryItems: queryItems)
+            resizedImageUrl(url, width: width, baseUrl: baseUrl, queryItems: queryItems)
         }
     }
 
-    private static func standardRequest(forUrn urn: String, baseUrl: URL, queryItems: [URLQueryItem]) -> URLRequest {
+    private static func request(forUrn urn: String, baseUrl: URL, queryItems: [URLQueryItem]) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .init(url: url)
@@ -78,7 +78,7 @@ public struct Server {
         return .init(url: components.url ?? url)
     }
 
-    private static func standardResizedImageUrl(_ url: URL, width: ImageWidth, baseUrl: URL, queryItems: [URLQueryItem]) -> URL {
+    private static func resizedImageUrl(_ url: URL, width: ImageWidth, baseUrl: URL, queryItems: [URLQueryItem]) -> URL {
         guard var components = URLComponents(
             url: baseUrl.appending(path: "images/"),
             resolvingAgainstBaseURL: false

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -15,40 +15,16 @@ public struct Server {
 #endif
 
     /// Production.
-    public static let production = custom(baseUrl: URL(string: "https://il.srgssr.ch")!)
+    public static let production = Self(baseUrl: URL(string: "https://il.srgssr.ch")!)
 
     /// Stage.
-    public static let stage = custom(baseUrl: URL(string: "https://il-stage.srgssr.ch")!)
+    public static let stage = Self(baseUrl: URL(string: "https://il-stage.srgssr.ch")!)
 
     /// Test.
-    public static let test = custom(baseUrl: URL(string: "https://il-test.srgssr.ch")!)
+    public static let test = Self(baseUrl: URL(string: "https://il-test.srgssr.ch")!)
 
-    private let mediaCompositionBuilder: (String) -> URLRequest
-    private let resizedImageUrlBuilder: (URL, ImageWidth) -> URL
-
-    private init(
-        mediaCompositionBuilder: @escaping (String) -> URLRequest,
-        resizedImageUrlBuilder: @escaping (URL, ImageWidth) -> URL
-    ) {
-        self.mediaCompositionBuilder = mediaCompositionBuilder
-        self.resizedImageUrlBuilder = resizedImageUrlBuilder
-    }
-
-    /// Custom environment.
-    ///
-    /// - Parameters:
-    ///   - mediaCompositionBuilder: A closure building a media composition request from a base URL and unique
-    ///     identifier (URN).
-    ///   - resizedImageUrlBuilder: A closure building a resized URL for an input URL and width.
-    ///
-    /// Useful for servers which can pose as SRG SSR servers and deliver the same playback metadata format (and
-    /// image resizing capabilities if possible).
-    public static func custom(
-        mediaCompositionBuilder: @escaping (String) -> URLRequest,
-        resizedImageUrlBuilder: @escaping (URL, ImageWidth) -> URL
-    ) -> Self {
-        .init(mediaCompositionBuilder: mediaCompositionBuilder, resizedImageUrlBuilder: resizedImageUrlBuilder)
-    }
+    private let baseUrl: URL
+    private let queryItems: [URLQueryItem]
 
     /// Custom environment.
     ///
@@ -58,27 +34,24 @@ public struct Server {
     ///
     /// Useful for servers which can exactly pose as SRG SSR servers and deliver the same playback metadata format and
     /// image scaling capabilities.
-    public static func custom(baseUrl: URL, queryItems: [URLQueryItem] = []) -> Self {
-        .custom { urn in
-            request(forUrn: urn, baseUrl: baseUrl, queryItems: queryItems)
-        } resizedImageUrlBuilder: { url, width in
-            resizedImageUrl(url, width: width, baseUrl: baseUrl, queryItems: queryItems)
-        }
+    public init(baseUrl: URL, queryItems: [URLQueryItem] = []) {
+        self.baseUrl = baseUrl
+        self.queryItems = queryItems
     }
 
-    private static func request(forUrn urn: String, baseUrl: URL, queryItems: [URLQueryItem]) -> URLRequest {
+    func request(forUrn urn: String) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .init(url: url)
         }
         components.queryItems = queryItems + [
             URLQueryItem(name: "onlyChapters", value: "true"),
-            URLQueryItem(name: "vector", value: vector)
+            URLQueryItem(name: "vector", value: Self.vector)
         ]
         return .init(url: components.url ?? url)
     }
 
-    private static func resizedImageUrl(_ url: URL, width: ImageWidth, baseUrl: URL, queryItems: [URLQueryItem]) -> URL {
+    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
         guard var components = URLComponents(
             url: baseUrl.appending(path: "images/"),
             resolvingAgainstBaseURL: false
@@ -96,13 +69,5 @@ public struct Server {
         else {
             return url
         }
-    }
-
-    func request(forUrn urn: String) -> URLRequest {
-        mediaCompositionBuilder(urn)
-    }
-
-    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
-        resizedImageUrlBuilder(url, width)
     }
 }

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -23,31 +23,31 @@ public struct Server {
     /// Test.
     public static let test = custom(baseUrl: URL(string: "https://il-test.srgssr.ch")!)
 
-    private let requestBuilder: (String) -> URLRequest
+    private let mediaCompositionBuilder: (String) -> URLRequest
     private let resizedImageUrlBuilder: (URL, ImageWidth) -> URL
 
     private init(
-        requestBuilder: @escaping (String) -> URLRequest,
+        mediaCompositionBuilder: @escaping (String) -> URLRequest,
         resizedImageUrlBuilder: @escaping (URL, ImageWidth) -> URL
     ) {
-        self.requestBuilder = requestBuilder
+        self.mediaCompositionBuilder = mediaCompositionBuilder
         self.resizedImageUrlBuilder = resizedImageUrlBuilder
     }
 
     /// Custom environment.
     ///
     /// - Parameters:
-    ///   - requestBuilder: A closure building a playback metadata (media composition) request from a base
-    ///     URL and unique identifier (URN).
+    ///   - mediaCompositionBuilder: A closure building a media composition request from a base URL and unique
+    ///     identifier (URN).
     ///   - resizedImageUrlBuilder: A closure building a resized URL for an input URL and width.
     ///
     /// Useful for servers which can pose as SRG SSR servers and deliver the same playback metadata format (and
     /// image resizing capabilities if possible).
     public static func custom(
-        requestBuilder: @escaping (String) -> URLRequest,
+        mediaCompositionBuilder: @escaping (String) -> URLRequest,
         resizedImageUrlBuilder: @escaping (URL, ImageWidth) -> URL
     ) -> Self {
-        .init(requestBuilder: requestBuilder, resizedImageUrlBuilder: resizedImageUrlBuilder)
+        .init(mediaCompositionBuilder: mediaCompositionBuilder, resizedImageUrlBuilder: resizedImageUrlBuilder)
     }
 
     /// Custom environment.
@@ -99,7 +99,7 @@ public struct Server {
     }
 
     func request(forUrn urn: String) -> URLRequest {
-        requestBuilder(urn)
+        mediaCompositionBuilder(urn)
     }
 
     func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -26,11 +26,11 @@ public struct Server {
     private let baseUrl: URL
     private let queryItems: [URLQueryItem]
 
-    /// Custom environment.
+    /// Creates a server with custom settings.
     ///
     /// - Parameters:
     ///   - baseUrl: The base URL of the server.
-    ///   - queryItems: Additional query items to use.
+    ///   - queryItems: Additional query items to associate with each request.
     ///
     /// Useful for servers which can exactly pose as SRG SSR servers and deliver the same playback metadata format and
     /// image scaling capabilities.
@@ -39,7 +39,7 @@ public struct Server {
         self.queryItems = queryItems
     }
 
-    func request(forUrn urn: String) -> URLRequest {
+    func mediaCompositionRequest(forUrn urn: String) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .init(url: url)

--- a/Sources/CoreBusiness/Model/ImageWidth.swift
+++ b/Sources/CoreBusiness/Model/ImageWidth.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+public enum ImageWidth: Int {
+    case width240 = 240
+    case width320 = 320
+    case width480 = 480
+    case width720 = 720
+    case width960 = 960
+    case width1920 = 1920
+}

--- a/Sources/CoreBusiness/Model/ImageWidth.swift
+++ b/Sources/CoreBusiness/Model/ImageWidth.swift
@@ -6,11 +6,23 @@
 
 import Foundation
 
+/// An width supported for image resizing.
 public enum ImageWidth: Int {
+    // 240 pixels.
     case width240 = 240
+
+    // 320 pixels.
     case width320 = 320
+
+    // 480 pixels.
     case width480 = 480
+
+    // 720 pixels.
     case width720 = 720
+
+    // 960 pixels.
     case width960 = 960
+
+    // 1920 pixels.
     case width1920 = 1920
 }

--- a/Sources/CoreBusiness/Model/ImageWidth.swift
+++ b/Sources/CoreBusiness/Model/ImageWidth.swift
@@ -6,23 +6,11 @@
 
 import Foundation
 
-/// An width supported for image resizing.
-public enum ImageWidth: Int {
-    // 240 pixels.
+enum ImageWidth: Int {
     case width240 = 240
-
-    // 320 pixels.
     case width320 = 320
-
-    // 480 pixels.
     case width480 = 480
-
-    // 720 pixels.
     case width720 = 720
-
-    // 960 pixels.
     case width960 = 960
-
-    // 1920 pixels.
     case width1920 = 1920
 }

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -150,6 +150,6 @@ extension MediaMetadata: AssetMetadata {
     }
 
     private func imageUrl(for chapter: MediaComposition.Chapter) -> URL {
-        dataProvider.scaledImageUrl(chapter.imageUrl, width: .width720)
+        dataProvider.resizedImageUrl(chapter.imageUrl, width: .width720)
     }
 }


### PR DESCRIPTION
# Description

This PR improves server support in Core Business. It also enhances server selection in the demo to support SAM as well as simulated locations in CH or abroad.

# Changes made

- Make it possible to use any server conforming to the media composition data format and image resizing. 
- Remove `.mmf` from Core Business server list (development tool). This is a breaking API change.
- Add support for SAM (prod, stage, test).
- Add support for simulated CH and WW locations for IL services (helpful to test geoblocking behavior).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
