### PR TITLE
Fix missing comScore labels when replaying content

### DIFF
--- a/Sources/Analytics/ComScore/Capture/ComScoreLabels.swift
+++ b/Sources/Analytics/ComScore/Capture/ComScoreLabels.swift
@@ -8,7 +8,8 @@
 ///
 /// Mainly used for development-oriented purposes (e.g. unit testing).
 public struct ComScoreLabels {
-    let dictionary: [String: String]
+    /// The raw label dictionary.
+    public let dictionary: [String: String]
 
     var listener_session_id: String? {
         extract()

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -25,7 +25,7 @@ public final class ComScoreTracker: PlayerItemTracker {
 
     public func updateMetadata(to metadata: [String: String]) {
         self.metadata = metadata
-        addMetadata(metadata)
+        setMetadata(metadata)
     }
 
     public func updateProperties(to properties: PlayerProperties) {
@@ -61,9 +61,10 @@ private extension ComScoreTracker {
         streamingAnalytics.createPlaybackSession()
         streamingAnalytics.setMediaPlayerName("Pillarbox")
         streamingAnalytics.setMediaPlayerVersion(Player.version)
+        setMetadata(metadata)
     }
 
-    func addMetadata(_ metadata: [String: String]) {
+    func setMetadata(_ metadata: [String: String]) {
         let builder = SCORStreamingContentMetadataBuilder()
         if let globals = Analytics.shared.comScoreGlobals {
             builder.setCustomLabels(metadata.merging(globals.labels) { _, new in new })

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -205,4 +205,33 @@ final class ComScoreTrackerTests: ComScoreTestCase {
             player.play()
         }
     }
+
+    func testReplay() {
+        let player = Player(item: .simple(
+            url: Stream.shortOnDemand.url,
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in .test }
+            ]
+        ))
+        var ns_st_id: String?
+        expectAtLeastHits(
+            play { labels in
+                expect(labels["media_title"]).to(equal("name"))
+                expect(labels.ns_st_id).notTo(beNil())
+                ns_st_id = labels.ns_st_id
+            },
+            end()
+        ) {
+            player.play()
+        }
+        expectAtLeastHits(
+            play { labels in
+                expect(labels["media_title"]).to(equal("name"))
+                expect(labels.ns_st_id).notTo(beNil())
+                expect(labels.ns_st_id).notTo(equal(ns_st_id))
+            }
+        ) {
+            player.replay()
+        }
+    }
 }


### PR DESCRIPTION
# Description

This PR fixes an issue affecting comScore streaming events when replaying content. Metadata was incorrectly missing after replaying the content.

# Changes made

- Fix aforementioned issue.
- Expose raw comScore label dictionary in hits (cannot be made for Commanders Act since parsed from JSON). This provides access to other labels, making it possible to test the issue that was reported.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
