### PR TITLE
Capture stalls in QoS metrics

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -265,9 +265,6 @@
     "Settings" : {
 
     },
-    "Show metrics" : {
-
-    },
     "Showcase" : {
 
     },

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -231,7 +231,7 @@ private struct MainView: View {
     private func metricsMenu() -> some View {
         if !isPresentingMetrics {
             Button(action: showMetrics) {
-                Label("Show metrics", systemImage: "chart.bar")
+                Label("Metrics", systemImage: "chart.bar")
             }
         }
     }

--- a/Sources/Core/Publisher.swift
+++ b/Sources/Core/Publisher.swift
@@ -189,6 +189,8 @@ public extension Publisher {
     /// Measure the date interval between consecutive outputs.
     ///
     /// - Parameter measure: A closure called for each output delivered upstream.
+    ///
+    /// The first measurement is made relative to the time at which subscription to the publisher was made.
     func measureDateInterval(perform measure: @escaping (DateInterval) -> Void) -> AnyPublisher<Output, Failure> {
         var startDate: Date?
         return handleEvents(
@@ -210,6 +212,8 @@ public extension Publisher {
     /// - Parameters
     ///    - measure: A closure called for each matching output delivered upstream.
     ///    - condition: A closure called to filter matching outputs.
+    ///
+    /// The first measurement is made relative to the time at which subscription to the publisher was made.
     func measureDateInterval(perform measure: @escaping (DateInterval) -> Void, when condition: @escaping (Output) -> Bool) -> AnyPublisher<Output, Failure> {
         var startDate: Date?
         return handleEvents(
@@ -231,9 +235,11 @@ public extension Publisher {
     /// - Parameters
     ///    - measure: A closure called for each output delivered upstream.
     ///    - condition: A closure called to find the first matching output.
-    func measureDateInterval(
+    ///
+    /// The measurement is made relative to the time at which subscription to the publisher was made.
+    func measureFirstDateInterval(
         perform measure: @escaping (DateInterval) -> Void,
-        firstWhen condition: @escaping (Output) -> Bool
+        when condition: @escaping (Output) -> Bool
     ) -> AnyPublisher<Output, Failure> {
         var startDate: Date?
         return handleEvents(

--- a/Sources/Core/Publisher.swift
+++ b/Sources/Core/Publisher.swift
@@ -264,10 +264,10 @@ public extension Publisher {
     ///    - endCondition: A closure called to to determine when a measurement must stop.
     ///
     /// A measurement is made for each pair of matching conditions.
-    func measureDateInterval(
+    func measureEachDateInterval(
         perform measure: @escaping (DateInterval) -> Void,
         after startCondition: @escaping (Output) -> Bool,
-        when endCondition: @escaping (Output) -> Bool
+        until endCondition: @escaping (Output) -> Bool
     ) -> AnyPublisher<Output, Failure> {
         var startDate: Date?
         return handleEvents(

--- a/Sources/Core/Publishers.swift
+++ b/Sources/Core/Publishers.swift
@@ -42,16 +42,16 @@ public extension Publishers {
                 .map { [$0] }
                 .eraseToAnyPublisher()
         case 2:
-            return Publishers.CombineLatest(publishersArray[0], publishersArray[1])
+            return CombineLatest(publishersArray[0], publishersArray[1])
                 .map { [$0, $1] }
                 .eraseToAnyPublisher()
         case 3:
-            return Publishers.CombineLatest3(publishersArray[0], publishersArray[1], publishersArray[2])
+            return CombineLatest3(publishersArray[0], publishersArray[1], publishersArray[2])
                 .map { [$0, $1, $2] }
                 .eraseToAnyPublisher()
         default:
             let half = publishersArray.count / 2
-            return Publishers.CombineLatest(
+            return CombineLatest(
                 AccumulateLatestMany(Array(publishersArray[0..<half])),
                 AccumulateLatestMany(Array(publishersArray[half..<publishersArray.count]))
             )
@@ -65,7 +65,7 @@ public extension Publishers {
     /// A publisher that receives and combines the latest elements from five publishers.
     static func CombineLatest5<A, B, C, D, E>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> AnyPublisher<(A.Output, B.Output, C.Output, D.Output, E.Output), A.Failure> where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, B.Failure == A.Failure, C.Failure == A.Failure, D.Failure == A.Failure, E.Failure == A.Failure {
         // swiftlint:disable:previous large_tuple line_length
-        Publishers.CombineLatest(Publishers.CombineLatest4(a, b, c, d), e)
+        CombineLatest(CombineLatest4(a, b, c, d), e)
             .map { ($0.0, $0.1, $0.2, $0.3, $1) }
             .eraseToAnyPublisher()
     }
@@ -73,7 +73,7 @@ public extension Publishers {
     /// A publisher that receives and combines the latest elements from six publishers.
     static func CombineLatest6<A, B, C, D, E, F>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> AnyPublisher<(A.Output, B.Output, C.Output, D.Output, E.Output, F.Output), A.Failure> where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, B.Failure == A.Failure, C.Failure == A.Failure, D.Failure == A.Failure, E.Failure == A.Failure, F.Failure == A.Failure {
         // swiftlint:disable:previous large_tuple line_length
-        Publishers.CombineLatest3(Publishers.CombineLatest4(a, b, c, d), e, f)
+        CombineLatest3(CombineLatest4(a, b, c, d), e, f)
             .map { ($0.0, $0.1, $0.2, $0.3, $1, $2) }
             .eraseToAnyPublisher()
     }
@@ -81,8 +81,16 @@ public extension Publishers {
     /// A publisher that receives and combines the latest elements from seven publishers.
     static func CombineLatest7<A, B, C, D, E, F, G>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> AnyPublisher<(A.Output, B.Output, C.Output, D.Output, E.Output, F.Output, G.Output), A.Failure> where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, B.Failure == A.Failure, C.Failure == A.Failure, D.Failure == A.Failure, E.Failure == A.Failure, F.Failure == A.Failure, G.Failure == A.Failure {
         // swiftlint:disable:previous large_tuple line_length
-        Publishers.CombineLatest4(Publishers.CombineLatest4(a, b, c, d), e, f, g)
+        CombineLatest4(CombineLatest4(a, b, c, d), e, f, g)
             .map { ($0.0, $0.1, $0.2, $0.3, $1, $2, $3) }
+            .eraseToAnyPublisher()
+    }
+
+    /// A publisher that receives and combines the latest elements from eight publishers.
+    static func CombineLatest8<A, B, C, D, E, F, G, H>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> AnyPublisher<(A.Output, B.Output, C.Output, D.Output, E.Output, F.Output, G.Output, H.Output), A.Failure> where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, H: Publisher, B.Failure == A.Failure, C.Failure == A.Failure, D.Failure == A.Failure, E.Failure == A.Failure, F.Failure == A.Failure, G.Failure == A.Failure, H.Failure == A.Failure {
+        // swiftlint:disable:previous large_tuple line_length
+        CombineLatest4(CombineLatest5(a, b, c, d, e), f, g, h)
+            .map { ($0.0, $0.1, $0.2, $0.3, $0.4, $1, $2, $3) }
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -25,6 +25,14 @@ public struct MetricEvent: Hashable {
 
         /// Warning.
         case warning(Error)
+
+        /// Stall.
+        case stall
+
+        /// Resume after stall.
+        ///
+        /// Measures the time for the player to recover after a stall.
+        case resumeAfterStall(DateInterval)
     }
 
     private let id = UUID()
@@ -78,6 +86,10 @@ extension MetricEvent: CustomStringConvertible {
             return "failure(\(error.localizedDescription))"
         case let .warning(error):
             return "warning(\(error.localizedDescription))"
+        case .stall:
+            return "stall"
+        case let .resumeAfterStall(dateInterval):
+            return "resumeAfterStall(\(dateInterval.duration))"
         }
     }
 }

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -10,7 +10,7 @@ import MediaAccessibility
 
 extension AVPlayerItem {
     func propertiesPublisher() -> AnyPublisher<PlayerItemProperties, Never> {
-        Publishers.CombineLatest7(
+        Publishers.CombineLatest8(
             statusPublisher()
                 .lane("player_item_status"),
             publisher(for: \.presentationSize),
@@ -19,9 +19,10 @@ extension AVPlayerItem {
             timePropertiesPublisher(),
             publisher(for: \.duration),
             minimumTimeOffsetFromLivePublisher(),
-            metricsStatePublisher()
+            metricsStatePublisher(),
+            isStalledPublisher()
         )
-        .map { [weak self] status, presentationSize, mediaSelectionProperties, timeProperties, duration, minimumTimeOffsetFromLive, metricsState in
+        .map { [weak self] status, presentationSize, mediaSelectionProperties, timeProperties, duration, minimumTimeOffsetFromLive, metricsState, isStalled in
             let isKnown = (status != .unknown)
             return .init(
                 itemProperties: .init(
@@ -30,7 +31,8 @@ extension AVPlayerItem {
                     duration: isKnown ? duration : .invalid,
                     minimumTimeOffsetFromLive: minimumTimeOffsetFromLive,
                     presentationSize: isKnown ? presentationSize : nil,
-                    metricsState: metricsState
+                    metricsState: metricsState,
+                    isStalled: isStalled
                 ),
                 mediaSelectionProperties: mediaSelectionProperties,
                 timeProperties: isKnown ? timeProperties : .empty
@@ -132,6 +134,12 @@ extension AVPlayerItem {
             .compactMap { $0 }
             .map { _ in false }
             .eraseToAnyPublisher()
+    }
+}
+
+extension AVPlayerItem {
+    func isStalledPublisher() -> AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -149,7 +149,7 @@ extension AVPlayerItem {
         )
         .prepend(false)
         .removeDuplicates()
-        .measureDateInterval { [weak self] dateInterval in
+        .measureEachDateInterval { [weak self] dateInterval in
             guard let self else { return }
             let event = MetricEvent(kind: .resumeAfterStall(dateInterval), time: currentTime())
             metricLog.appendEvent(event)
@@ -158,7 +158,7 @@ extension AVPlayerItem {
             let event = MetricEvent(kind: .stall, time: currentTime())
             metricLog.appendEvent(event)
             return true
-        } when: { isStalled in
+        } until: { isStalled in
             !isStalled
         }
         .eraseToAnyPublisher()

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -48,10 +48,10 @@ extension AVPlayerItem {
             publisher(for: \.seekableTimeRanges)
                 .lane("player_item_seekable_time_ranges"),
             publisher(for: \.isPlaybackLikelyToKeepUp)
-                .measureDateInterval { [metricLog] interval in
+                .measureFirstDateInterval { [metricLog] interval in
                     let event = MetricEvent(kind: .resourceLoading(interval))
                     metricLog.appendEvent(event)
-                } firstWhen: { isPlaybackLikelyToKeepUp in
+                } when: { isPlaybackLikelyToKeepUp in
                     isPlaybackLikelyToKeepUp
                 }
         )

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -139,7 +139,14 @@ extension AVPlayerItem {
 
 extension AVPlayerItem {
     func isStalledPublisher() -> AnyPublisher<Bool, Never> {
-        Just(false).eraseToAnyPublisher()
+        Publishers.Merge(
+            NotificationCenter.default.weakPublisher(for: AVPlayerItem.playbackStalledNotification, object: self)
+                .map { _ in true },
+            publisher(for: \.isPlaybackLikelyToKeepUp)
+                .compactMap { $0 ? false : nil }
+        )
+        .removeDuplicates()
+        .eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -147,6 +147,8 @@ extension AVPlayerItem {
             publisher(for: \.isPlaybackLikelyToKeepUp)
                 .compactMap { $0 ? false : nil }
         )
+        .prepend(false)
+        .removeDuplicates()
         .measureDateInterval { [weak self] dateInterval in
             guard let self else { return }
             let event = MetricEvent(kind: .resumeAfterStall(dateInterval), time: currentTime())
@@ -159,7 +161,6 @@ extension AVPlayerItem {
         } when: { isStalled in
             !isStalled
         }
-        .removeDuplicates()
         .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -14,7 +14,8 @@ struct ItemProperties: Equatable {
         duration: .invalid,
         minimumTimeOffsetFromLive: .invalid,
         presentationSize: nil,
-        metricsState: .empty
+        metricsState: .empty,
+        isStalled: false
     )
 
     let item: AVPlayerItem?
@@ -25,6 +26,8 @@ struct ItemProperties: Equatable {
 
     let presentationSize: CGSize?
     let metricsState: MetricsState
+
+    let isStalled: Bool
 
     func metrics() -> Metrics? {
         guard let item else { return nil }

--- a/Tests/CoreTests/MeasurePublisherTests.swift
+++ b/Tests/CoreTests/MeasurePublisherTests.swift
@@ -143,7 +143,7 @@ final class MeasurePublisherTests: XCTestCase {
         }
     }
 
-    func testAfterWhen() {
+    func testEachAfterUntil() {
         let expectation = expectation(description: "Done")
         var durations: [TimeInterval] = []
         [1, 2, 3, 4, 5, 6].publisher
@@ -151,11 +151,11 @@ final class MeasurePublisherTests: XCTestCase {
                 Just(value)
                     .delay(for: .milliseconds(value * 100), scheduler: DispatchQueue.main)
             }
-            .measureDateInterval { interval in
+            .measureEachDateInterval { interval in
                 durations.append(interval.duration)
             } after: { value in
                 value.isMultiple(of: 2)
-            } when: { value in
+            } until: { value in
                 value.isMultiple(of: 5)
             }
             .sink(

--- a/Tests/CoreTests/MeasurePublisherTests.swift
+++ b/Tests/CoreTests/MeasurePublisherTests.swift
@@ -123,9 +123,9 @@ final class MeasurePublisherTests: XCTestCase {
                 Just(value)
                     .delay(for: .milliseconds(value * 100), scheduler: DispatchQueue.main)
             }
-            .measureDateInterval { interval in
+            .measureFirstDateInterval { interval in
                 durations.append(interval.duration)
-            } firstWhen: { value in
+            } when: { value in
                 value.isMultiple(of: 2)
             }
             .sink(


### PR DESCRIPTION
# Description

This PR logs stalls to our metric event log.

# Changes made

- Add new measurement method to calculate date intervals based on start and end conditions.
- Provide `isStalled` state in item properties.
- Add new metric events for stalls (start / end).
- Measure date intervals when `isStalled` changes from `true` to `false`.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
