### PR TITLE
Deliver metadata with business errors

### DIFF
--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -34,14 +34,6 @@ final class DataProvider {
             .eraseToAnyPublisher()
     }
 
-    func mediaMetadataPublisher(forUrn urn: String) -> AnyPublisher<MediaMetadata, Error> {
-        mediaCompositionPublisher(forUrn: urn)
-            .tryMap { response in
-                try MediaMetadata(mediaCompositionResponse: response, dataProvider: self)
-            }
-            .eraseToAnyPublisher()
-    }
-
     func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
         server.resizedImageUrl(url, width: width)
     }

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -72,7 +72,7 @@ public struct Asset<M> {
             configuration: configuration
         )
     }
-    
+
     /// Returns an unavailable asset.
     ///
     /// - Parameters:

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -80,7 +80,7 @@ public struct Asset<M> {
     ///   - metadata: The metadata associated with the asset.
     /// - Returns: The asset
     ///
-    /// Return an unavailable asset when a business reason prevents the content from being played but metadata is
+    /// Use an unavailable asset when a business reason prevents the content from being played but metadata is
     /// nonetheless available.
     public static func unavailable(
         with error: Error,

--- a/Sources/Player/Asset.swift
+++ b/Sources/Player/Asset.swift
@@ -72,6 +72,26 @@ public struct Asset<M> {
             configuration: configuration
         )
     }
+    
+    /// Returns an unavailable asset.
+    ///
+    /// - Parameters:
+    ///   - error: The reason why the asset is not available.
+    ///   - metadata: The metadata associated with the asset.
+    /// - Returns: The asset
+    ///
+    /// Return an unavailable asset when a business reason prevents the content from being played but metadata is
+    /// nonetheless available.
+    public static func unavailable(
+        with error: Error,
+        metadata: M
+    ) -> Self {
+        .init(
+            resource: .failing(error: error),
+            metadata: metadata,
+            configuration: .default
+        )
+    }
 }
 
 public extension Asset where M == Void {

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -12,21 +12,14 @@ import XCTest
 final class DataProviderTests: XCTestCase {
     func testExistingMediaMetadata() {
         expectSuccess(
-            from: DataProvider().mediaMetadataPublisher(forUrn: "urn:rts:video:6820736")
+            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:6820736")
         )
     }
 
     func testNonExistingMediaMetadata() {
         expectFailure(
             DataError.http(withStatusCode: 404),
-            from: DataProvider().mediaMetadataPublisher(forUrn: "urn:rts:video:unknown")
-        )
-    }
-
-    func testBlockedMediaMetadata() {
-        expectFailure(
-            DataError.blocked(withMessage: ""),
-            from: DataProvider().mediaMetadataPublisher(forUrn: "urn:rts:video:13382911")
+            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:unknown")
         )
     }
 }


### PR DESCRIPTION
# Description

This PR makes it possible to deliver metadata event when a business error prevents playback. This makes it possible to create more engaging experiences in this case (e.g. display content information or thumbnail).

# Changes made

- Add asset type that carries both an error and metadata.
- The demo player layout was not updated. It is complicated enough already.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
