### PR TITLE
Improve behavior for streams providing no metrics

### DIFF
--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -118,8 +118,6 @@ private struct StartupTimesSectionContent: View {
 }
 
 struct MetricsView: View {
-    private static let limit = 90
-
     @ObservedObject var metricsCollector: MetricsCollector
 
     var body: some View {
@@ -144,17 +142,9 @@ struct MetricsView: View {
         metricsCollector.metrics
     }
 
-    private var metricEvents: [MetricEvent] {
-        metricsCollector.metricEvents
-    }
-
-    private var currentMetrics: Metrics? {
-        metrics.last
-    }
-
     private func startupTimesSection() -> some View {
         Section {
-            StartupTimesSectionContent(metricEvents: metricEvents)
+            StartupTimesSectionContent(metricEvents: metricsCollector.metricEvents)
         } header: {
             Text("Startup times")
         }
@@ -175,7 +165,7 @@ struct MetricsView: View {
     private func indicatedBitrateSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                IndicatedBitrateChart(metrics: metrics, limit: Self.limit)
+                IndicatedBitrateChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Indicated bitrate")
             }
@@ -186,7 +176,7 @@ struct MetricsView: View {
     private func observedBitrateSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                ObservedBitrateChart(metrics: metrics, limit: Self.limit)
+                ObservedBitrateChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Observed bitrate")
             }
@@ -197,7 +187,7 @@ struct MetricsView: View {
     private func dataVolumeSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                DataVolumeChart(metrics: metrics, limit: Self.limit)
+                DataVolumeChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Data volume")
             }
@@ -208,7 +198,7 @@ struct MetricsView: View {
     private func mediaRequestsSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                MediaRequestChart(metrics: metrics, limit: Self.limit)
+                MediaRequestChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Media requests")
             }
@@ -219,7 +209,7 @@ struct MetricsView: View {
     private func stallsSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                StallsChart(metrics: metrics, limit: Self.limit)
+                StallsChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Stalls")
             }
@@ -230,7 +220,7 @@ struct MetricsView: View {
     private func frameDropsSection() -> some View {
         if !metrics.isEmpty {
             Section {
-                FrameDropsChart(metrics: metrics, limit: Self.limit)
+                FrameDropsChart(metrics: metrics, limit: metricsCollector.limit)
             } header: {
                 Text("Frame drops")
             }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -21,7 +21,7 @@ private struct MainView: View {
     let progressTracker: ProgressTracker
 
     @StateObject private var visibilityTracker = VisibilityTracker()
-    @State private var metricsCollector = MetricsCollector(interval: .init(value: 1, timescale: 1))
+    @State private var metricsCollector = MetricsCollector(interval: .init(value: 1, timescale: 1), limit: 90)
 
     @State private var layoutInfo: LayoutInfo = .none
     @State private var isPresentingMetrics = false

--- a/Sources/Player/Metrics/MetricsCollector.swift
+++ b/Sources/Player/Metrics/MetricsCollector.swift
@@ -49,19 +49,14 @@ public final class MetricsCollector: ObservableObject {
     private func configureMetricsPublisher(interval: CMTime) {
         $player
             .removeDuplicates()
-            .map { player -> AnyPublisher<Metrics?, Never> in
+            .map { player -> AnyPublisher<[Metrics], Never> in
                 guard let player else {
-                    return Just(nil).eraseToAnyPublisher()
+                    return Just([]).eraseToAnyPublisher()
                 }
                 return player.periodicMetricsPublisher(forInterval: interval)
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
-            .removeDuplicates()
-            .scan([]) { initial, next in
-                guard let next else { return [] }
-                return initial + [next]
-            }
             .receiveOnMainThread()
             .assign(to: &$metrics)
     }

--- a/Sources/Player/Metrics/MetricsCollector.swift
+++ b/Sources/Player/Metrics/MetricsCollector.swift
@@ -22,6 +22,9 @@ import SwiftUI
 /// 3. Current metrics can be retrieved from the ``metrics`` property and displayed in any way you want, e.g. in a
 ///    textual form or with charts.
 public final class MetricsCollector: ObservableObject {
+    /// The maximum number of metrics to keep in the history.
+    public let limit: Int
+
     /// The player to attach.
     ///
     /// Use `View.bind(_:to:)` in SwiftUI code.
@@ -37,11 +40,15 @@ public final class MetricsCollector: ObservableObject {
 
     /// Creates a metrics collector gathering metrics at the specified interval.
     ///
-    /// - Parameter interval: The interval at which metrics must be gathered, according to progress of the current
-    ///   time of the associated player timebase.
+    /// - Parameters:
+    ///   - interval: The interval at which metrics must be gathered, according to progress of the current
+    ///     time of the associated player timebase.
+    ///   - limit: The maximum number of metrics to keep in the history.
     ///
     /// Additional metrics will be collected when time jumps or when playback starts or stops.
-    public init(interval: CMTime) {
+    public init(interval: CMTime, limit: Int = .max) {
+        self.limit = limit
+
         configureMetricsPublisher(interval: interval)
         configureMetricEventsPublisher()
     }
@@ -49,11 +56,11 @@ public final class MetricsCollector: ObservableObject {
     private func configureMetricsPublisher(interval: CMTime) {
         $player
             .removeDuplicates()
-            .map { player -> AnyPublisher<[Metrics], Never> in
+            .map { [limit] player -> AnyPublisher<[Metrics], Never> in
                 guard let player else {
                     return Just([]).eraseToAnyPublisher()
                 }
-                return player.periodicMetricsPublisher(forInterval: interval)
+                return player.periodicMetricsPublisher(forInterval: interval, limit: limit)
                     .eraseToAnyPublisher()
             }
             .switchToLatest()

--- a/Sources/Player/Metrics/MetricsState.swift
+++ b/Sources/Player/Metrics/MetricsState.swift
@@ -17,8 +17,12 @@ struct MetricsState: Equatable {
         .init(time: time, event: events.last, total: events.reduce(.zero) { $0 + .values(from: $1) })
     }
 
+    func updated(with events: [AVPlayerItemAccessLogEvent], at time: CMTime) -> Self {
+        updated(with: events.map { .init($0) }, at: time)
+    }
+
     func updated(with log: AVPlayerItemAccessLog?, at time: CMTime) -> Self {
-        updated(with: log?.events.map { .init($0) } ?? [], at: time)
+        updated(with: log?.events ?? [], at: time)
     }
 
     func metrics(from state: Self) -> Metrics {

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -17,7 +17,7 @@ public extension Player {
     ///   - interval: The interval at which the history should be updated, according to progress of the current time of
     ///     the timebase.
     ///   - queue: The queue on which values are published.
-    ///   - limit: The maximum number of items to keep in the history.
+    ///   - limit: The maximum number of metrics to keep in the history.
     /// - Returns: The publisher.
     ///
     /// Additional non-periodic updates will be published when time jumps or when playback starts or stops. Each

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -11,26 +11,27 @@ import PillarboxCore
 private let kMetricsQueue = DispatchQueue(label: "ch.srgssr.player.metrics")
 
 public extension Player {
-    /// Returns a publisher periodically emitting metrics when the player is playing content.
+    /// Returns a periodically updated metrics history associated to the current item.
     ///
     /// - Parameters:
     ///   - interval: The interval at which events must be emitted, according to progress of the current time of the timebase.
     ///   - queue: The queue on which values are published.
     /// - Returns: The publisher.
     ///
-    /// Additional non-periodic updates will be published when time jumps or when playback starts or stops. The
+    /// Additional non-periodic updates will be published when time jumps or when playback starts or stops. Each
     /// included ``Metrics/increment`` collates data since the previous periodic update.
-    func periodicMetricsPublisher(forInterval interval: CMTime, queue: DispatchQueue = .main) -> AnyPublisher<Metrics?, Never> {
+    func periodicMetricsPublisher(forInterval interval: CMTime, queue: DispatchQueue = .main) -> AnyPublisher<[Metrics], Never> {
         currentPlayerItemPublisher()
-            .map { [queuePlayer] item -> AnyPublisher<Metrics?, Never> in
-                guard let item else { return Just(nil).eraseToAnyPublisher() }
+            .map { [queuePlayer] item -> AnyPublisher<[Metrics], Never> in
+                guard let item else { return Just([]).eraseToAnyPublisher() }
                 return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
                     .scan(MetricsState.empty) { state, time in
                         state.updated(with: item.accessLog(), at: time)
                     }
-                    .removeDuplicates()
                     .withPrevious(MetricsState.empty)
                     .map { $0.current.metrics(from: $0.previous) }
+                    .scan([]) { $0 + [$1] }
+                    .prepend([])
                     .eraseToAnyPublisher()
             }
             .switchToLatest()

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -14,19 +14,23 @@ public extension Player {
     /// Returns a periodically updated metrics history associated to the current item.
     ///
     /// - Parameters:
-    ///   - interval: The interval at which events must be emitted, according to progress of the current time of the timebase.
+    ///   - interval: The interval at which the history should be updated, according to progress of the current time of
+    ///     the timebase.
     ///   - queue: The queue on which values are published.
     /// - Returns: The publisher.
     ///
     /// Additional non-periodic updates will be published when time jumps or when playback starts or stops. Each
-    /// included ``Metrics/increment`` collates data since the previous periodic update.
+    /// included ``Metrics/increment`` collates data since the entry that precedes it in the history. No updates are
+    /// published if no metrics are provided for the item being played.
     func periodicMetricsPublisher(forInterval interval: CMTime, queue: DispatchQueue = .main) -> AnyPublisher<[Metrics], Never> {
         currentPlayerItemPublisher()
             .map { [queuePlayer] item -> AnyPublisher<[Metrics], Never> in
                 guard let item else { return Just([]).eraseToAnyPublisher() }
                 return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
-                    .scan(MetricsState.empty) { state, time in
-                        state.updated(with: item.accessLog(), at: time)
+                    .compactMap { _ in item.accessLog()?.events }
+                    .filter { !$0.isEmpty }
+                    .scan(MetricsState.empty) { state, events in
+                        state.updated(with: events, at: item.currentTime())
                     }
                     .withPrevious(MetricsState.empty)
                     .map { $0.current.metrics(from: $0.previous) }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -92,9 +92,10 @@ public final class Player: ObservableObject, Equatable {
         .eraseToAnyPublisher()
     }()
 
-    /// A shared publisher delivering metric events
+    /// A shared publisher delivering metric events associated to the current item.
     ///
     /// All metric events related to the item currently being played, if any, are received upon subscription.
+    /// Events are ordered from the oldest to the newest one.
     public lazy var metricEventsPublisher: AnyPublisher<[MetricEvent], Never> = {
         currentItemPublisher()
             .map { item -> AnyPublisher<[MetricEvent], Never> in

--- a/Sources/Streams/Stream.swift
+++ b/Sources/Streams/Stream.swift
@@ -107,6 +107,12 @@ public extension Stream {
         url: URL(string: "http://localhost:8123/unavailable.mp3")!,
         duration: .indefinite
     )
+
+    /// A MP3 live stream.
+    static let liveMp3: Self = .init(
+        url: URL(string: "http://stream.srg-ssr.ch/m/couleur3/mp3_128")!,
+        duration: .indefinite
+    )
 }
 
 public extension Stream {

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -14,8 +14,8 @@ final class PeriodicMetricsPublisherTests: TestCase {
     func testEmpty() {
         let player = Player()
             expectEqualPublished(
-                values: [nil],
-                from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)),
+                values: [0],
+                from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count),
                 during: .seconds(1)
             )
     }
@@ -24,24 +24,23 @@ final class PeriodicMetricsPublisherTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expectAtLeastEqualPublished(
-            values: [nil, Stream.onDemand.url.absoluteString],
-            from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4))
-                .map(\.?.uri)
+            values: [0, 1, 2],
+            from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count)
         ) {
             player.play()
         }
     }
 
     func testPlaylist() {
-        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.onDemand.url)
         let item2 = PlayerItem.simple(url: Stream.mediumOnDemand.url)
         let player = Player(items: [item1, item2])
-        expectAtLeastEqualPublished(
-            values: [nil, Stream.shortOnDemand.url.absoluteString, Stream.mediumOnDemand.url.absoluteString],
-            from: player.periodicMetricsPublisher(forInterval: .init(value: 2, timescale: 1))
-                .map(\.?.uri)
-        ) {
+        let publisher = player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count)
+        expectAtLeastEqualPublished(values: [0, 1], from: publisher) {
             player.play()
+        }
+        expectAtLeastEqualPublished(values: [0, 1, 2], from: publisher) {
+            player.advanceToNextItem()
         }
     }
 }

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -32,15 +32,12 @@ final class PeriodicMetricsPublisherTests: TestCase {
     }
 
     func testPlaylist() {
-        let item1 = PlayerItem.simple(url: Stream.onDemand.url)
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.mediumOnDemand.url)
         let player = Player(items: [item1, item2])
-        let publisher = player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count)
-        expectAtLeastEqualPublished(values: [0, 1], from: publisher) {
+        let publisher = player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 1)).map(\.count)
+        expectAtLeastEqualPublished(values: [0, 1, 0, 1], from: publisher) {
             player.play()
-        }
-        expectAtLeastEqualPublished(values: [0, 1, 2], from: publisher) {
-            player.advanceToNextItem()
         }
     }
 

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -31,4 +31,17 @@ final class PeriodicMetricsPublisherTests: TestCase {
             player.play()
         }
     }
+
+    func testPlaylist() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.mediumOnDemand.url)
+        let player = Player(items: [item1, item2])
+        expectAtLeastEqualPublished(
+            values: [nil, Stream.shortOnDemand.url.absoluteString, Stream.mediumOnDemand.url.absoluteString],
+            from: player.periodicMetricsPublisher(forInterval: .init(value: 2, timescale: 1))
+                .map(\.?.uri)
+        ) {
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -43,4 +43,12 @@ final class PeriodicMetricsPublisherTests: TestCase {
             player.advanceToNextItem()
         }
     }
+
+    func testNoMetricsForLiveMp3() {
+        let player = Player(item: .simple(url: Stream.liveMp3.url))
+        let publisher = player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count)
+        expectEqualPublished(values: [0], from: publisher, during: .milliseconds(500)) {
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -48,4 +48,15 @@ final class PeriodicMetricsPublisherTests: TestCase {
             player.play()
         }
     }
+
+    func testLimit() {
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(item: item)
+        expectAtLeastEqualPublished(
+            values: [0, 1, 2, 2, 2, 2],
+            from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4), limit: 2).map(\.count)
+        ) {
+            player.play()
+        }
+    }
 }


### PR DESCRIPTION
# Description

This PR improves support for streams that do not deliver any metrics in the access log, like MP3 livestreams for example.

# Changes made

- Revisit metrics publisher API contract to deliver metrics history updates associated with the current item.
- Accumulate metrics in the collector (a limit can now also be set).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
