### PR TITLE
Send QoS tracker payload data to a specific endpoint

### DIFF
--- a/Sources/Monitoring/MetricErrorData.swift
+++ b/Sources/Monitoring/MetricErrorData.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+import Foundation
+
 struct MetricErrorData: Encodable {
     enum Severity: String, Encodable {
         case warning = "WARNING"
@@ -13,5 +15,6 @@ struct MetricErrorData: Encodable {
     let severity: Severity
     let name: String
     let message: String
+    let url: URL?
     let playerPosition: Int?
 }

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -49,9 +49,7 @@ public final class MetricsTracker: PlayerItemTracker {
         switch events.last?.kind {
         case .resourceLoading:
             isStarted = true
-            if let data = startPayload(from: events) {
-                send(data: data)
-            }
+            sendPayload(data: startPayload(from: events))
         case .stall:
             stallDate = Date()
         case .resumeAfterStall:
@@ -59,17 +57,11 @@ public final class MetricsTracker: PlayerItemTracker {
             stallDuration += Date().timeIntervalSince(stallDate)
         case let .failure(error):
             if !isStarted {
-                if let data = startPayload(from: events) {
-                    send(data: data)
-                }
+                sendPayload(data: startPayload(from: events))
             }
-            if let data = errorPayload(error: error, severity: .fatal) {
-                send(data: data)
-            }
+            sendPayload(data: errorPayload(error: error, severity: .fatal))
         case let .warning(error):
-            if let data = errorPayload(error: error, severity: .warning) {
-                send(data: data)
-            }
+            sendPayload(data: errorPayload(error: error, severity: .warning))
         default:
             break
         }
@@ -79,9 +71,7 @@ public final class MetricsTracker: PlayerItemTracker {
         defer {
             reset()
         }
-        if let data = stopPayload(with: properties) {
-            send(data: data)
-        }
+        sendPayload(data: stopPayload(with: properties))
     }
 }
 
@@ -197,7 +187,8 @@ private extension MetricsTracker {
 }
 
 private extension MetricsTracker {
-    func send(data: Data) {
+    func sendPayload(data: Data?) {
+        guard let data else { return }
         var request = URLRequest(url: serverUrl)
         request.httpMethod = "POST"
         request.httpBody = data

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -163,6 +163,7 @@ private extension MetricsTracker {
                 severity: severity,
                 name: "\(error.domain)(\(error.code))",
                 message: error.localizedDescription,
+                url: URL(string: properties?.metrics()?.uri),
                 playerPosition: properties?.time().toMilliseconds
             )
         )

--- a/Sources/Monitoring/URL.swift
+++ b/Sources/Monitoring/URL.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+extension URL {
+    init?(string: String?) {
+        guard let string else { return nil }
+        self.init(string: string)
+    }
+}


### PR DESCRIPTION
# Description

This PR allows us to send the metric payloads to an endpoint.

# Changes made

- A `send` method has been added to the metrics tracker to send the payload data to an endpoint. The endpoint have to be provided via a configuration.
- The stream URL has been added to the error payload.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
