### PR TITLE
Document PillarboxPlayer APIs as supported on the main thread only

### DIFF
--- a/Sources/Player/Player.docc/PillarboxPlayer.md
+++ b/Sources/Player/Player.docc/PillarboxPlayer.md
@@ -8,6 +8,8 @@ Create engaging audio and video playback experiences.
 
 ## Overview
 
+> Warning: PillarboxPlayer APIs are currently meant to be used from the main thread only. Calling APIs from background threads is not supported and leads to undefined behavior.
+
 The PillarboxPlayer framework provides a complete toolbox to add advanced audiovisual media capabilities to your app.
 
 Play content easily with a ``Player`` and display its content in the standard AVKit user interface with ``SystemVideoView``, or build an entirely custom user interface starting from a simple ``VideoView``. Play any kind of content from any source by implementing your own ``PlayerItem``s and ``Asset``s, no matter where your content comes from or how it must be played. Track playback with your own ``PlayerItemTracker``, whether for analytics purposes or Quality of Service (QoS) data collection.

--- a/Sources/Player/Tracking/CurrentTracker.swift
+++ b/Sources/Player/Tracking/CurrentTracker.swift
@@ -19,12 +19,14 @@ final class CurrentTracker {
         item.enableTrackers(for: player)
 
         player.propertiesPublisher
+            .receiveOnMainThread()
             .sink { properties in
                 item.updateTrackerProperties(properties)
             }
             .store(in: &cancellables)
 
         item.metricLog.eventPublisher()
+            .receiveOnMainThread()
             .sink { event in
                 item.receiveMetricEvent(event)
             }


### PR DESCRIPTION
# Description

This PR adds an important warning to PillarboxPlayer main documentation entry point, explicitly stating that corresponding APIs are supported from the main thread only. It also ensures that tracker lifecycle methods are called on the main thread, which was not guaranteed. 

Calling PillarboxPlayer APIs from background threads is theoretically possible but requires some work, see #931. Until then it is best to warn developers about the current limitations, which should not change anything in practice (most public Pillarbox APIs are meant to be used from UI code anyway).

# Changes made

- Add documentation warning.
- Ensure tracker lifecycle methods are called on the main thread.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
