### PR TITLE
Fix incorrect metadata timings after recovering from failure

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -267,7 +267,10 @@
     "Stalls" : {
 
     },
-    "Startup times" : {
+    "Startup times (QoE)" : {
+
+    },
+    "Startup times (QoS)" : {
 
     },
     "Stop" : {

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -82,8 +82,8 @@ private struct ExperienceStartupTimesSectionContent: View {
     private var assetInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .asset(experience: qoe):
-                return qoe.duration
+            case let .asset(experience: experience):
+                return experience.duration
             default:
                 return nil
             }

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -82,8 +82,8 @@ private struct StartupTimesQoeSectionContent: View {
     private var assetInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .asset(interval):
-                return interval.duration
+            case let .asset(qoe: qoe):
+                return qoe.duration
             default:
                 return nil
             }

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -71,8 +71,9 @@ private struct StartupTimesSectionContent: View {
     private var metadataInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .metadata(interval):
-                return interval.duration
+            case let .metadata(qoe: qoe, qos: qos):
+                // FIXME:
+                return qos.duration
             default:
                 return nil
             }

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -59,7 +59,7 @@ private struct InformationSectionContent: View {
     }
 }
 
-private struct StartupTimesQoeSectionContent: View {
+private struct ExperienceStartupTimesSectionContent: View {
     let metricEvents: [MetricEvent]
 
     var body: some View {
@@ -71,8 +71,8 @@ private struct StartupTimesQoeSectionContent: View {
     private var metadataInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .metadata(qoe: qoe, qos: _):
-                return qoe.duration
+            case let .metadata(experience: experience, service: _):
+                return experience.duration
             default:
                 return nil
             }
@@ -82,7 +82,7 @@ private struct StartupTimesQoeSectionContent: View {
     private var assetInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .asset(qoe: qoe):
+            case let .asset(experience: qoe):
                 return qoe.duration
             default:
                 return nil
@@ -118,7 +118,7 @@ private struct StartupTimesQoeSectionContent: View {
     }
 }
 
-private struct StartupTimesQosSectionContent: View {
+private struct ServiceStartupTimesSectionContent: View {
     let metricEvents: [MetricEvent]
 
     var body: some View {
@@ -128,8 +128,8 @@ private struct StartupTimesQosSectionContent: View {
     private var metadataInterval: TimeInterval? {
         metricEvents.compactMap { event in
             switch event.kind {
-            case let .metadata(qoe: _, qos: qos):
-                return qos.duration
+            case let .metadata(experience: _, service: service):
+                return service.duration
             default:
                 return nil
             }
@@ -179,8 +179,8 @@ struct MetricsView: View {
 
     private func list() -> some View {
         List {
-            startupTimesQoeSection()
-            startupTimesQosSection()
+            experienceStartupTimesSection()
+            serviceStartupTimesSection()
             trackingSection()
             if !metricsCollector.metrics.isEmpty {
                 informationSection()
@@ -196,18 +196,18 @@ struct MetricsView: View {
     }
 
     @ViewBuilder
-    private func startupTimesQoeSection() -> some View {
+    private func experienceStartupTimesSection() -> some View {
         Section {
-            StartupTimesQoeSectionContent(metricEvents: metricsCollector.metricEvents)
+            ExperienceStartupTimesSectionContent(metricEvents: metricsCollector.metricEvents)
         } header: {
             Text("Startup times (QoE)")
         }
     }
 
     @ViewBuilder
-    private func startupTimesQosSection() -> some View {
+    private func serviceStartupTimesSection() -> some View {
         Section {
-            StartupTimesQosSectionContent(metricEvents: metricsCollector.metricEvents)
+            ServiceStartupTimesSectionContent(metricEvents: metricsCollector.metricEvents)
         } header: {
             Text("Startup times (QoS)")
         }

--- a/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
+++ b/Sources/Circumspect/Expectations/ExpectOnlyPublished.swift
@@ -164,7 +164,7 @@ public extension XCTestCase {
             line: line,
             while: executing
         ) else {
-            XCTFail("No values were produced", file: file, line: line)
+            XCTFail("The publisher never completed", file: file, line: line)
             return
         }
 

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -138,7 +138,8 @@ private extension MetricsTracker {
                 metadataUrl: metadata?.metadataUrl,
                 origin: Bundle.main.bundleIdentifier
             ),
-            qoeMetrics: .init(events: events)
+            qoeMetrics: .init(events: events),
+            qosMetrics: .init(events: events)
         )
     }
 

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -73,8 +73,8 @@ extension MetricStartData {
 private extension MetricStartData.QualityOfExperienceMetrics {
     static func metadata(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .metadata(dateInterval):
-            return dateInterval.duration.toMilliseconds
+        case let .metadata(qoe: qoe, qos: _):
+            return qoe.duration.toMilliseconds
         default:
             return nil
         }

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -82,8 +82,8 @@ private extension MetricStartData.QualityOfExperienceMetrics {
 
     static func asset(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .asset(dateInterval):
-            return dateInterval.duration.toMilliseconds
+        case let .asset(qoe: qoe):
+            return qoe.duration.toMilliseconds
         default:
             return nil
         }

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -73,7 +73,7 @@ extension MetricStartData {
 private extension MetricStartData.QualityOfExperienceMetrics {
     static func metadata(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .metadata(qoe: qoe, qos: _):
+        case let .metadata(experience: qoe, service: _):
             return qoe.duration.toMilliseconds
         default:
             return nil
@@ -82,8 +82,8 @@ private extension MetricStartData.QualityOfExperienceMetrics {
 
     static func asset(from event: MetricEvent) -> Int? {
         switch event.kind {
-        case let .asset(qoe: qoe):
-            return qoe.duration.toMilliseconds
+        case let .asset(experience: experience):
+            return experience.duration.toMilliseconds
         default:
             return nil
         }

--- a/Sources/Player/Interfaces/PlaybackResource.swift
+++ b/Sources/Player/Interfaces/PlaybackResource.swift
@@ -11,7 +11,7 @@ protocol PlaybackResource {
 }
 
 extension PlaybackResource {
-    var isLoadable: Bool {
+    var isLoaded: Bool {
         !isLoading && !isFailing
     }
 

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -12,9 +12,15 @@ public struct MetricEvent: Hashable {
     /// A kind of metric event.
     public enum Kind {
         /// Metadata is available.
+        ///
+        /// Two associated date intervals are provided, respectively measuring when metadata retrieval started / ended from
+        /// an end-user or from a technical perspective.
         case metadata(experience: DateInterval, service: DateInterval)
 
         /// The asset is ready to play.
+        ///
+        /// An associated date interval is provided, measuring when asset retrieval started / ended from an end-user
+        /// perspective.
         case asset(experience: DateInterval)
 
         /// Failure.

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -21,7 +21,7 @@ public struct MetricEvent: Hashable {
         ///
         /// The date interval corresponding to the process is provided as associated value. Note that this interval
         /// measures the perceived user experience and might be empty in the event of preloading.
-        case asset(DateInterval)
+        case asset(qoe: DateInterval)
 
         /// Failure.
         case failure(Error)
@@ -69,7 +69,7 @@ extension MetricEvent.Kind: CustomStringConvertible {
         switch self {
         case let .metadata(qoe: qoe, qos: qos):
             return "Metadata: qoe = \(Self.duration(from: qoe.duration)), qos = \(Self.duration(from: qos.duration))"
-        case let .asset(dateInterval):
+        case let .asset(qoe: dateInterval):
             return "Asset: \(Self.duration(from: dateInterval.duration))"
         case let .failure(error):
             return "Failure: \(error.localizedDescription)"

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -12,16 +12,10 @@ public struct MetricEvent: Hashable {
     /// A kind of metric event.
     public enum Kind {
         /// Metadata is available.
-        ///
-        /// The date interval corresponding to the process is provided as associated value. Note that this interval
-        /// measures the perceived user experience and might be empty in the event of preloading.
-        case metadata(qoe: DateInterval, qos: DateInterval)
+        case metadata(experience: DateInterval, service: DateInterval)
 
         /// The asset is ready to play.
-        ///
-        /// The date interval corresponding to the process is provided as associated value. Note that this interval
-        /// measures the perceived user experience and might be empty in the event of preloading.
-        case asset(qoe: DateInterval)
+        case asset(experience: DateInterval)
 
         /// Failure.
         case failure(Error)
@@ -67,10 +61,10 @@ public struct MetricEvent: Hashable {
 extension MetricEvent.Kind: CustomStringConvertible {
     public var description: String {
         switch self {
-        case let .metadata(qoe: qoe, qos: qos):
-            return "Metadata: qoe = \(Self.duration(from: qoe.duration)), qos = \(Self.duration(from: qos.duration))"
-        case let .asset(qoe: dateInterval):
-            return "Asset: \(Self.duration(from: dateInterval.duration))"
+        case let .metadata(experience: experience, service: service):
+            return "Metadata: \(Self.duration(from: experience.duration)) (experience), \(Self.duration(from: service.duration)) (service)"
+        case let .asset(experience: experience):
+            return "Asset: \(Self.duration(from: experience.duration)) (experience)"
         case let .failure(error):
             return "Failure: \(error.localizedDescription)"
         case let .warning(error):

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -15,7 +15,7 @@ public struct MetricEvent: Hashable {
         ///
         /// The date interval corresponding to the process is provided as associated value. Note that this interval
         /// measures the perceived user experience and might be empty in the event of preloading.
-        case metadata(DateInterval)
+        case metadata(qoe: DateInterval, qos: DateInterval)
 
         /// The asset is ready to play.
         ///
@@ -49,18 +49,6 @@ public struct MetricEvent: Hashable {
     /// Might be `.invalid`.
     public let time: CMTime
 
-    /// The event duration.
-    public var duration: TimeInterval {
-        switch kind {
-        case let .metadata(dateInterval):
-            return dateInterval.duration
-        case let .asset(dateInterval):
-            return dateInterval.duration
-        default:
-            return 0
-        }
-    }
-
     init(kind: Kind, date: Date = .init(), time: CMTime = .invalid) {
         self.kind = kind
         self.date = date
@@ -79,8 +67,8 @@ public struct MetricEvent: Hashable {
 extension MetricEvent.Kind: CustomStringConvertible {
     public var description: String {
         switch self {
-        case let .metadata(dateInterval):
-            return "Metadata: \(Self.duration(from: dateInterval.duration))"
+        case let .metadata(qoe: qoe, qos: qos):
+            return "Metadata: qoe = \(Self.duration(from: qoe.duration)), qos = \(Self.duration(from: qos.duration))"
         case let .asset(dateInterval):
             return "Asset: \(Self.duration(from: dateInterval.duration))"
         case let .failure(error):

--- a/Sources/Player/Player+Metrics.swift
+++ b/Sources/Player/Player+Metrics.swift
@@ -45,7 +45,7 @@ public extension Player {
             queuePlayer.publisher(for: \.isExternalPlaybackActive)
         )
         .map { [queuePlayer] item, _ -> AnyPublisher<[Metrics], Never> in
-            guard let item, item.isLoadable else { return Just([]).eraseToAnyPublisher() }
+            guard let item, item.isLoaded else { return Just([]).eraseToAnyPublisher() }
             return Publishers.PeriodicTimePublisher(for: queuePlayer, interval: interval, queue: kMetricsQueue)
                 .compactMap { _ in MetricsState(from: item) }
                 .withPrevious(MetricsState.empty)

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -130,7 +130,7 @@ public final class PlayerItem: Hashable {
             }
             .switchToLatest()
             .map { asset, metadata, dateInterval in
-                return AssetContent(
+                AssetContent(
                     id: id,
                     resource: asset.resource,
                     metadata: metadata,

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -218,7 +218,7 @@ extension AVPlayerItem {
             .weakCapture(self)
             .map { dateInterval, item in
                 MetricEvent(
-                    kind: .asset(qoe: dateInterval),
+                    kind: .asset(experience: dateInterval),
                     date: dateInterval.end,
                     time: item.currentTime()
                 )

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -218,7 +218,7 @@ extension AVPlayerItem {
             .weakCapture(self)
             .map { dateInterval, item in
                 MetricEvent(
-                    kind: .asset(dateInterval),
+                    kind: .asset(qoe: dateInterval),
                     date: dateInterval.end,
                     time: item.currentTime()
                 )

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -5,19 +5,35 @@
 //
 
 import Combine
+import Foundation
 import PillarboxCore
 
 extension PlayerItem {
+    static func qoeDateInterval(forQosDateInterval qosDateInterval: DateInterval, startDate: Date) -> DateInterval {
+        if startDate < qosDateInterval.end {
+            return .init(start: startDate, end: qosDateInterval.end)
+        }
+        else {
+            return .init(start: startDate, duration: 0)
+        }
+    }
+
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
-        $content
-            .compactMap(\.dateInterval)
-            .removeDuplicates()
-            .map { dateInterval in
-                MetricEvent(
-                    kind: .metadata(dateInterval),
-                    date: dateInterval.end
-                )
-            }
-            .eraseToAnyPublisher()
+        Publishers.CombineLatest(
+            $content
+                .compactMap(\.dateInterval)
+                .removeDuplicates(),
+            Just(Date())
+        )
+        .map { dateInterval, startDate in
+            return MetricEvent(
+                kind: .metadata(
+                    qoe: Self.qoeDateInterval(forQosDateInterval: dateInterval, startDate: startDate),
+                    qos: dateInterval
+                ),
+                date: dateInterval.end
+            )
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -10,8 +10,8 @@ import PillarboxCore
 extension PlayerItem {
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         $content
-            .first(where: \.resource.isLoadable)
-            .measureDateInterval()
+            .compactMap(\.dateInterval)
+            .removeDuplicates()
             .map { dateInterval in
                 MetricEvent(
                     kind: .metadata(dateInterval),

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -26,7 +26,7 @@ extension PlayerItem {
             Just(Date())
         )
         .map { dateInterval, startDate in
-            return MetricEvent(
+            MetricEvent(
                 kind: .metadata(
                     experience: Self.experience(forService: dateInterval, startDate: startDate),
                     service: dateInterval

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -9,9 +9,9 @@ import Foundation
 import PillarboxCore
 
 extension PlayerItem {
-    static func qoeDateInterval(forQosDateInterval qosDateInterval: DateInterval, startDate: Date) -> DateInterval {
-        if startDate < qosDateInterval.end {
-            return .init(start: startDate, end: qosDateInterval.end)
+    private static func experience(forService service: DateInterval, startDate: Date) -> DateInterval {
+        if startDate < service.end {
+            return .init(start: startDate, end: service.end)
         }
         else {
             return .init(start: startDate, duration: 0)
@@ -28,8 +28,8 @@ extension PlayerItem {
         .map { dateInterval, startDate in
             return MetricEvent(
                 kind: .metadata(
-                    qoe: Self.qoeDateInterval(forQosDateInterval: dateInterval, startDate: startDate),
-                    qos: dateInterval
+                    experience: Self.experience(forService: dateInterval, startDate: startDate),
+                    service: dateInterval
                 ),
                 date: dateInterval.end
             )

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -12,13 +12,14 @@ struct AssetContent {
     let resource: Resource
     let metadata: PlayerMetadata
     let configuration: PlayerItemConfiguration
+    let dateInterval: DateInterval?
 
     static func loading(id: UUID) -> Self {
-        .init(id: id, resource: .loading, metadata: .empty, configuration: .default)
+        .init(id: id, resource: .loading, metadata: .empty, configuration: .default, dateInterval: nil)
     }
 
     static func failing(id: UUID, error: Error) -> Self {
-        .init(id: id, resource: .failing(error: error), metadata: .empty, configuration: .default)
+        .init(id: id, resource: .failing(error: error), metadata: .empty, configuration: .default, dateInterval: nil)
     }
 
     func update(item: AVPlayerItem) {

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -39,7 +39,7 @@ extension ItemProperties {
     }
 
     func metrics() -> Metrics? {
-        guard let item, item.isLoadable, let state = MetricsState(from: item) else { return nil }
+        guard let item, item.isLoaded, let state = MetricsState(from: item) else { return nil }
         return state.metrics(from: .empty)
     }
 }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
@@ -167,7 +167,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
 
 private extension AssetContent {
     static func test(id: Character) -> Self {
-        AssetContent(id: UUID(id), resource: .simple(url: Stream.onDemand.url), metadata: .empty, configuration: .default)
+        AssetContent(
+            id: UUID(id),
+            resource: .simple(url: Stream.onDemand.url),
+            metadata: .empty,
+            configuration: .default,
+            dateInterval: nil
+        )
     }
 }
 

--- a/Tests/PlayerTests/Extensions/MetricEvent.swift
+++ b/Tests/PlayerTests/Extensions/MetricEvent.swift
@@ -9,7 +9,7 @@
 private struct AnyError: Error {}
 
 extension MetricEvent {
-    static let anyMetadata = Self(kind: .metadata(.init()))
+    static let anyMetadata = Self(kind: .metadata(qoe: .init(), qos: .init()))
     static let anyAsset = Self(kind: .asset(.init()))
     static let anyFailure = Self(kind: .failure(AnyError()))
     static let anyWarning = Self(kind: .warning(AnyError()))

--- a/Tests/PlayerTests/Extensions/MetricEvent.swift
+++ b/Tests/PlayerTests/Extensions/MetricEvent.swift
@@ -9,8 +9,8 @@
 private struct AnyError: Error {}
 
 extension MetricEvent {
-    static let anyMetadata = Self(kind: .metadata(qoe: .init(), qos: .init()))
-    static let anyAsset = Self(kind: .asset(qoe: .init()))
+    static let anyMetadata = Self(kind: .metadata(experience: .init(), service: .init()))
+    static let anyAsset = Self(kind: .asset(experience: .init()))
     static let anyFailure = Self(kind: .failure(AnyError()))
     static let anyWarning = Self(kind: .warning(AnyError()))
 }

--- a/Tests/PlayerTests/Extensions/MetricEvent.swift
+++ b/Tests/PlayerTests/Extensions/MetricEvent.swift
@@ -10,7 +10,7 @@ private struct AnyError: Error {}
 
 extension MetricEvent {
     static let anyMetadata = Self(kind: .metadata(qoe: .init(), qos: .init()))
-    static let anyAsset = Self(kind: .asset(.init()))
+    static let anyAsset = Self(kind: .asset(qoe: .init()))
     static let anyFailure = Self(kind: .failure(AnyError()))
     static let anyWarning = Self(kind: .warning(AnyError()))
 }

--- a/Tests/PlayerTests/Publishers/PlayerItemMetricEventPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PlayerItemMetricEventPublisherTests.swift
@@ -11,7 +11,7 @@ import PillarboxStreams
 final class PlayerItemMetricEventPublisherTests: TestCase {
     func testPlayableItemMetricEvent() {
         let item = PlayerItem.mock(url: Stream.onDemand.url, loadedAfter: 0.1)
-        expectOnlySimilarPublished(
+        expectAtLeastSimilarPublished(
             values: [.anyMetadata],
             from: item.metricEventPublisher()
         ) {

--- a/Tests/PlayerTests/Publishers/PlayerPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/PlayerPublisherTests.swift
@@ -57,7 +57,7 @@ final class PlayerPublisherTests: TestCase {
         expectEqualPublished(
             values: [true, false],
             from: Self.bufferingPublisher(for: player),
-            during: .milliseconds(500)
+            during: .seconds(1)
         )
     }
 


### PR DESCRIPTION
# Description

This PR fixes incorrect measurements after failure. This also allowed us to properly measure metadata timings for QoE and QoS purposes at the same time. 

# Changes made

- Measure metadata QoS and QoE timings.
- Provide QoS timings in monitoring JSON payloads.
- Display QoS timings in the metrics debugging view.
- Fix error reported by publisher test expectation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
