### PR TITLE
Add mandatory tracker support

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -52,8 +52,7 @@ public final class CommandersActTracker: PlayerItemTracker {
 
     public func disable(with properties: PlayerProperties) {
         notify(.stop, properties: properties)
-        stopwatch.reset()
-        heartbeat.reset()
+        reset()
     }
 }
 
@@ -88,6 +87,12 @@ private extension CommandersActTracker {
             ))
             lastEvent = event
         }
+    }
+
+    func reset() {
+        stopwatch.reset()
+        heartbeat.reset()
+        lastEvent = .none
     }
 }
 

--- a/Sources/Player/Player.docc/Articles/tracking/tracking.md
+++ b/Sources/Player/Player.docc/Articles/tracking/tracking.md
@@ -53,4 +53,4 @@ let item = PlayerItem.simple(url: url, metadata: CustomMetadata(), trackerAdapte
 
 Note that alternative adapter creation methods are available if your tracker has `Void` configuration and / or metadata.
 
-> Tip: You can enable or disable trackers using ``Player/isTrackingEnabled``. This behavior can be disabled by setting the tracker behavior to ``TrackingBehavior/mandatory`` when calling ``PlayerItemTracker/adapter(configuration:behavior:mapper:)``.
+> Tip: You can enable or disable trackers with the ``Player/isTrackingEnabled`` player property. Trackers ignore this setting if their behavior is set to to ``TrackingBehavior/mandatory`` when creating the associated adapter with ``PlayerItemTracker/adapter(configuration:behavior:mapper:)``.

--- a/Sources/Player/Player.docc/Articles/tracking/tracking.md
+++ b/Sources/Player/Player.docc/Articles/tracking/tracking.md
@@ -41,7 +41,7 @@ Once you have a tracker you can attach it to any item. The only requirement is t
 
 > Tip: More information about <doc:metadata> is available from the dedicated article.
 
-This transformation requires the use of a dedicated adapter, simply created from your custom tracker type using the ``PlayerItemTracker/adapter(configuration:mapper:)`` method. The adapter is also where you can supply any configuration required by your tracker:
+This transformation requires the use of a dedicated adapter, simply created from your custom tracker type using the ``PlayerItemTracker/adapter(configuration:behavior:mapper:)`` method. The adapter is also where you can supply any configuration required by your tracker:
 
 ```swift
 let item = PlayerItem.simple(url: url, metadata: CustomMetadata(), trackerAdapters: [
@@ -52,3 +52,5 @@ let item = PlayerItem.simple(url: url, metadata: CustomMetadata(), trackerAdapte
 ```
 
 Note that alternative adapter creation methods are available if your tracker has `Void` configuration and / or metadata.
+
+> Tip: You can enable or disable trackers using ``Player/isTrackingEnabled``. This behavior can be disabled by setting the tracker behavior to ``TrackingBehavior/mandatory`` when calling ``PlayerItemTracker/adapter(configuration:behavior:mapper:)``.

--- a/Sources/Player/Player.docc/Extensions/player.md
+++ b/Sources/Player/Player.docc/Extensions/player.md
@@ -126,6 +126,7 @@
 ### Tracking
 
 - ``isTrackingEnabled``
+- ``currentSessionIdentifiers(trackedBy:)``
 
 ### User Interface
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -122,8 +122,9 @@ public final class Player: ObservableObject, Equatable {
 
     /// A Boolean setting whether trackers must be enabled or not.
     ///
-    /// Optional trackers only are affected by this setting, see ``TrackingBehavior``. This behavior can be
-    /// customized when creating an adapter using one of the available ``PlayerItemTracker`` methods.
+    /// This property only affects trackers having optional ``TrackingBehavior``, set when creating a corresponding
+    /// adapter using ``PlayerItemTracker/adapter(configuration:behavior:mapper:)`` and similar methods.
+    ///
     public var isTrackingEnabled = true {
         didSet {
             tracker?.isEnabled = isTrackingEnabled

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -121,6 +121,9 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// A Boolean setting whether trackers must be enabled or not.
+    ///
+    /// Optional trackers only are affected by this setting, see ``TrackingBehavior``. This behavior can be
+    /// customized when creating an adapter using one of the available ``PlayerItemTracker`` methods.
     public var isTrackingEnabled = true {
         didSet {
             tracker?.isEnabled = isTrackingEnabled

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -123,7 +123,7 @@ public final class Player: ObservableObject, Equatable {
     /// A Boolean setting whether trackers must be enabled or not.
     ///
     /// This property only affects trackers having optional ``TrackingBehavior``, set when creating a corresponding
-    /// adapter using ``PlayerItemTracker/adapter(configuration:behavior:mapper:)`` and similar methods.
+    /// adapter using ``PlayerItemTracker/adapter(configuration:behavior:mapper:)`` or similar methods.
     ///
     public var isTrackingEnabled = true {
         didSet {

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -137,30 +137,30 @@ public final class PlayerItem: Equatable {
 }
 
 extension PlayerItem {
-    private func trackerAdapters(mandatory: Bool) -> [PlayerItemTracking] {
-        trackerAdapters.filter { $0.isMandatory == mandatory }
+    private func trackerAdapters(behavior: TrackingBehavior) -> [PlayerItemTracking] {
+        trackerAdapters.filter { $0.behavior == behavior }
     }
 
-    func enableTrackers(mandatory: Bool, for player: AVPlayer) {
-        trackerAdapters(mandatory: mandatory).forEach { adapter in
+    func enableTrackers(behavior: TrackingBehavior, for player: AVPlayer) {
+        trackerAdapters(behavior: behavior).forEach { adapter in
             adapter.enable(for: player)
         }
     }
 
-    func updateTrackersProperties(mandatory: Bool, to properties: PlayerProperties) {
-        trackerAdapters(mandatory: mandatory).forEach { adapter in
+    func updateTrackersProperties(behavior: TrackingBehavior, to properties: PlayerProperties) {
+        trackerAdapters(behavior: behavior).forEach { adapter in
             adapter.updateProperties(to: properties)
         }
     }
 
-    func updateTrackersMetricEvents(mandatory: Bool, to events: [MetricEvent]) {
-        trackerAdapters(mandatory: mandatory).forEach { adapter in
+    func updateTrackersMetricEvents(behavior: TrackingBehavior, to events: [MetricEvent]) {
+        trackerAdapters(behavior: behavior).forEach { adapter in
             adapter.updateMetricEvents(to: events)
         }
     }
 
-    func disableTrackers(mandatory: Bool, with properties: PlayerProperties) {
-        trackerAdapters(mandatory: mandatory).forEach { adapter in
+    func disableTrackers(behavior: TrackingBehavior, with properties: PlayerProperties) {
+        trackerAdapters(behavior: behavior).forEach { adapter in
             adapter.disable(with: properties)
         }
     }

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -137,26 +137,30 @@ public final class PlayerItem: Equatable {
 }
 
 extension PlayerItem {
-    func enableTrackers(for player: AVPlayer) {
-        trackerAdapters.forEach { adapter in
+    private func trackerAdapters(mandatory: Bool) -> [PlayerItemTracking] {
+        trackerAdapters.filter { $0.isMandatory == mandatory }
+    }
+
+    func enableTrackers(mandatory: Bool, for player: AVPlayer) {
+        trackerAdapters(mandatory: mandatory).forEach { adapter in
             adapter.enable(for: player)
         }
     }
 
-    func updateTrackersProperties(to properties: PlayerProperties) {
-        trackerAdapters.forEach { adapter in
+    func updateTrackersProperties(mandatory: Bool, to properties: PlayerProperties) {
+        trackerAdapters(mandatory: mandatory).forEach { adapter in
             adapter.updateProperties(to: properties)
         }
     }
 
-    func updateTrackersMetricEvents(to events: [MetricEvent]) {
-        trackerAdapters.forEach { adapter in
+    func updateTrackersMetricEvents(mandatory: Bool, to events: [MetricEvent]) {
+        trackerAdapters(mandatory: mandatory).forEach { adapter in
             adapter.updateMetricEvents(to: events)
         }
     }
 
-    func disableTrackers(with properties: PlayerProperties) {
-        trackerAdapters.forEach { adapter in
+    func disableTrackers(mandatory: Bool, with properties: PlayerProperties) {
+        trackerAdapters(mandatory: mandatory).forEach { adapter in
             adapter.disable(with: properties)
         }
     }

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -137,30 +137,30 @@ public final class PlayerItem: Equatable {
 }
 
 extension PlayerItem {
-    private func trackerAdapters(behavior: TrackingBehavior) -> [PlayerItemTracking] {
+    private func trackerAdapters(matchingBehavior behavior: TrackingBehavior) -> [PlayerItemTracking] {
         trackerAdapters.filter { $0.behavior == behavior }
     }
 
-    func enableTrackers(behavior: TrackingBehavior, for player: AVPlayer) {
-        trackerAdapters(behavior: behavior).forEach { adapter in
+    func enableTrackers(matchingBehavior behavior: TrackingBehavior, for player: AVPlayer) {
+        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
             adapter.enable(for: player)
         }
     }
 
-    func updateTrackersProperties(behavior: TrackingBehavior, to properties: PlayerProperties) {
-        trackerAdapters(behavior: behavior).forEach { adapter in
+    func updateTrackersProperties(matchingBehavior behavior: TrackingBehavior, to properties: PlayerProperties) {
+        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
             adapter.updateProperties(to: properties)
         }
     }
 
-    func updateTrackersMetricEvents(behavior: TrackingBehavior, to events: [MetricEvent]) {
-        trackerAdapters(behavior: behavior).forEach { adapter in
+    func updateTrackersMetricEvents(matchingBehavior behavior: TrackingBehavior, to events: [MetricEvent]) {
+        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
             adapter.updateMetricEvents(to: events)
         }
     }
 
-    func disableTrackers(behavior: TrackingBehavior, with properties: PlayerProperties) {
-        trackerAdapters(behavior: behavior).forEach { adapter in
+    func disableTrackers(matchingBehavior behavior: TrackingBehavior, with properties: PlayerProperties) {
+        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
             adapter.disable(with: properties)
         }
     }

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -97,8 +97,8 @@ public extension PlayerItemTracker where Configuration == Void {
     /// Creates an adapter for the receiver.
     /// 
     /// - Parameters:
-    ///   - mapper: A closure that maps an item metadata to tracker metadata.
     ///   - behavior: The tracking behavior.
+    ///   - mapper: A closure that maps an item metadata to tracker metadata.
     /// - Returns: The tracker adapter.
     static func adapter<M>(behavior: TrackingBehavior = .optional, mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
         .init(trackerType: Self.self, configuration: (), behavior: behavior, mapper: mapper)

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -81,38 +81,45 @@ public extension PlayerItemTracker {
     ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
+    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
     ///   - mapper: A closure that maps an item metadata to tracker metadata.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(configuration: Configuration, mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, configuration: configuration, mapper: mapper)
+    static func adapter<M>(configuration: Configuration, mandatory: Bool = false, mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, mandatory: mandatory, configuration: configuration, mapper: mapper)
     }
 }
 
 public extension PlayerItemTracker where Configuration == Void {
     /// Creates an adapter for the receiver.
     /// 
-    /// - Parameter mapper: A closure that maps an item metadata to tracker metadata.
+    /// - Parameters:
+    ///   - mapper: A closure that maps an item metadata to tracker metadata.
+    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, configuration: (), mapper: mapper)
+    static func adapter<M>(mapper: @escaping (M) -> Metadata, mandatory: Bool = false) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, mandatory: mandatory, configuration: (), mapper: mapper)
     }
 }
 
 public extension PlayerItemTracker where Metadata == Void {
     /// Creates an adapter for the receiver.
     ///
-    /// - Parameter configuration: The tracker configuration.
+    /// - Parameters:
+    ///   - configuration: The tracker configuration.
+    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(configuration: Configuration) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, configuration: configuration) { _ in }
+    static func adapter<M>(configuration: Configuration, mandatory: Bool = false) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, mandatory: mandatory, configuration: configuration) { _ in }
     }
 }
 
 public extension PlayerItemTracker where Configuration == Void, Metadata == Void {
     /// Creates an adapter for the receiver.
     ///
+    /// - Parameter mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
+    ///
     /// - Returns: The tracker adapter.
-    static func adapter<M>() -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, configuration: ()) { _ in }
+    static func adapter<M>(mandatory: Bool = false) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, mandatory: mandatory, configuration: ()) { _ in }
     }
 }

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -81,8 +81,8 @@ public extension PlayerItemTracker {
     ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
-    ///   - mapper: A closure that maps an item metadata to tracker metadata.
     ///   - behavior: The tracking behavior.
+    ///   - mapper: A closure that maps an item metadata to tracker metadata.
     /// - Returns: The tracker adapter.
     static func adapter<M>(
         configuration: Configuration,

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -81,11 +81,15 @@ public extension PlayerItemTracker {
     ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
-    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
     ///   - mapper: A closure that maps an item metadata to tracker metadata.
+    ///   - behavior: The tracking behavior.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(configuration: Configuration, mandatory: Bool = false, mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, mandatory: mandatory, configuration: configuration, mapper: mapper)
+    static func adapter<M>(
+        configuration: Configuration,
+        behavior: TrackingBehavior = .optional,
+        mapper: @escaping (M) -> Metadata
+    ) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, configuration: configuration, behavior: behavior, mapper: mapper)
     }
 }
 
@@ -94,10 +98,10 @@ public extension PlayerItemTracker where Configuration == Void {
     /// 
     /// - Parameters:
     ///   - mapper: A closure that maps an item metadata to tracker metadata.
-    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
+    ///   - behavior: The tracking behavior.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(mapper: @escaping (M) -> Metadata, mandatory: Bool = false) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, mandatory: mandatory, configuration: (), mapper: mapper)
+    static func adapter<M>(mapper: @escaping (M) -> Metadata, behavior: TrackingBehavior = .optional) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, configuration: (), behavior: behavior, mapper: mapper)
     }
 }
 
@@ -106,20 +110,20 @@ public extension PlayerItemTracker where Metadata == Void {
     ///
     /// - Parameters:
     ///   - configuration: The tracker configuration.
-    ///   - mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
+    ///   - behavior: The tracking behavior.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(configuration: Configuration, mandatory: Bool = false) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, mandatory: mandatory, configuration: configuration) { _ in }
+    static func adapter<M>(configuration: Configuration, behavior: TrackingBehavior = .optional) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, configuration: configuration, behavior: behavior) { _ in }
     }
 }
 
 public extension PlayerItemTracker where Configuration == Void, Metadata == Void {
     /// Creates an adapter for the receiver.
     ///
-    /// - Parameter mandatory: Set to `true` to prevent the tracker from being disabled with with ``Player/isTrackingEnabled``.
+    /// - Parameter behavior: The tracking behavior.
     ///
     /// - Returns: The tracker adapter.
-    static func adapter<M>(mandatory: Bool = false) -> TrackerAdapter<M> {
-        .init(trackerType: Self.self, mandatory: mandatory, configuration: ()) { _ in }
+    static func adapter<M>(behavior: TrackingBehavior = .optional) -> TrackerAdapter<M> {
+        .init(trackerType: Self.self, configuration: (), behavior: behavior) { _ in }
     }
 }

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -100,7 +100,7 @@ public extension PlayerItemTracker where Configuration == Void {
     ///   - mapper: A closure that maps an item metadata to tracker metadata.
     ///   - behavior: The tracking behavior.
     /// - Returns: The tracker adapter.
-    static func adapter<M>(mapper: @escaping (M) -> Metadata, behavior: TrackingBehavior = .optional) -> TrackerAdapter<M> {
+    static func adapter<M>(behavior: TrackingBehavior = .optional, mapper: @escaping (M) -> Metadata) -> TrackerAdapter<M> {
         .init(trackerType: Self.self, configuration: (), behavior: behavior, mapper: mapper)
     }
 }

--- a/Sources/Player/Tracking/PlayerItemTracking.swift
+++ b/Sources/Player/Tracking/PlayerItemTracking.swift
@@ -7,7 +7,7 @@
 import AVFoundation
 
 protocol PlayerItemTracking {
-    var isMandatory: Bool { get }
+    var behavior: TrackingBehavior { get }
     var registration: TrackingRegistration? { get }
 
     func enable(for player: AVPlayer)

--- a/Sources/Player/Tracking/PlayerItemTracking.swift
+++ b/Sources/Player/Tracking/PlayerItemTracking.swift
@@ -7,6 +7,7 @@
 import AVFoundation
 
 protocol PlayerItemTracking {
+    var isMandatory: Bool { get }
     var registration: TrackingRegistration? { get }
 
     func enable(for player: AVPlayer)

--- a/Sources/Player/Tracking/Tracker.swift
+++ b/Sources/Player/Tracking/Tracker.swift
@@ -21,12 +21,12 @@ final class Tracker {
         didSet {
             guard isEnabled != oldValue else { return }
             if isEnabled {
-                enable(behavior: .optional)
+                enableTrackers(matchingBehavior: .optional)
                 updateTrackersProperties(to: properties)
                 updateTrackersMetricEvents(to: metricEventCollector.metricEvents)
             }
             else {
-                disable(behavior: .optional)
+                disableTrackers(matchingBehavior: .optional)
             }
         }
     }
@@ -47,32 +47,32 @@ final class Tracker {
         self.isEnabled = isEnabled
         self.metricEventCollector = MetricEventCollector(items: items)
 
-        enable(behavior: .mandatory)
+        enableTrackers(matchingBehavior: .mandatory)
         if isEnabled {
-            enable(behavior: .optional)
+            enableTrackers(matchingBehavior: .optional)
         }
         configurePublishers()
     }
 
-    private func enable(behavior: TrackingBehavior) {
-        item.enableTrackers(behavior: behavior, for: player)
+    private func enableTrackers(matchingBehavior behavior: TrackingBehavior) {
+        item.enableTrackers(matchingBehavior: behavior, for: player)
     }
 
-    private func disable(behavior: TrackingBehavior) {
-        item.disableTrackers(behavior: behavior, with: properties)
+    private func disableTrackers(matchingBehavior behavior: TrackingBehavior) {
+        item.disableTrackers(matchingBehavior: behavior, with: properties)
     }
 
     private func updateTrackersProperties(to properties: PlayerProperties) {
-        item.updateTrackersProperties(behavior: .mandatory, to: properties)
+        item.updateTrackersProperties(matchingBehavior: .mandatory, to: properties)
         if isEnabled {
-            item.updateTrackersProperties(behavior: .optional, to: properties)
+            item.updateTrackersProperties(matchingBehavior: .optional, to: properties)
         }
     }
 
     private func updateTrackersMetricEvents(to events: [MetricEvent]) {
-        item.updateTrackersMetricEvents(behavior: .mandatory, to: events)
+        item.updateTrackersMetricEvents(matchingBehavior: .mandatory, to: events)
         if isEnabled {
-            item.updateTrackersMetricEvents(behavior: .optional, to: events)
+            item.updateTrackersMetricEvents(matchingBehavior: .optional, to: events)
         }
     }
 
@@ -98,8 +98,8 @@ final class Tracker {
 
     deinit {
         if isEnabled {
-            disable(behavior: .optional)
+            disableTrackers(matchingBehavior: .optional)
         }
-        disable(behavior: .mandatory)
+        disableTrackers(matchingBehavior: .mandatory)
     }
 }

--- a/Sources/Player/Tracking/Tracker.swift
+++ b/Sources/Player/Tracking/Tracker.swift
@@ -21,12 +21,12 @@ final class Tracker {
         didSet {
             guard isEnabled != oldValue else { return }
             if isEnabled {
-                enable(mandatory: false)
+                enable(behavior: .optional)
                 updateTrackersProperties(to: properties)
                 updateTrackersMetricEvents(to: metricEventCollector.metricEvents)
             }
             else {
-                disable(mandatory: false)
+                disable(behavior: .optional)
             }
         }
     }
@@ -47,32 +47,32 @@ final class Tracker {
         self.isEnabled = isEnabled
         self.metricEventCollector = MetricEventCollector(items: items)
 
-        enable(mandatory: true)
+        enable(behavior: .mandatory)
         if isEnabled {
-            enable(mandatory: false)
+            enable(behavior: .optional)
         }
         configurePublishers()
     }
 
-    private func enable(mandatory: Bool) {
-        item.enableTrackers(mandatory: mandatory, for: player)
+    private func enable(behavior: TrackingBehavior) {
+        item.enableTrackers(behavior: behavior, for: player)
     }
 
-    private func disable(mandatory: Bool) {
-        item.disableTrackers(mandatory: mandatory, with: properties)
+    private func disable(behavior: TrackingBehavior) {
+        item.disableTrackers(behavior: behavior, with: properties)
     }
 
     private func updateTrackersProperties(to properties: PlayerProperties) {
-        item.updateTrackersProperties(mandatory: true, to: properties)
+        item.updateTrackersProperties(behavior: .mandatory, to: properties)
         if isEnabled {
-            item.updateTrackersProperties(mandatory: false, to: properties)
+            item.updateTrackersProperties(behavior: .optional, to: properties)
         }
     }
 
     private func updateTrackersMetricEvents(to events: [MetricEvent]) {
-        item.updateTrackersMetricEvents(mandatory: true, to: events)
+        item.updateTrackersMetricEvents(behavior: .mandatory, to: events)
         if isEnabled {
-            item.updateTrackersMetricEvents(mandatory: false, to: events)
+            item.updateTrackersMetricEvents(behavior: .optional, to: events)
         }
     }
 
@@ -98,8 +98,8 @@ final class Tracker {
 
     deinit {
         if isEnabled {
-            disable(mandatory: false)
+            disable(behavior: .optional)
         }
-        disable(mandatory: true)
+        disable(behavior: .mandatory)
     }
 }

--- a/Sources/Player/Tracking/Tracker.swift
+++ b/Sources/Player/Tracking/Tracker.swift
@@ -22,8 +22,8 @@ final class Tracker {
             guard isEnabled != oldValue else { return }
             if isEnabled {
                 enableTrackers(matchingBehavior: .optional)
-                updateTrackersProperties(to: properties)
-                updateTrackersMetricEvents(to: metricEventCollector.metricEvents)
+                item.updateTrackersProperties(matchingBehavior: .optional, to: properties)
+                item.updateTrackersMetricEvents(matchingBehavior: .optional, to: metricEventCollector.metricEvents)
             }
             else {
                 disableTrackers(matchingBehavior: .optional)

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -13,15 +13,8 @@ public struct TrackerAdapter<M> {
     private let tracker: any PlayerItemTracker
     private let mandatory: Bool
     private let update: (M) -> Void
-
-    /// Creates an adapter for a type of tracker with the provided mapper.
-    /// 
-    /// - Parameters:
-    ///   - trackerType: The type of the tracker to instantiate and manage.
-    ///   - mandatory: Set to `true` prevent ``Player/isTrackingEnabled``from disabling the tracker.
-    ///   - configuration: The tracker configuration.
-    ///   - mapper: The metadata mapper.
-    public init<T>(
+    
+    init<T>(
         trackerType: T.Type,
         mandatory: Bool = false,
         configuration: T.Configuration,

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -10,14 +10,15 @@ import AVFoundation
 ///
 /// An adapter transforms metadata delivered by a player item into the metadata format required by the tracker.
 public struct TrackerAdapter<M> {
+    let behavior: TrackingBehavior
+
     private let tracker: any PlayerItemTracker
-    let isMandatory: Bool
     private let update: (M) -> Void
 
     init<T>(
         trackerType: T.Type,
-        mandatory: Bool = false,
         configuration: T.Configuration,
+        behavior: TrackingBehavior,
         mapper: ((M) -> T.Metadata)?
     ) where T: PlayerItemTracker {
         let tracker = trackerType.init(configuration: configuration)
@@ -27,7 +28,7 @@ public struct TrackerAdapter<M> {
             }
         }
         self.tracker = tracker
-        self.isMandatory = mandatory
+        self.behavior = behavior
     }
 
     func updateMetadata(to metadata: M) {

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -11,7 +11,7 @@ import AVFoundation
 /// An adapter transforms metadata delivered by a player item into the metadata format required by the tracker.
 public struct TrackerAdapter<M> {
     private let tracker: any PlayerItemTracker
-    private let mandatory: Bool
+    let isMandatory: Bool
     private let update: (M) -> Void
 
     init<T>(
@@ -27,7 +27,7 @@ public struct TrackerAdapter<M> {
             }
         }
         self.tracker = tracker
-        self.mandatory = mandatory
+        self.isMandatory = mandatory
     }
 
     func updateMetadata(to metadata: M) {

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -11,15 +11,22 @@ import AVFoundation
 /// An adapter transforms metadata delivered by a player item into the metadata format required by the tracker.
 public struct TrackerAdapter<M> {
     private let tracker: any PlayerItemTracker
+    private let mandatory: Bool
     private let update: (M) -> Void
 
     /// Creates an adapter for a type of tracker with the provided mapper.
     /// 
     /// - Parameters:
     ///   - trackerType: The type of the tracker to instantiate and manage.
+    ///   - mandatory: Set to `true` prevent ``Player/isTrackingEnabled``from disabling the tracker.
     ///   - configuration: The tracker configuration.
     ///   - mapper: The metadata mapper.
-    public init<T>(trackerType: T.Type, configuration: T.Configuration, mapper: ((M) -> T.Metadata)?) where T: PlayerItemTracker {
+    public init<T>(
+        trackerType: T.Type,
+        mandatory: Bool = false,
+        configuration: T.Configuration,
+        mapper: ((M) -> T.Metadata)?
+    ) where T: PlayerItemTracker {
         let tracker = trackerType.init(configuration: configuration)
         update = { metadata in
             if let mapper {
@@ -27,6 +34,7 @@ public struct TrackerAdapter<M> {
             }
         }
         self.tracker = tracker
+        self.mandatory = mandatory
     }
 
     func updateMetadata(to metadata: M) {

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -13,7 +13,7 @@ public struct TrackerAdapter<M> {
     private let tracker: any PlayerItemTracker
     private let mandatory: Bool
     private let update: (M) -> Void
-    
+
     init<T>(
         trackerType: T.Type,
         mandatory: Bool = false,

--- a/Sources/Player/Types/TrackingBehavior.swift
+++ b/Sources/Player/Types/TrackingBehavior.swift
@@ -10,11 +10,11 @@
 public enum TrackingBehavior {
     /// Optional tracking.
     ///
-    /// The ``TrackerAdapter`` can be disabled ``Player/isTrackingEnabled``.
+    /// The ``TrackerAdapter`` is affected by ``Player/isTrackingEnabled``.
     case optional
 
     /// Mandatory tracking.
     ///
-    /// The ``TrackerAdapter`` can never be disabled with  ``Player/isTrackingEnabled``.
+    /// The ``TrackerAdapter`` is not affected by  ``Player/isTrackingEnabled``.
     case mandatory
 }

--- a/Sources/Player/Types/TrackingBehavior.swift
+++ b/Sources/Player/Types/TrackingBehavior.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+/// A tracking behavior.
+///
+/// Determines how a ``TrackerAdapter`` is affected by ``Player/isTrackingEnabled``.
+public enum TrackingBehavior {
+    /// Optional tracking.
+    ///
+    /// The ``TrackerAdapter`` can be disabled ``Player/isTrackingEnabled``.
+    case optional
+
+    /// Mandatory tracking.
+    ///
+    /// The ``TrackerAdapter`` can never be disabled with  ``Player/isTrackingEnabled``.
+    case mandatory
+}

--- a/Sources/Player/Types/TrackingBehavior.swift
+++ b/Sources/Player/Types/TrackingBehavior.swift
@@ -6,15 +6,15 @@
 
 /// A tracking behavior.
 ///
-/// Determines how a ``TrackerAdapter`` is affected by ``Player/isTrackingEnabled``.
+/// Determines how a ``TrackerAdapter`` is affected by the ``Player/isTrackingEnabled`` player setting.
 public enum TrackingBehavior {
     /// Optional tracking.
     ///
-    /// The ``TrackerAdapter`` is affected by ``Player/isTrackingEnabled``.
+    /// The ``TrackerAdapter`` takes into account the ``Player/isTrackingEnabled`` player setting.
     case optional
 
     /// Mandatory tracking.
     ///
-    /// The ``TrackerAdapter`` is not affected by  ``Player/isTrackingEnabled``.
+    /// The ``TrackerAdapter`` ignores the ``Player/isTrackingEnabled`` player setting.
     case mandatory
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
@@ -180,4 +180,29 @@ final class CommandersActTrackerTests: CommandersActTestCase {
             player.isTrackingEnabled = true
         }
     }
+
+    func testEnableTrackingAgainWhilePaused() {
+        let player = Player()
+        player.append(.simple(
+            url: Stream.onDemand.url,
+            trackerAdapters: [
+                CommandersActTracker.adapter { _ in [:] }
+            ]
+        ))
+
+        expectAtLeastHits(play()) {
+            player.play()
+        }
+        expectAtLeastHits(stop()) {
+            player.isTrackingEnabled = false
+        }
+
+        player.pause()
+        expect(player.playbackState).toEventually(equal(.paused))
+
+        expectAtLeastHits(play()) {
+            player.isTrackingEnabled = true
+            player.play()
+        }
+    }
 }

--- a/Tests/MonitoringTests/MetricsTrackerTests.swift
+++ b/Tests/MonitoringTests/MetricsTrackerTests.swift
@@ -76,15 +76,7 @@ final class MetricsTrackerTests: MonitoringTestCase {
                 ) { _ in .test }
             ]
         ))
-        expectAtLeastHits(
-            start(),
-            heartbeat { payload in
-                expect(payload.data.playerPosition).to(beCloseTo(1000, within: 100))
-            },
-            heartbeat { payload in
-                expect(payload.data.playerPosition).to(beCloseTo(2000, within: 100))
-            }
-        ) {
+        expectAtLeastHits(start(), heartbeat(), heartbeat()) {
             player.play()
         }
     }

--- a/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
+++ b/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
@@ -63,7 +63,7 @@ final class PlayerItemTrackerMock: PlayerItemTracker {
 }
 
 extension PlayerItemTrackerMock {
-    static func adapter(statePublisher: StatePublisher) -> TrackerAdapter<Void> {
-        adapter(configuration: Configuration(statePublisher: statePublisher))
+    static func adapter(statePublisher: StatePublisher, mandatory: Bool = false) -> TrackerAdapter<Void> {
+        adapter(configuration: Configuration(statePublisher: statePublisher), mandatory: mandatory)
     }
 }

--- a/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
+++ b/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
@@ -63,7 +63,7 @@ final class PlayerItemTrackerMock: PlayerItemTracker {
 }
 
 extension PlayerItemTrackerMock {
-    static func adapter(statePublisher: StatePublisher, mandatory: Bool = false) -> TrackerAdapter<Void> {
-        adapter(configuration: Configuration(statePublisher: statePublisher), mandatory: mandatory)
+    static func adapter(statePublisher: StatePublisher, behavior: TrackingBehavior = .optional) -> TrackerAdapter<Void> {
+        adapter(configuration: Configuration(statePublisher: statePublisher), behavior: behavior)
     }
 }

--- a/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
@@ -47,7 +47,7 @@ final class PlayerItemTrackerMetricPublisherTests: TestCase {
                 [.anyAssetLoading, .anyResourceLoading]
             ],
             from: player.metricEventsPublisher,
-            during: .milliseconds(1500)
+            during: .seconds(2)
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
@@ -109,7 +109,7 @@ final class PlayerTrackingTests: TestCase {
         }
     }
 
-    func testEnablingTrackingMustNotEmitMandatoryTrackerMetricEvents() {
+    func testEnablingTrackingMustNotEmitMetricEventsAgainForMandatoryTracker() {
         let player = Player()
         player.isTrackingEnabled = false
 

--- a/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
@@ -102,7 +102,7 @@ final class PlayerTrackingTests: TestCase {
                 .simple(
                     url: Stream.shortOnDemand.url,
                     trackerAdapters: [
-                        PlayerItemTrackerMock.adapter(statePublisher: publisher, mandatory: true)
+                        PlayerItemTrackerMock.adapter(statePublisher: publisher, behavior: .mandatory)
                     ]
                 )
             )

--- a/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
@@ -90,4 +90,22 @@ final class PlayerTrackingTests: TestCase {
             player.isTrackingEnabled = true
         }
     }
+
+    func testMandatoryTracker() {
+        let player = Player()
+        player.isTrackingEnabled = false
+
+        let publisher = PlayerItemTrackerMock.StatePublisher()
+
+        expectEqualPublished(values: [.initialized, .enabled, .metricEvents, .metricEvents], from: publisher, during: .seconds(1)) {
+            player.append(
+                .simple(
+                    url: Stream.shortOnDemand.url,
+                    trackerAdapters: [
+                        PlayerItemTrackerMock.adapter(statePublisher: publisher, mandatory: true)
+                    ]
+                )
+            )
+        }
+    }
 }

--- a/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerTrackingTests.swift
@@ -108,4 +108,26 @@ final class PlayerTrackingTests: TestCase {
             )
         }
     }
+
+    func testEnablingTrackingMustNotEmitMandatoryTrackerMetricEvents() {
+        let player = Player()
+        player.isTrackingEnabled = false
+
+        let publisher = PlayerItemTrackerMock.StatePublisher()
+
+        expectEqualPublished(values: [.initialized, .enabled, .metricEvents, .metricEvents], from: publisher, during: .seconds(1)) {
+            player.append(
+                .simple(
+                    url: Stream.onDemand.url,
+                    trackerAdapters: [
+                        PlayerItemTrackerMock.adapter(statePublisher: publisher, behavior: .mandatory)
+                    ]
+                )
+            )
+        }
+
+        expectNothingPublished(from: publisher, during: .seconds(1)) {
+            player.isTrackingEnabled = true
+        }
+    }
 }


### PR DESCRIPTION
# Description

This PR adds support for mandatory trackers. When creating an associated adapter with mandatory behavior, the tracker will never be affected by the `isTrackingEnabled` property anymore. This is especially useful for QoS / QoE trackers that, unlike analytics trackers, might be useful in all cases.

# API design considerations

I considered many API design options and associated signatures, from a Boolean parameter to signatures including a _when_ plus some enum parameter, but none felt natural to read. The current proposal is the best I could come up with from an expressiveness point of view.

# Changes made

- Add new `TrackingBehavior` with `optional` and `mandatory` options.
- Add `behavior` parameter to tracker adapter creation methods. Default is `optional` (behavior until now).
- Fix Commanders Act tracking issue found when performing tests (a bug could prevent a tracker from being enabled in some scenario).
- Make an existing playlist-related test less flaky.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
