### PR TITLE
Improve metric event name consistency

### DIFF
--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -71,7 +71,7 @@ private struct StartupTimesSectionContent: View {
     private var metadataInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .metadataReady(interval):
+            case let .metadata(interval):
                 return interval.duration
             default:
                 return nil
@@ -82,7 +82,7 @@ private struct StartupTimesSectionContent: View {
     private var assetInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .assetReady(interval):
+            case let .asset(interval):
                 return interval.duration
             default:
                 return nil

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -46,7 +46,7 @@ public final class MetricsTracker: PlayerItemTracker {
     // swiftlint:disable:next cyclomatic_complexity
     public func updateMetricEvents(to events: [MetricEvent]) {
         switch events.last?.kind {
-        case .assetReady:
+        case .asset:
             session.start()
             sendEvent(name: .start, data: startData(from: events))
             startHeartbeat()

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -73,7 +73,7 @@ extension MetricStartData {
 private extension MetricStartData.QualityOfExperienceMetrics {
     static func metadata(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .metadataReady(dateInterval):
+        case let .metadata(dateInterval):
             return dateInterval.duration.toMilliseconds
         default:
             return nil
@@ -82,7 +82,7 @@ private extension MetricStartData.QualityOfExperienceMetrics {
 
     static func asset(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .assetReady(dateInterval):
+        case let .asset(dateInterval):
             return dateInterval.duration.toMilliseconds
         default:
             return nil

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -11,17 +11,17 @@ import Foundation
 public struct MetricEvent: Hashable {
     /// A kind of metric event.
     public enum Kind {
-        /// Metadata is ready.
+        /// Metadata is available.
         ///
         /// The date interval corresponding to the process is provided as associated value. Note that this interval
         /// measures the perceived user experience and might be empty in the event of preloading.
-        case metadataReady(DateInterval)
+        case metadata(DateInterval)
 
-        /// The asset is ready.
+        /// The asset is ready to play.
         ///
         /// The date interval corresponding to the process is provided as associated value. Note that this interval
         /// measures the perceived user experience and might be empty in the event of preloading.
-        case assetReady(DateInterval)
+        case asset(DateInterval)
 
         /// Failure.
         case failure(Error)
@@ -52,9 +52,9 @@ public struct MetricEvent: Hashable {
     /// The event duration.
     public var duration: TimeInterval {
         switch kind {
-        case let .metadataReady(dateInterval):
+        case let .metadata(dateInterval):
             return dateInterval.duration
-        case let .assetReady(dateInterval):
+        case let .asset(dateInterval):
             return dateInterval.duration
         default:
             return 0
@@ -79,10 +79,10 @@ public struct MetricEvent: Hashable {
 extension MetricEvent.Kind: CustomStringConvertible {
     public var description: String {
         switch self {
-        case let .metadataReady(dateInterval):
-            return "Metadata ready in \(Self.duration(from: dateInterval.duration))"
-        case let .assetReady(dateInterval):
-            return "Asset ready in \(Self.duration(from: dateInterval.duration))"
+        case let .metadata(dateInterval):
+            return "Metadata: \(Self.duration(from: dateInterval.duration))"
+        case let .asset(dateInterval):
+            return "Asset: \(Self.duration(from: dateInterval.duration))"
         case let .failure(error):
             return "Failure: \(error.localizedDescription)"
         case let .warning(error):

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -203,7 +203,7 @@ extension AVPlayerItem {
 extension AVPlayerItem {
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         Publishers.Merge4(
-            assetReadyMetricEventPublisher(),
+            assetMetricEventPublisher(),
             failureMetricEventPublisher(),
             warningMetricEventPublisher(),
             stallEventPublisher()
@@ -211,14 +211,14 @@ extension AVPlayerItem {
         .eraseToAnyPublisher()
     }
 
-    func assetReadyMetricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
+    func assetMetricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         publisher(for: \.isPlaybackLikelyToKeepUp)
             .first { $0 }
             .measureDateInterval()
             .weakCapture(self)
             .map { dateInterval, item in
                 MetricEvent(
-                    kind: .assetReady(dateInterval),
+                    kind: .asset(dateInterval),
                     date: dateInterval.end,
                     time: item.currentTime()
                 )

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -14,7 +14,7 @@ extension PlayerItem {
             .measureDateInterval()
             .map { dateInterval in
                 MetricEvent(
-                    kind: .metadataReady(dateInterval),
+                    kind: .metadata(dateInterval),
                     date: dateInterval.end
                 )
             }

--- a/Tests/PlayerTests/Extensions/MetricEvent.swift
+++ b/Tests/PlayerTests/Extensions/MetricEvent.swift
@@ -9,8 +9,8 @@
 private struct AnyError: Error {}
 
 extension MetricEvent {
-    static let anyMetadataReady = Self(kind: .metadataReady(.init()))
-    static let anyAssetReady = Self(kind: .assetReady(.init()))
+    static let anyMetadata = Self(kind: .metadata(.init()))
+    static let anyAsset = Self(kind: .asset(.init()))
     static let anyFailure = Self(kind: .failure(AnyError()))
     static let anyWarning = Self(kind: .warning(AnyError()))
 }

--- a/Tests/PlayerTests/Publishers/AVPlayerItemMetricEventPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/AVPlayerItemMetricEventPublisherTests.swift
@@ -10,19 +10,19 @@ import AVFoundation
 import PillarboxStreams
 
 final class AVPlayerItemMetricEventPublisherTests: TestCase {
-    func testPlayableItemAssetReadyMetricEvent() {
+    func testPlayableItemAssetMetricEvent() {
         let item = AVPlayerItem(url: Stream.onDemand.url)
         _ = AVPlayer(playerItem: item)
         expectOnlySimilarPublished(
-            values: [.anyAssetReady],
-            from: item.assetReadyMetricEventPublisher()
+            values: [.anyAsset],
+            from: item.assetMetricEventPublisher()
         )
     }
 
-    func testFailingItemAssetReadyMetricEvent() {
+    func testFailingItemAssetMetricEvent() {
         let item = AVPlayerItem(url: Stream.unavailable.url)
         _ = AVPlayer(playerItem: item)
-        expectNothingPublished(from: item.assetReadyMetricEventPublisher(), during: .milliseconds(500))
+        expectNothingPublished(from: item.assetMetricEventPublisher(), during: .milliseconds(500))
     }
 
     func testPlayableItemFailureMetricEvent() {

--- a/Tests/PlayerTests/Publishers/PlayerItemMetricEventPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PlayerItemMetricEventPublisherTests.swift
@@ -12,7 +12,7 @@ final class PlayerItemMetricEventPublisherTests: TestCase {
     func testPlayableItemMetricEvent() {
         let item = PlayerItem.mock(url: Stream.onDemand.url, loadedAfter: 0.1)
         expectOnlySimilarPublished(
-            values: [.anyMetadataReady],
+            values: [.anyMetadata],
             from: item.metricEventPublisher()
         ) {
             PlayerItem.load(for: item.id)

--- a/Tests/PlayerTests/Tools/Similarity.swift
+++ b/Tests/PlayerTests/Tools/Similarity.swift
@@ -48,7 +48,7 @@ extension NowPlaying.Info: Similar {
 extension MetricEvent: Similar {
     public static func ~~ (lhs: MetricEvent, rhs: MetricEvent) -> Bool {
         switch (lhs.kind, rhs.kind) {
-        case (.metadataReady, .metadataReady), (.assetReady, .assetReady), (.failure, .failure), (.warning, .warning):
+        case (.metadata, .metadata), (.asset, .asset), (.failure, .failure), (.warning, .warning):
             return true
         default:
             return false

--- a/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
@@ -20,8 +20,8 @@ final class PlayerItemTrackerMetricPublisherTests: TestCase {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
         expectAtLeastSimilarPublished(values: [
             [],
-            [.anyMetadataReady],
-            [.anyMetadataReady, .anyAssetReady],
+            [.anyMetadata],
+            [.anyMetadata, .anyAsset],
             []
         ], from: player.metricEventsPublisher) {
             player.play()
@@ -32,8 +32,8 @@ final class PlayerItemTrackerMetricPublisherTests: TestCase {
         let player = Player(item: .simple(url: Stream.unavailable.url))
         expectAtLeastSimilarPublished(values: [
             [],
-            [.anyMetadataReady],
-            [.anyMetadataReady, .anyFailure]
+            [.anyMetadata],
+            [.anyMetadata, .anyFailure]
         ], from: player.metricEventsPublisher)
     }
 
@@ -42,9 +42,9 @@ final class PlayerItemTrackerMetricPublisherTests: TestCase {
         expectSimilarPublished(
             values: [
                 [],
-                [.anyMetadataReady],
-                [.anyMetadataReady, .anyAssetReady],
-                [.anyMetadataReady, .anyAssetReady]
+                [.anyMetadata],
+                [.anyMetadata, .anyAsset],
+                [.anyMetadata, .anyAsset]
             ],
             from: player.metricEventsPublisher,
             during: .seconds(2)


### PR DESCRIPTION
# Description

This PR again iterates on `MetricEvent` naming. It is likely enough to use the noun indicating what the event is about to have a more consistent result.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
