### PR TITLE
Fix incorrect QoE timing after recovering from failure

### DIFF
--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -9,8 +9,11 @@ import Foundation
 import PillarboxCore
 
 extension PlayerItem {
-    private static func experience(forService service: DateInterval, startDate: Date) -> DateInterval {
-        if startDate < service.end {
+    private static func experience(fromService service: DateInterval, startDate: Date) -> DateInterval {
+        if startDate < service.start {
+            return service
+        }
+        else if startDate < service.end {
             return .init(start: startDate, end: service.end)
         }
         else {
@@ -28,7 +31,7 @@ extension PlayerItem {
         .map { dateInterval, startDate in
             MetricEvent(
                 kind: .metadata(
-                    experience: Self.experience(forService: dateInterval, startDate: startDate),
+                    experience: Self.experience(fromService: dateInterval, startDate: startDate),
                     service: dateInterval
                 ),
                 date: dateInterval.end


### PR DESCRIPTION
# Description

This PR fixes incorrect QoE timing after recovering from failure, the issue initially reported in #987 but not fixed by #990.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
