### PR TITLE
Fix incorrect negative metrics when toggling AirPlay

### DIFF
--- a/Sources/Core/Publishers.swift
+++ b/Sources/Core/Publishers.swift
@@ -85,14 +85,6 @@ public extension Publishers {
             .map { ($0.0, $0.1, $0.2, $0.3, $1, $2, $3) }
             .eraseToAnyPublisher()
     }
-
-    /// A publisher that receives and combines the latest elements from eight publishers.
-    static func CombineLatest8<A, B, C, D, E, F, G, H>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> AnyPublisher<(A.Output, B.Output, C.Output, D.Output, E.Output, F.Output, G.Output, H.Output), A.Failure> where A: Publisher, B: Publisher, C: Publisher, D: Publisher, E: Publisher, F: Publisher, G: Publisher, H: Publisher, B.Failure == A.Failure, C.Failure == A.Failure, D.Failure == A.Failure, E.Failure == A.Failure, F.Failure == A.Failure, G.Failure == A.Failure, H.Failure == A.Failure {
-        // swiftlint:disable:previous large_tuple line_length
-        CombineLatest4(CombineLatest5(a, b, c, d, e), f, g, h)
-            .map { ($0.0, $0.1, $0.2, $0.3, $0.4, $1, $2, $3) }
-            .eraseToAnyPublisher()
-    }
 }
 
 public extension Publishers {

--- a/Sources/Player/Metrics/MetricsState.swift
+++ b/Sources/Player/Metrics/MetricsState.swift
@@ -19,9 +19,9 @@ struct MetricsState: Equatable {
         self.total = events.reduce(.zero) { $0 + .values(from: $1) }
     }
 
-    init(from item: AVPlayerItem) {
-        let events = item.accessLog()?.events.map { AccessLogEvent($0) } ?? []
-        self.init(with: events, at: item.currentTime())
+    init?(from item: AVPlayerItem) {
+        guard let events = item.accessLog()?.events, !events.isEmpty else { return nil }
+        self.init(with: events.map { AccessLogEvent($0) }, at: item.currentTime())
     }
 
     func metrics(from state: Self) -> Metrics {

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -42,11 +42,7 @@ public extension Player {
             .map { [queuePlayer] item -> AnyPublisher<[Metrics], Never> in
                 guard let item else { return Just([]).eraseToAnyPublisher() }
                 return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
-                    .compactMap { _ in item.accessLog()?.events }
-                    .filter { !$0.isEmpty }
-                    .scan(MetricsState.empty) { state, events in
-                        state.updated(with: events, at: item.currentTime())
-                    }
+                    .map { _ in MetricsState(from: item) }
                     .withPrevious(MetricsState.empty)
                     .map { $0.current.metrics(from: $0.previous) }
                     .scan([]) { ($0 + [$1]).suffix(limit) }

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -45,7 +45,7 @@ public extension Player {
         .map { [queuePlayer] item, _ -> AnyPublisher<[Metrics], Never> in
             guard let item else { return Just([]).eraseToAnyPublisher() }
             return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
-                .map { _ in MetricsState(from: item) }
+                .compactMap { _ in MetricsState(from: item) }
                 .withPrevious(MetricsState.empty)
                 .map { $0.current.metrics(from: $0.previous) }
                 .scan([]) { ($0 + [$1]).suffix(limit) }

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -37,6 +37,8 @@ public extension Player {
     /// Additional non-periodic updates will be published when time jumps or when playback starts or stops. Each
     /// included ``Metrics/increment`` collates data since the entry that precedes it in the history. No updates are
     /// published if no metrics are provided for the item being played.
+    ///
+    /// > Important: The metrics history is reset when toggling external playback.
     func periodicMetricsPublisher(forInterval interval: CMTime, queue: DispatchQueue = .main, limit: Int = .max) -> AnyPublisher<[Metrics], Never> {
         Publishers.CombineLatest(
             currentPlayerItemPublisher(),

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -11,7 +11,7 @@ import PillarboxCore
 
 extension AVPlayerItem {
     func propertiesPublisher() -> AnyPublisher<PlayerItemProperties, Never> {
-        Publishers.CombineLatest8(
+        Publishers.CombineLatest7(
             statusPublisher()
                 .lane("player_item_status"),
             publisher(for: \.presentationSize),
@@ -20,10 +20,9 @@ extension AVPlayerItem {
             timePropertiesPublisher(),
             publisher(for: \.duration),
             minimumTimeOffsetFromLivePublisher(),
-            metricsStatePublisher(),
             isStalledPublisher()
         )
-        .map { [weak self] status, presentationSize, mediaSelectionProperties, timeProperties, duration, minimumTimeOffsetFromLive, metricsState, isStalled in
+        .map { [weak self] status, presentationSize, mediaSelectionProperties, timeProperties, duration, minimumTimeOffsetFromLive, isStalled in
             let isKnown = (status != .unknown)
             return .init(
                 itemProperties: .init(
@@ -32,7 +31,6 @@ extension AVPlayerItem {
                     duration: isKnown ? duration : .invalid,
                     minimumTimeOffsetFromLive: minimumTimeOffsetFromLive,
                     presentationSize: isKnown ? presentationSize : nil,
-                    metricsState: metricsState,
                     isStalled: isStalled
                 ),
                 mediaSelectionProperties: mediaSelectionProperties,
@@ -199,9 +197,7 @@ extension AVPlayerItem {
         NotificationCenter.default.weakPublisher(for: AVPlayerItem.newAccessLogEntryNotification, object: self)
             .compactMap { $0.object as? AVPlayerItem }
             .prepend(self)
-            .scan(.empty) { state, item in
-                state.updated(with: item.accessLog(), at: item.currentTime())
-            }
+            .map { .init(from: $0) }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -197,7 +197,7 @@ extension AVPlayerItem {
         NotificationCenter.default.weakPublisher(for: AVPlayerItem.newAccessLogEntryNotification, object: self)
             .compactMap { $0.object as? AVPlayerItem }
             .prepend(self)
-            .map { .init(from: $0) }
+            .compactMap { .init(from: $0) }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -14,7 +14,6 @@ struct ItemProperties: Equatable {
         duration: .invalid,
         minimumTimeOffsetFromLive: .invalid,
         presentationSize: nil,
-        metricsState: .empty,
         isStalled: false
     )
 
@@ -25,7 +24,6 @@ struct ItemProperties: Equatable {
     let minimumTimeOffsetFromLive: CMTime
 
     let presentationSize: CGSize?
-    let metricsState: MetricsState
 
     let isStalled: Bool
 }
@@ -42,7 +40,6 @@ extension ItemProperties {
 
     func metrics() -> Metrics? {
         guard let item else { return nil }
-        let updatedState = metricsState.updated(with: item.accessLog(), at: item.currentTime())
-        return updatedState.metrics(from: metricsState)
+        return MetricsState(from: item).metrics(from: .empty)
     }
 }

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -39,7 +39,7 @@ extension ItemProperties {
     }
 
     func metrics() -> Metrics? {
-        guard let item else { return nil }
-        return MetricsState(from: item).metrics(from: .empty)
+        guard let item, let state = MetricsState(from: item) else { return nil }
+        return state.metrics(from: .empty)
     }
 }

--- a/Sources/Player/Types/PlayerProperties.swift
+++ b/Sources/Player/Types/PlayerProperties.swift
@@ -132,8 +132,10 @@ public extension PlayerProperties {
     /// The current player metrics, if available.
     ///
     /// Each call to this function might return different results reflecting the most recent metrics available. The
-    /// included ``Metrics/increment`` collates data from the most recent period of playback not interrupted by a
-    /// seek or variant switch.
+    /// included ``Metrics/increment`` collates data from the entire playback session and is therefore always equal
+    /// to ``Metrics/total``.
+    ///
+    /// > Important: Metrics are reset when toggling external playback.
     func metrics() -> Metrics? {
         coreProperties.metrics()
     }

--- a/Tests/PlayerTests/Metrics/MetricsStateTests.swift
+++ b/Tests/PlayerTests/Metrics/MetricsStateTests.swift
@@ -12,8 +12,7 @@ import Nimble
 final class MetricsStateTests: TestCase {
     // swiftlint:disable:next function_body_length
     func testMetrics() {
-        let initialState = MetricsState.empty
-        let state = initialState.updated(with: [
+        let state = MetricsState(with: [
             .init(
                 uri: "uri",
                 serverAddress: "serverAddress",
@@ -42,7 +41,7 @@ final class MetricsStateTests: TestCase {
             )
         ], at: .init(value: 12, timescale: 1))
 
-        let metrics = state.metrics(from: initialState)
+        let metrics = state.metrics(from: .empty)
         expect(metrics.playbackStartDate).to(equal(Date(timeIntervalSince1970: 1)))
         expect(metrics.time).to(equal(.init(value: 12, timescale: 1)))
         expect(metrics.uri).to(equal("uri"))


### PR DESCRIPTION
# Description

This PR fixes negative metrics increments when toggling AirPlay (external playback).

![negative-metrics](https://github.com/user-attachments/assets/dcd2a3c4-cadb-4b8c-b3ae-d214210bd259)

These occur because the `AVPlayerItemAccessLog` is cleared when transitioning between devices, leading to a decrease in totals and thus to negative increments.

Fixing this issue requires seing local and remote sessions as separate. We cannot namely reliably merge local and distant sessions, as this would require us to be able to capture the most recent `AVPlayerItemAccessLogEvent` values just before AirPlay is toggled. The issue is that we are often too late when we can detect that AirPlay has been toggled, so that we cannot capture most recent values, only new ones (empty just after the transition into / out of AirPlay).

# Changes made

- Make `MetricsState` construction simpler. We had inherited an update-based API from our many iterations, but this was not used at all.
- Remove cached metrics from `PlayerProperties`. Those were always calculated from scratch anyway.
- Clear metrics when toggling external playback.
- Remove `CombineLatest8` which is not needed anymore.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
