### PR TITLE
Wait until the User Agent is retrieved by Commanders Act

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -32,6 +32,7 @@ final class CommandersActService {
             serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
             serverSide.addPermanentData("navigation_device", withValue: Self.device())
             serverSide.enableRunningInBackground()
+            serverSide.waitForUserAgent()
             self.serverSide = serverSide
         }
 


### PR DESCRIPTION
# Description

This PR enables a Commanders Act opt-in that ensures User Agent retrieval before sending events. This should avoid inconsistent User Agents from being forwarded to Mapp.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
