### PR TITLE
Avoid returning metrics for reserved items

### DIFF
--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -14,6 +14,13 @@ extension AVPlayerItem {
     }
 }
 
+extension AVPlayerItem: PlaybackResource {
+    func contains(url: URL) -> Bool {
+        guard let urlAsset = asset as? AVURLAsset else { return false }
+        return urlAsset.url == url
+    }
+}
+
 extension AVPlayerItem {
     /// Returns the list of `AVPlayerItems` to load into an `AVQueuePlayer` when a list of contents replaces a previous
     /// one.

--- a/Sources/Player/Extensions/URL.swift
+++ b/Sources/Player/Extensions/URL.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+extension URL {
+    // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
+    static let loading = URL(string: "pillarbox://loading.m3u8")!
+    static let failing = URL(string: "pillarbox://failing.m3u8")!
+}

--- a/Sources/Player/Interfaces/PlaybackResource.swift
+++ b/Sources/Player/Interfaces/PlaybackResource.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+protocol PlaybackResource {
+    func contains(url: URL) -> Bool
+}
+
+extension PlaybackResource {
+    var isLoadable: Bool {
+        !isLoading && !isFailing
+    }
+
+    var isFailing: Bool {
+        contains(url: .failing)
+    }
+
+    var isLoading: Bool {
+        contains(url: .loading)
+    }
+}

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -45,7 +45,7 @@ public extension Player {
             queuePlayer.publisher(for: \.isExternalPlaybackActive)
         )
         .map { [queuePlayer] item, _ -> AnyPublisher<[Metrics], Never> in
-            guard let item else { return Just([]).eraseToAnyPublisher() }
+            guard let item, item.isLoadable else { return Just([]).eraseToAnyPublisher() }
             return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
                 .compactMap { _ in MetricsState(from: item) }
                 .withPrevious(MetricsState.empty)

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -10,7 +10,7 @@ import PillarboxCore
 extension PlayerItem {
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         $content
-            .first(where: \.isLoaded)
+            .first(where: \.resource.isLoadable)
             .measureDateInterval()
             .map { dateInterval in
                 MetricEvent(

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -17,23 +17,6 @@ enum Resource {
 
     private static let logger = Logger(category: "Resource")
 
-    var isFailing: Bool {
-        containsUrl(Self.failingUrl)
-    }
-
-    var isLoading: Bool {
-        containsUrl(Self.loadingUrl)
-    }
-
-    private func containsUrl(_ containedUrl: URL) -> Bool {
-        switch self {
-        case let .custom(url: url, _) where url == containedUrl:
-            true
-        default:
-            false
-        }
-    }
-
     func playerItem() -> AVPlayerItem {
         switch self {
         case let .simple(url: url):
@@ -58,15 +41,22 @@ enum Resource {
     }
 }
 
-extension Resource {
-    // Provide a playlist extension so that resource loader errors are correctly forwarded through the resource loader.
-    static let loadingUrl = URL(string: "pillarbox://loading.m3u8")!
-    static let failingUrl = URL(string: "pillarbox://failing.m3u8")!
+extension Resource: PlaybackResource {
+    func contains(url: URL) -> Bool {
+        switch self {
+        case let .custom(url: customUrl, _) where customUrl == url:
+            true
+        default:
+            false
+        }
+    }
+}
 
-    static let loading = Self.custom(url: loadingUrl, delegate: LoadingResourceLoaderDelegate())
+extension Resource {
+    static let loading = Self.custom(url: .loading, delegate: LoadingResourceLoaderDelegate())
 
     static func failing(error: Error) -> Self {
-        .custom(url: failingUrl, delegate: FailedResourceLoaderDelegate(error: error))
+        .custom(url: .failing, delegate: FailedResourceLoaderDelegate(error: error))
     }
 }
 

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -13,10 +13,6 @@ struct AssetContent {
     let metadata: PlayerMetadata
     let configuration: PlayerItemConfiguration
 
-    var isLoaded: Bool {
-        !resource.isLoading && !resource.isFailing
-    }
-
     static func loading(id: UUID) -> Self {
         .init(id: id, resource: .loading, metadata: .empty, configuration: .default)
     }

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -39,7 +39,7 @@ extension ItemProperties {
     }
 
     func metrics() -> Metrics? {
-        guard let item, let state = MetricsState(from: item) else { return nil }
+        guard let item, item.isLoadable, let state = MetricsState(from: item) else { return nil }
         return state.metrics(from: .empty)
     }
 }

--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -78,4 +78,9 @@ final class PlayerTests: TestCase {
         expect(player.items.map(\.content.resource)).toEventually(beSimilarTo(expectedResources))
         expect(player.items.map(\.content.resource)).toAlways(beSimilarTo(expectedResources), until: .seconds(1))
     }
+
+    func testNoMetricsWhenFailed() {
+        let player = Player(item: .failing(loadedAfter: 0.1))
+        expect(player.properties.metrics()).toAlways(beNil(), until: .seconds(1))
+    }
 }

--- a/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PeriodicMetricsPublisherTests.swift
@@ -13,11 +13,11 @@ import PillarboxStreams
 final class PeriodicMetricsPublisherTests: TestCase {
     func testEmpty() {
         let player = Player()
-            expectEqualPublished(
-                values: [0],
-                from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count),
-                during: .seconds(1)
-            )
+        expectEqualPublished(
+            values: [0],
+            from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count),
+            during: .seconds(1)
+        )
     }
 
     func testPlayback() {
@@ -58,5 +58,15 @@ final class PeriodicMetricsPublisherTests: TestCase {
         ) {
             player.play()
         }
+    }
+
+    func testFailure() {
+        let item = PlayerItem.failing(loadedAfter: 0.1)
+        let player = Player(item: item)
+        expectEqualPublished(
+            values: [0],
+            from: player.periodicMetricsPublisher(forInterval: .init(value: 1, timescale: 4)).map(\.count),
+            during: .seconds(1)
+        )
     }
 }


### PR DESCRIPTION
# Description

This PR avoids returning meaningless metrics when the player current item is a loading or failing item:

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/18a1be03-a94f-4c73-9921-78c82df0f17b) | ![after](https://github.com/user-attachments/assets/f068beef-7bfe-477f-9714-44b23b67feae) | 

# Changes made

Self-explanatory. Note that metrics might still be returned for items with a valid non-reserved URL but failing to play.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
