### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,17 @@ name: 🐞 Bug report
 description: File a bug report
 labels: ["bug", "triage"]
 body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: >
+        Please search to see if an
+        [issue](https://github.com/SRGSSR/pillarbox-apple/issues?q=is%3Aissue)
+        already exists for the bug you encountered.
+      options:
+        - label: >
+            I have searched existing issues and found no similar bug report.
+          required: true
   - type: textarea
     id: description
     attributes:
@@ -54,14 +65,3 @@ body:
     attributes:
       label: Code sample
       description: Attach a code sample reproducing the issue if possible.
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: >
-        Please search to see if an
-        [issue](https://github.com/SRGSSR/pillarbox-apple/issues?q=is%3Aissue)
-        already exists for the bug you encountered.
-      options:
-        - label: >
-            I have searched existing issues and found no similar bug report.
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,6 +3,19 @@ name: 💡 Feature request
 description: Request a feature or submit an idea you have.
 labels: ["enhancement", "triage"]
 body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing similar feature request?
+      options:
+        - label: >
+            I have searched existing
+            [features](https://github.com/SRGSSR/pillarbox-apple/issues?q=is%3Aissue+label%3Aenhancement+)
+            and found no similar request.
+          required: true
+        - label: >
+            I have browsed the available API and found no way to achieve
+            the use case I described.
+          required: true
   - type: textarea
     id: use_case
     attributes:
@@ -28,16 +41,3 @@ body:
       label: Alternatives considered
       description: >
         Describe any alternative solutions you might consider applicable.
-  - type: checkboxes
-    attributes:
-      label: Is there an existing similar feature request?
-      options:
-        - label: >
-            I have searched existing
-            [features](https://github.com/SRGSSR/pillarbox-apple/issues?q=is%3Aissue+label%3Aenhancement+)
-            and found no similar request.
-          required: true
-        - label: >
-            I have browsed the available API and found no way to achieve
-            the use case I described.
-          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -3,13 +3,6 @@ name: 💭 Question
 description: Ask us for guidance or help.
 labels: ["question", "triage"]
 body:
-  - type: textarea
-    id: description
-    attributes:
-      label: Detailed question
-      description: Please develop your question in further detail.
-    validations:
-      required: true
   - type: checkboxes
     attributes:
       label: Can your answer be found elsewhere?
@@ -23,3 +16,10 @@ body:
             I have browsed the available documentation and found no answer
             to my question.
           required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed question
+      description: Please develop your question in further detail.
+    validations:
+      required: true


### PR DESCRIPTION
# Description

This PR updates issue templates, moving check for duplicates to the top. This avoids people entering all information about an issue before performing this check, possibly wasting time if they find a duplicate at the very end of the process.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
