### PR TITLE
Use built-in player metadata image retrieval

### DIFF
--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -98,27 +98,22 @@ struct Media: Hashable {
 
 extension Media {
     private func simplePlayerItem(for url: URL, configuration: PlayerItemConfiguration) -> PlayerItem {
-        .init(
-            publisher: imagePublisher()
-                .map { image in
-                    .simple(
-                        url: url,
-                        metadata: Media(title: title, subtitle: subtitle, image: image, type: type, timeRanges: timeRanges),
-                        configuration: configuration
-                    )
-                },
+        .simple(
+            url: url,
+            metadata: Media(title: title, subtitle: subtitle, imageUrl: imageUrl, image: image, type: type, timeRanges: timeRanges),
             trackerAdapters: [
                 DemoTracker.adapter { metadata in
                     DemoTracker.Metadata(title: metadata.title)
                 }
-            ]
+            ],
+            configuration: configuration
         )
     }
 
     private func tokenProtectedPlayerItem(for url: URL, configuration: PlayerItemConfiguration) -> PlayerItem {
         .tokenProtected(
             url: url,
-            metadata: Media(title: title, subtitle: subtitle, image: image, type: type, timeRanges: timeRanges),
+            metadata: Media(title: title, subtitle: subtitle, imageUrl: imageUrl, image: image, type: type, timeRanges: timeRanges),
             configuration: configuration
         )
     }
@@ -127,18 +122,9 @@ extension Media {
         .encrypted(
             url: url,
             certificateUrl: certificateUrl,
-            metadata: Media(title: title, subtitle: subtitle, image: image, type: type, timeRanges: timeRanges),
+            metadata: Media(title: title, subtitle: subtitle, imageUrl: imageUrl, image: image, type: type, timeRanges: timeRanges),
             configuration: configuration
         )
-    }
-
-    private func imagePublisher() -> AnyPublisher<UIImage?, Never> {
-        guard let imageUrl else { return Just(nil).eraseToAnyPublisher() }
-        return URLSession.shared.dataTaskPublisher(for: imageUrl)
-            .map(\.data)
-            .map { UIImage(data: $0) }
-            .replaceError(with: nil)
-            .eraseToAnyPublisher()
     }
 }
 
@@ -148,7 +134,14 @@ extension Media: AssetMetadata {
     }
 
     private var imageSource: ImageSource {
-        guard let image else { return .none }
-        return .image(image)
+        if let image {
+            return .image(image)
+        }
+        else if let imageUrl {
+            return .url(imageUrl)
+        }
+        else {
+            return .none
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR removes manual image retrieval to rely on built-in image retrieval provided by Pillarbox player.

# Changes made

Self-explanatory. We also thought we could update `PlayerItem` to remove publisher-based initial delivery, removing the need for main-thread dispatching in case the asset is known, but this is not a good idea:

- This duplicates code.
- This removes lazy loading asset loading.
- We still need to have publishers for asset updates following image delivery.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).