### PR TITLE
Remove Timelane

### DIFF
--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
       "state" : {
-        "revision" : "c2f74c7cc02f8bb01b51c08297f7cbc486f3ca65",
-        "version" : "6.12.3"
+        "revision" : "2d1cd9c0cb52ca76702023b528a059fc0a7d5a4d",
+        "version" : "6.13.0"
       }
     },
     {
@@ -61,24 +61,6 @@
       "state" : {
         "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
         "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "timelanecombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCombine.git",
-      "state" : {
-        "revision" : "e6837bcbb19332866d5e37d501c05d68fbf985f2",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "timelanecore",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCore",
-      "state" : {
-        "revision" : "c554d6d61be14bd7acb8b10161fe5d9dc20d7fbc",
-        "version" : "2.0.2"
       }
     }
   ],

--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -125,24 +125,6 @@
         "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
         "version" : "1.1.0"
       }
-    },
-    {
-      "identity" : "timelanecombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCombine",
-      "state" : {
-        "revision" : "e6837bcbb19332866d5e37d501c05d68fbf985f2",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "timelanecore",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCore",
-      "state" : {
-        "revision" : "c554d6d61be14bd7acb8b10161fe5d9dc20d7fbc",
-        "version" : "2.0.2"
-      }
     }
   ],
   "version" : 2

--- a/Package.resolved
+++ b/Package.resolved
@@ -62,24 +62,6 @@
         "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
         "version" : "1.1.2"
       }
-    },
-    {
-      "identity" : "timelanecombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCombine.git",
-      "state" : {
-        "revision" : "e6837bcbb19332866d5e37d501c05d68fbf985f2",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "timelanecore",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/icanzilb/TimelaneCore",
-      "state" : {
-        "revision" : "c554d6d61be14bd7acb8b10161fe5d9dc20d7fbc",
-        "version" : "2.0.2"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -39,8 +39,7 @@ let package = Package(
         .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0")),
-        .package(url: "https://github.com/icanzilb/TimelaneCombine.git", .upToNextMajor(from: "2.0.0"))
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0"))
     ],
     targets: [
         .target(
@@ -101,8 +100,7 @@ let package = Package(
             name: "PillarboxPlayer",
             dependencies: [
                 .target(name: "PillarboxCore"),
-                .product(name: "DequeModule", package: "swift-collections"),
-                .product(name: "TimelaneCombine", package: "TimelaneCombine")
+                .product(name: "DequeModule", package: "swift-collections")
             ],
             path: "Sources/Player",
             resources: [

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -9,7 +9,6 @@ import Combine
 import DequeModule
 import MediaPlayer
 import PillarboxCore
-import TimelaneCombine
 
 /// An observable audio / video player maintaining its items as a double-ended queue.
 public final class Player: ObservableObject, Equatable {
@@ -360,7 +359,6 @@ private extension Player {
         queuePublisher
             .slice(at: \.index)
             .receiveOnMainThread()
-            .lane("player_current_index")
             .assign(to: &$currentIndex)
     }
 

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -12,11 +12,9 @@ import PillarboxCore
 extension AVPlayerItem {
     func propertiesPublisher() -> AnyPublisher<PlayerItemProperties, Never> {
         Publishers.CombineLatest7(
-            statusPublisher()
-                .lane("player_item_status"),
+            statusPublisher(),
             publisher(for: \.presentationSize),
-            mediaSelectionPropertiesPublisher()
-                .lane("player_item_media_selection"),
+            mediaSelectionPropertiesPublisher(),
             timePropertiesPublisher(),
             publisher(for: \.duration),
             minimumTimeOffsetFromLivePublisher(),
@@ -66,8 +64,7 @@ extension AVPlayerItem {
     private func timePropertiesPublisher() -> AnyPublisher<TimeProperties, Never> {
         Publishers.CombineLatest3(
             publisher(for: \.loadedTimeRanges),
-            publisher(for: \.seekableTimeRanges)
-                .lane("player_item_seekable_time_ranges"),
+            publisher(for: \.seekableTimeRanges),
             publisher(for: \.isPlaybackLikelyToKeepUp)
         )
         .map { .init(loadedTimeRanges: $0, seekableTimeRanges: $1, isPlaybackLikelyToKeepUp: $2) }

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -119,10 +119,6 @@ Please ensure that the target an Xcode preview belongs to is selected before att
 
 We are currently using [cloud signing](https://developer.apple.com/wwdc21/10204) with automatic provisioning updates. Code signing requires access to our [internal configuration repository](https://github.com/SRGSSR/pillarbox-apple-configuration) which is automatically pulled when running `make setup`, provided you have been granted access to it.
 
-## Timelane
-
-The project supports instrumentation with [Timelane](https://timelane.tools). Simply follow the  instructions to install the dedicated instrument so that you can inspect player events directly within Instruments.
-
 ## Other resources
 
 SwiftUI view behavior is documented with the terminology introduced in the [following article](http://defagos.github.io/understanding_swiftui_layout_behaviors).


### PR DESCRIPTION
# Description

This PR removes Timelane. With the property publisher consolidation we made the tool is not as valuable as it was. We also have a [potentially related issue](https://github.com/SRGSSR/pillarbox-apple/issues/956), and having less 3rd party dependencies is always good.

# Changes made

- Remove Timelane.
- Update hidden package resolved files so that comScore and Commanders Act versions are consistent with other similar files.
- Update documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
