### PR TITLE
Update SwiftLint to version 0.56.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,7 @@ excluded:
 disabled_rules:
   - accessibility_label_for_image
   - conditional_returns_on_newline
+  - contrasted_opening_brace
   - discouraged_none_name
   - explicit_acl
   - explicit_enum_raw_value
@@ -28,6 +29,7 @@ disabled_rules:
   - multiple_closures_with_trailing_closure
   - nimble_operator
   - number_separator
+  - no_empty_block
   - no_extension_access_modifier
   - no_grouping_extension
   - no_magic_numbers
@@ -112,6 +114,7 @@ opt_in_rules:
   - override_in_extension
   - pattern_matching_keywords
   - period_spacing
+  - prefer_key_path
   - prefer_nimble
   - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self

--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,1 @@
-realm/SwiftLint@0.55.1
+realm/SwiftLint@0.56.1

--- a/Sources/Player/Player.docc/Articles/metrics/metrics-article.md
+++ b/Sources/Player/Player.docc/Articles/metrics/metrics-article.md
@@ -11,7 +11,7 @@ Inspect key metrics during playback.
 
 Providing the best playback experience to your users is crucial. This can prove to be challenging, especially since media playback involves many moving parts (stream encoding and packaging, metadata delivery, CDN, network quality), all possibly negatively impacting the end user experience in various ways.
 
-> Tip: More information about stream encoding and packaging please refer to <doc:stream-encoding-and-packaging-advice-article>.
+> Tip: For more information about stream encoding and packaging please refer to <doc:stream-encoding-and-packaging-advice-article>.
 
 To better understand how your playback experience is perceived by your users, you usually need to ask yourself:
 

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -10,7 +10,7 @@ import PillarboxCore
 extension PlayerItem {
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         $content
-            .first { $0.isLoaded }
+            .first(where: \.isLoaded)
             .measureDateInterval()
             .map { dateInterval in
                 MetricEvent(

--- a/Tests/PlayerTests/MediaSelection/AVMediaSelectionGroupTests.swift
+++ b/Tests/PlayerTests/MediaSelection/AVMediaSelectionGroupTests.swift
@@ -23,7 +23,7 @@ final class AVMediaSelectionGroupTests: TestCase {
                 from: options,
                 withMediaCharacteristics: [.describesMusicAndSoundForAccessibility]
             )
-            .map { $0.displayName }
+            .map(\.displayName)
             .sorted()
         )
         .to(equal([
@@ -46,7 +46,7 @@ final class AVMediaSelectionGroupTests: TestCase {
                 from: options,
                 withoutMediaCharacteristics: [.describesMusicAndSoundForAccessibility]
             )
-            .map { $0.displayName }
+            .map(\.displayName)
             .sorted()
         )
         .to(equal([

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -42,7 +42,7 @@ Token-protected content cannot be played on old Apple TV 3rd generation devices.
 
 No workaround is available yet.
 
-## Media type is unknown when playback is started after an AirPlay session has been established
+## Media type is unknown when playback is started after an AirPlay session has been established (FB5464600)
 
 The media type is `.unknown` if playback is started after an AirPlay session has been established. A correct value is delivered when AirPlay is enabled after playback has already been started, though.
 


### PR DESCRIPTION
# Description

This PR updates SwiftLint 0.56.1 and tweaks a few rules accordingly.

# Changes made

- Update SwiftLint.
- Enable `prefer_key_path` and perform associated code adjustments.
- Disable `no_empty_block` and `contrasted_opening_brace` explicitly.

Minor (unrelated) documentation improvements have been made as well:

- Fix typo in documentation.
- Add feedback number.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
