### PR TITLE
Add basic keyboard shortcut support

### DIFF
--- a/Demo/Sources/Model/Template.swift
+++ b/Demo/Sources/Model/Template.swift
@@ -143,7 +143,7 @@ enum URLTemplate {
         title: "Brain Farm Skate Phantom Flex",
         subtitle: "4K video",
         imageUrl: "https://i.ytimg.com/vi/d4_96ZWu3Vk/maxresdefault.jpg",
-        type: .url("http://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8")
+        type: .url("https://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8")
     )
     static let onDemandVideoLocalHLS = Template(
         title: "Test video pattern",

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -677,7 +677,9 @@ private struct PlaybackButton: View {
                 Color.clear
             }
         }
+#if os(iOS)
         .keyboardShortcut(.space, modifiers: [])
+#endif
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -345,7 +345,7 @@ private struct SkipBackwardButton: View {
         .frame(height: 45)
         .opacity(player.canSkipBackward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipBackward())
-        .keyboardShortcut(.leftArrow, modifiers: [])
+        .keyboardShortcut("s", modifiers: [])
     }
 
     private func skipBackward() {
@@ -368,7 +368,7 @@ private struct SkipForwardButton: View {
         .frame(height: 45)
         .opacity(player.canSkipForward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipForward())
-        .keyboardShortcut(.rightArrow, modifiers: [])
+        .keyboardShortcut("d", modifiers: [])
     }
 
     private func skipForward() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -387,6 +387,7 @@ private struct FullScreenButton: View {
                     .tint(.white)
                     .font(.system(size: 20))
             }
+            .keyboardShortcut("f", modifiers: [])
         }
     }
 

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -424,6 +424,7 @@ private struct VolumeButton: View {
                 .tint(.white)
                 .font(.system(size: 20))
         }
+        .keyboardShortcut("m", modifiers: [])
     }
 
     private var imageName: String {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -673,6 +673,7 @@ private struct PlaybackButton: View {
                 Color.clear
             }
         }
+        .keyboardShortcut(.space, modifiers: [])
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -345,6 +345,7 @@ private struct SkipBackwardButton: View {
         .frame(height: 45)
         .opacity(player.canSkipBackward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipBackward())
+        .keyboardShortcut(.leftArrow, modifiers: [])
     }
 
     private func skipBackward() {
@@ -367,6 +368,7 @@ private struct SkipForwardButton: View {
         .frame(height: 45)
         .opacity(player.canSkipForward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipForward())
+        .keyboardShortcut(.rightArrow, modifiers: [])
     }
 
     private func skipForward() {

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -16,5 +16,6 @@ struct CloseButton: View {
                 .font(.system(size: 20))
         }
         .shadow(color: .black, radius: 1)
+        .keyboardShortcut(.escape, modifiers: [])
     }
 }

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -16,6 +16,8 @@ struct CloseButton: View {
                 .font(.system(size: 20))
         }
         .shadow(color: .black, radius: 1)
+#if os(iOS)
         .keyboardShortcut(.escape, modifiers: [])
+#endif
     }
 }

--- a/Demo/Sources/Views/PiPButton.swift
+++ b/Demo/Sources/Views/PiPButton.swift
@@ -14,6 +14,8 @@ struct PiPButton: View {
                 .tint(.white)
                 .font(.system(size: 20))
         }
+#if os(iOS)
         .keyboardShortcut("p", modifiers: [])
+#endif
     }
 }

--- a/Demo/Sources/Views/PiPButton.swift
+++ b/Demo/Sources/Views/PiPButton.swift
@@ -14,5 +14,6 @@ struct PiPButton: View {
                 .tint(.white)
                 .font(.system(size: 20))
         }
+        .keyboardShortcut("p", modifiers: [])
     }
 }


### PR DESCRIPTION
# Description

This PR introduces a few obvious keyboard shortcuts which make the user experience better on iPad or macOS (as iPad app):

- Space to toggle play / pause.
- `S` and `D` to for skips.
- `F` to toggle full screen.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
