### PR TITLE
Provide warnings in QoS metric events

### DIFF
--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -164,7 +164,7 @@ extension AVPlayerItem {
     private func errorLogMonitoringPublisher() -> AnyPublisher<Error, Never> {
         NotificationCenter.default.weakPublisher(for: AVPlayerItem.newErrorLogEntryNotification, object: self)
             .compactMap { notification -> Error? in
-                guard let item = notification.object as? AVPlayerItem, let lastErrorEvent = item.errorLog()?.events.last else { return nil }
+                guard let lastErrorEvent = (notification.object as? AVPlayerItem)?.errorLog()?.events.last else { return nil }
                 return NSError(
                     domain: lastErrorEvent.errorDomain,
                     code: lastErrorEvent.errorStatusCode,

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -137,9 +137,10 @@ extension AVPlayerItem {
 
 extension AVPlayerItem {
     func errorPublisher() -> AnyPublisher<Error, Never> {
-        Publishers.Merge(
+        Publishers.Merge3(
             intrinsicErrorPublisher(),
-            playbackErrorPublisher()
+            playbackErrorPublisher(),
+            errorLogPublisher()
         )
         .eraseToAnyPublisher()
     }
@@ -158,6 +159,10 @@ extension AVPlayerItem {
         NotificationCenter.default.weakPublisher(for: AVPlayerItem.failedToPlayToEndTimeNotification, object: self)
             .compactMap { $0.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error }
             .eraseToAnyPublisher()
+    }
+
+    private func errorLogPublisher() -> AnyPublisher<Error, Never> {
+        Empty().eraseToAnyPublisher()
     }
 }
 

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -140,7 +140,7 @@ extension AVPlayerItem {
         Publishers.Merge3(
             intrinsicErrorPublisher(),
             playbackErrorPublisher(),
-            errorLogPublisher()
+            errorLogMonitoringPublisher()
         )
         .eraseToAnyPublisher()
     }
@@ -161,7 +161,7 @@ extension AVPlayerItem {
             .eraseToAnyPublisher()
     }
 
-    private func errorLogPublisher() -> AnyPublisher<Error, Never> {
+    private func errorLogMonitoringPublisher() -> AnyPublisher<Error, Never> {
         NotificationCenter.default.weakPublisher(for: AVPlayerItem.newErrorLogEntryNotification, object: self)
             .compactMap { notification -> Error? in
                 guard let item = notification.object as? AVPlayerItem, let lastErrorEvent = item.errorLog()?.events.last else { return nil }


### PR DESCRIPTION
# Description

This PR reports warnings (from the error log) to our metric log.

# Changes made

Self-explanatory. All error log events are reported as warnings until `AVMetrics` can be used.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
