### PR TITLE
Reuse comScore session when pausing at item end

### DIFF
--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -46,7 +46,6 @@ public final class ComScoreTracker: PlayerItemTracker {
         case (false, false):
             streamingAnalytics.notifyBufferStop()
             streamingAnalytics.notifyEvent(for: properties.playbackState, at: properties.rate)
-            renewPlaybackSessionIfNeeded(for: properties.playbackState)
         }
     }
 
@@ -58,12 +57,6 @@ public final class ComScoreTracker: PlayerItemTracker {
 }
 
 private extension ComScoreTracker {
-    func renewPlaybackSessionIfNeeded(for playbackState: PlaybackState) {
-        guard playbackState == .ended else { return }
-        createPlaybackSession()
-        addMetadata(metadata)
-    }
-
     func createPlaybackSession() {
         streamingAnalytics.createPlaybackSession()
         streamingAnalytics.setMediaPlayerName("Pillarbox")

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -213,41 +213,4 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             player.play()
         }
     }
-
-    func testSessionRenewal() {
-        let player = Player(item: .simple(
-            url: Stream.shortOnDemand.url,
-            trackerAdapters: [
-                ComScoreTracker.adapter { _ in .test }
-            ]
-        ))
-        player.actionAtItemEnd = .pause
-
-        var ns_st_id: String?
-
-        expectAtLeastHits(
-            .play { labels in
-                ns_st_id = labels.ns_st_id
-            },
-            .end()
-        ) {
-            player.play()
-        }
-
-        expectAtLeastHits(
-            .play { labels in
-                expect(labels.ns_st_id).notTo(beNil())
-                expect(labels.ns_st_id).notTo(equal(ns_st_id))
-
-                // Other metadata must be preserved as well.
-                expect(labels.ns_st_mp).to(equal("Pillarbox"))
-                expect(labels.ns_st_mv).to(equal(PackageInfo.version))
-                expect(labels["media_title"]).to(equal("name"))
-                expect(labels.cs_ucfr).to(beEmpty())
-            }
-        ) {
-            player.seek(to: .zero)
-            player.play()
-        }
-    }
 }


### PR DESCRIPTION
# Description

This PR makes our comScore implementation simpler by avoiding superfluous session creation when pausing at item end.

# Changes made

- Remove session renewal code.
- Remove associated test (now irrelevant).

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
