### PR TITLE
Add useful testing information for stream encoding and packaging teams

### DIFF
--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice.md
@@ -1,16 +1,18 @@
-# Stream packaging advice
+# Stream Encoding and Packaging Advice
 
 @Metadata {
     @PageColor(purple)
 }
 
-Package streams for optimal compatibility with the PillarboxPlayer framework.
+Encode and package streams for optimal compatibility with the PillarboxPlayer framework.
 
 ## Overview
 
-The optimal playback experience which can be obtained with the PillarboxPlayer framework requires streams to be packaged accordingly. This most notably affects the ability of the player to automatically apply default media selections as well as the quality of its scrubbing user experience.
+Apple provides HLS [authoring specifications](https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices/) regarding encoding and packaging best practices for compatibility with Apple devices. These  specifications cover compatible codecs, encoding profiles or recommended encoding ladders, among many other topics.
 
-More information about automatic selection is available from <doc:subtitles-and-alternative-audio-tracks>.
+For optimal playback experience with the PillarboxPlayer framework some of these specifications need to be followed rigorously. This article covers these specific requirements in more detail and provides more information about how streams can be tested for compatibility with PillarboxPlayer.
+
+> Note: More information about automatic media selection is available from <doc:subtitles-and-alternative-audio-tracks>.
 
 ### Automatic media option selection
 
@@ -46,6 +48,8 @@ If you think audible or legible renditions are incorrectly handled for some cont
     - The user accessibility settings (AD and SDH / CC preferences). Enable or disable these settings according to your needs.
 3. Whether your code overrides rendition selection with ``Player/setMediaSelection(preferredLanguages:for:)``.
 
+> Tip: Check the _Inspecting and testing streams_ section below for tools that can make troubleshooting easier.
+
 ### Trick mode / Trick play
 
 ``Player`` supports [trick mode](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Trick-Play) (aka trick play) which requires dedicated I-frame playlists to be delivered in video master playlists to provide for a [faster scrubbing experience](https://en.wikipedia.org/wiki/Trick_mode).
@@ -54,7 +58,49 @@ The player still attempts to offer a good scrubbing experience when I-frame play
 
 Note that I-frame playlists are a [must-have](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Trick-Play) for tvOS since they are the only way to provide previews during scrubbing.
 
-### Links
+### Inspecting and testing streams
+
+Several tools are available for stream encoding and packaging teams to check that the streams they deliver work well with PillarboxPlayer.
+
+#### HTTP Live Streaming Tools
+
+Apple provides a series of command-line tools, available for macOS and CentOS Linux, on its [developer portal](https://developer.apple.com/download/all/) (a developer account is required).
+
+These most notably contain the `mediastreamvalidator` command which which HLS streams can be validated. Please refer to the associated documentation for more information.
+
+#### Inspection tools
+
+The following commands can be useful to inspect streams:
+
+- ffprobe, which is part of [ffmpeg](https://ffmpeg.org/ffprobe.html).
+- [MediaInfo](https://mediaarea.net/en/MediaInfo), which provides a GUI as well as a command-line tool.
+
+#### Proxy applications
+
+Network activity associated with HLS streaming can be inspected with proxy tools like [Charles](https://www.charlesproxy.com) or [Proxyman](https://proxyman.io). Please refer to their respective documentation for more information.
+
+#### Official Apple players
+
+HLS streams can always be tested with a variety of native players, most notably:
+
+- Safari on macOS.
+- Safari on iOS / iPadOS.
+- QuickTime Player on macOS.
+
+> Important: Streams that cannot be correctly played with Apple official players will almost certainly fail to play correctly with PillarboxPlayer.
+
+#### 3rd party players
+
+HLS streams can be tested with 3rd party players, mostly on the web. These include:
+
+- hls.js, which provides an [official online playground](https://hlsjs.video-dev.org/demo).
+- [Video.js](https://videojs.com/), for which [official](https://videojs-http-streaming.netlify.app) and [non-official](https://amtins.github.io/cassettator-forbidden-adventures/) online playgrounds are available.
+
+#### Pillarbox demo
+
+Any URL, including SRG SSR URLs protected with DRM or a token, can be played directly with Pillarbox demo. You can install the iOS and tvOS demo applications by registering [with TestFlight](https://testflight.apple.com/join/TS6ngLqf) (an Apple ID is required).
+
+### Technical documentation
 
 Please refer to the official documentation for more information:
 

--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice.md
@@ -73,6 +73,7 @@ These most notably contain the `mediastreamvalidator` command which which HLS st
 The following commands can be useful to inspect streams:
 
 - ffprobe, which is part of [ffmpeg](https://ffmpeg.org/ffprobe.html).
+- [TSDuck](https://tsduck.io/)
 - [MediaInfo](https://mediaarea.net/en/MediaInfo), which provides a GUI as well as a command-line tool.
 
 #### Proxy applications

--- a/Sources/Player/Player.docc/PillarboxPlayer.md
+++ b/Sources/Player/Player.docc/PillarboxPlayer.md
@@ -109,4 +109,4 @@ The PillarboxPlayer framework fully integrates with SwiftUI, embracing its decla
 
 ### Technical Notes
 
-- <doc:stream-packaging-advice>
+- <doc:stream-encoding-and-packaging-advice>


### PR DESCRIPTION
# Description

This PR documents tools available for inspecting and testing streams. This should help stream encoding and packaging teams be more autonomous in testing streams before they deliver them to our Pillarbox players.

# Changes made

- Enhance stream packaging documentation (extend it to encoding as well).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
