### PR TITLE
Support repeat modes

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "1c49fc1243018f81a7ea99cb5e0985b00096e9f4",
-        "version" : "13.3.0"
+        "revision" : "54b4e52183f16fe806014cbfd63718a84f8ba072",
+        "version" : "13.4.0"
       }
     },
     {

--- a/Demo/Sources/Model/MediaList.swift
+++ b/Demo/Sources/Model/MediaList.swift
@@ -107,6 +107,39 @@ enum MediaList {
         )
     ]
 
+    static let storyUrns = [
+        Media(
+            title: "Mario vs Sonic",
+            subtitle: "Tataki 1",
+            type: .urn("urn:rts:video:13950405")
+        ),
+        Media(
+            title: "Pourquoi Beyoncé fait de la country",
+            subtitle: "Tataki 2",
+            type: .urn("urn:rts:video:14815579")
+        ),
+        Media(
+            title: "L'île North Sentinel",
+            subtitle: "Tataki 3",
+            type: .urn("urn:rts:video:13795051")
+        ),
+        Media(
+            title: "Mourir pour ressembler à une idole",
+            subtitle: "Tataki 4",
+            type: .urn("urn:rts:video:14020134")
+        ),
+        Media(
+            title: "Pourquoi les gens mangent des insectes ?",
+            subtitle: "Tataki 5",
+            type: .urn("urn:rts:video:12631996")
+        ),
+        Media(
+            title: "Le concert de Beyoncé à Dubai",
+            subtitle: "Tataki 6",
+            type: .urn("urn:rts:video:13752646")
+        )
+    ]
+
     static let longVideoUrns = [
         Media(
             title: "J'ai pas l'air malade mais… (#1)",

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -58,6 +58,10 @@ private struct Toolbar: View {
     @ViewBuilder
     private func managementButtons() -> some View {
         HStack(spacing: 30) {
+            Button(action: toggleRepeatMode) {
+                Image(systemName: repeatModeImageName())
+            }
+
             Button(action: model.shuffle) {
                 Image(systemName: "shuffle")
             }
@@ -80,6 +84,28 @@ private struct Toolbar: View {
             Image(systemName: "arrow.right")
         }
         .disabled(!player.canAdvanceToNext())
+    }
+
+    private func toggleRepeatMode() {
+        switch player.repeatMode {
+        case .off:
+            player.repeatMode = .all
+        case .one:
+            player.repeatMode = .off
+        case .all:
+            player.repeatMode = .one
+        }
+    }
+
+    private func repeatModeImageName() -> String {
+        switch player.repeatMode {
+        case .off:
+            "repeat.circle"
+        case .one:
+            "repeat.1.circle.fill"
+        case .all:
+            "repeat.circle.fill"
+        }
     }
 
     private func add() {

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -27,6 +27,17 @@ private struct Toolbar: View {
     @ObservedObject private var model: PlaylistViewModel
     @State private var isSelectionPresented = false
 
+    private var repeatModeImageName: String {
+        switch player.repeatMode {
+        case .off:
+            "repeat.circle"
+        case .one:
+            "repeat.1.circle.fill"
+        case .all:
+            "repeat.circle.fill"
+        }
+    }
+
     var body: some View {
         HStack {
             previousButton()
@@ -59,7 +70,7 @@ private struct Toolbar: View {
     private func managementButtons() -> some View {
         HStack(spacing: 30) {
             Button(action: toggleRepeatMode) {
-                Image(systemName: repeatModeImageName())
+                Image(systemName: repeatModeImageName)
             }
 
             Button(action: model.shuffle) {
@@ -94,17 +105,6 @@ private struct Toolbar: View {
             player.repeatMode = .off
         case .all:
             player.repeatMode = .one
-        }
-    }
-
-    private func repeatModeImageName() -> String {
-        switch player.repeatMode {
-        case .off:
-            "repeat.circle"
-        case .one:
-            "repeat.1.circle.fill"
-        case .all:
-            "repeat.circle.fill"
         }
     }
 

--- a/Demo/Sources/Showcase/Stories/StoriesView.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesView.swift
@@ -44,7 +44,7 @@ private struct TimeProgress: View {
 
 // Behavior: h-exp, v-exp
 struct StoriesView: View {
-    @StateObject private var model = StoriesViewModel(stories: Story.stories(from: MediaList.videoUrls))
+    @StateObject private var model = StoriesViewModel(stories: Story.stories(from: MediaList.storyUrns))
 
     var body: some View {
         TabView(selection: $model.currentStory) {

--- a/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesViewModel.swift
@@ -35,7 +35,7 @@ final class StoriesViewModel: ObservableObject {
 
     private static func player(for story: Story) -> Player {
         let player = Player(item: story.media.item(), configuration: .externalPlaybackDisabled)
-        player.actionAtItemEnd = .pause
+        player.repeatMode = .one
         return player
     }
 

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -92,14 +92,7 @@ extension AVPlayerItem {
     private static func playerItems(from sources: [ItemSource], length: Int, reload: Bool) -> [AVPlayerItem] {
         sources
             .prefix(length)
-            .map { source in
-                if let item = source.item {
-                    return item.updated(with: source.content)
-                }
-                else {
-                    return source.content.playerItem(reload: reload)
-                }
-            }
+            .map { $0.playerItem(reload: reload) }
     }
 
     private static func newItemSources(from contents: [AssetContent]) -> [ItemSource] {

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -38,14 +38,16 @@ extension AVPlayerItem {
         repeatMode: RepeatMode,
         length: Int
     ) -> [AVPlayerItem] {
-        itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem, repeatMode: repeatMode).prefix(length).map { source in
-            if let item = source.item {
-                return item.updated(with: source.content)
+        itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem, repeatMode: repeatMode)
+            .prefix(length)
+            .map { source in
+                if let item = source.item {
+                    return item.updated(with: source.content)
+                }
+                else {
+                    return source.content.playerItem(reload: false)
+                }
             }
-            else {
-                return source.content.playerItem(reload: false)
-            }
-        }
     }
 
     private static func itemSources(

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -38,30 +38,30 @@ extension AVPlayerItem {
         repeatMode: RepeatMode,
         length: Int
     ) -> [AVPlayerItem] {
-        guard let currentItem else { return playerItems(from: Array(currentContents.prefix(length))) }
+        guard let currentItem else { return playerItems(from: Array(currentContents), repeatMode: repeatMode, length: length) }
         if let currentIndex = matchingIndex(for: currentItem, in: currentContents) {
             let currentContent = currentContents[currentIndex]
             if findContent(currentContent, in: previousContents) {
                 currentContent.update(item: currentItem)
-                return [currentItem] + playerItems(from: Array(currentContents.suffix(from: currentIndex + 1).prefix(length - 1)))
+                return [currentItem] + playerItems(from: Array(currentContents.suffix(from: currentIndex + 1)), repeatMode: repeatMode, length: length - 1)
             }
             else {
-                return playerItems(from: Array(currentContents.suffix(from: currentIndex).prefix(length)))
+                return playerItems(from: Array(currentContents.suffix(from: currentIndex)), repeatMode: repeatMode, length: length)
             }
         }
         else if let commonIndex = firstCommonIndex(in: currentContents, matching: previousContents, after: currentItem) {
-            return playerItems(from: Array(currentContents.suffix(from: commonIndex).prefix(length)))
+            return playerItems(from: Array(currentContents.suffix(from: commonIndex)), repeatMode: repeatMode, length: length)
         }
         else {
-            return playerItems(from: Array(currentContents.prefix(length)))
+            return playerItems(from: Array(currentContents), repeatMode: repeatMode, length: length)
         }
     }
 
-    static func playerItems(from items: [PlayerItem], length: Int, reload: Bool) -> [AVPlayerItem] {
-        playerItems(from: items.prefix(length).map(\.content), reload: reload)
+    static func playerItems(from items: [PlayerItem], repeatMode: RepeatMode, length: Int, reload: Bool) -> [AVPlayerItem] {
+        playerItems(from: items.map(\.content), repeatMode: repeatMode, length: length, reload: reload)
     }
 
-    private static func playerItems(from contents: [AssetContent], reload: Bool = false) -> [AVPlayerItem] {
+    private static func playerItems(from contents: [AssetContent], repeatMode: RepeatMode, length: Int, reload: Bool = false) -> [AVPlayerItem] {
         contents.map { $0.playerItem(reload: reload) }
     }
 

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -28,11 +28,14 @@ extension AVPlayerItem {
     ///   - currentContents: The current list of contents.
     ///   - previousContents: The previous list of contents.
     ///   - currentItem: The item currently being played by the player.
+    ///   - repeatMode: The current repeat mode setting.
+    ///   - length: The maximum number of items to return.
     /// - Returns: The list of player items to load into the player.
     static func playerItems(
         for currentContents: [AssetContent],
         replacing previousContents: [AssetContent],
         currentItem: AVPlayerItem?,
+        repeatMode: RepeatMode,
         length: Int
     ) -> [AVPlayerItem] {
         guard let currentItem else { return playerItems(from: Array(currentContents.prefix(length))) }

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -40,9 +40,7 @@ extension AVPlayerItem {
     ) -> [AVPlayerItem] {
         itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem, repeatMode: repeatMode).prefix(length).map { source in
             if let item = source.item {
-                // TODO: Turn into `AVPlayer.updated(with:)` method
-                source.content.update(item: item)
-                return item
+                return item.updated(with: source.content)
             }
             else {
                 return source.content.playerItem(reload: false)
@@ -153,6 +151,19 @@ extension AVPlayerItem {
     /// - Returns: The receiver with the id assigned to it.
     func withId(_ id: UUID) -> AVPlayerItem {
         self.id = id
+        return self
+    }
+
+    func updated(with content: AssetContent) -> AVPlayerItem {
+        externalMetadata = content.metadata.externalMetadata
+#if os(tvOS)
+        interstitialTimeRanges = content.metadata.blockedTimeRanges.map { timeRange in
+            .init(timeRange: timeRange)
+        }
+        navigationMarkerGroups = [
+            AVNavigationMarkersGroup(title: "chapters", timedNavigationMarkers: content.metadata.timedNavigationMarkers)
+        ]
+#endif
         return self
     }
 }

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -51,7 +51,7 @@ extension AVPlayerItem {
         case .one:
             guard let firstSource = sources.first else { return sources }
             var updatedSources = sources
-            updatedSources.insert(.new(content: firstSource.content), at: 1)
+            updatedSources.insert(firstSource.copy(), at: 1)
             return updatedSources
         case .all:
             guard let firstContent else { return sources }

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -38,12 +38,12 @@ extension AVPlayerItem {
         repeatMode: RepeatMode,
         length: Int
     ) -> [AVPlayerItem] {
-        let _sources = itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem)
-        let sources = itemSources(_sources, firstContent: currentContents.first, repeatMode: repeatMode)
-        return playerItems(from: sources, length: length, reload: false)
+        let sources = itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem)
+        let updatedSources = updatedItemSources(sources, repeatMode: repeatMode, firstContent: currentContents.first)
+        return playerItems(from: updatedSources, length: length, reload: false)
     }
 
-    private static func itemSources(_ sources: [ItemSource], firstContent: AssetContent?, repeatMode: RepeatMode) -> [ItemSource] {
+    private static func updatedItemSources(_ sources: [ItemSource], repeatMode: RepeatMode, firstContent: AssetContent?) -> [ItemSource] {
         switch repeatMode {
         case .off:
             return sources
@@ -85,7 +85,7 @@ extension AVPlayerItem {
 
     static func playerItems(from items: [PlayerItem], after index: Int, repeatMode: RepeatMode, length: Int, reload: Bool) -> [AVPlayerItem] {
         let afterContents = items.suffix(from: index).map(\.content)
-        let sources = itemSources(newItemSources(from: afterContents), firstContent: items.first?.content, repeatMode: repeatMode)
+        let sources = updatedItemSources(newItemSources(from: afterContents), repeatMode: repeatMode, firstContent: items.first?.content)
         return playerItems(from: sources, length: length, reload: reload)
     }
 

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -50,12 +50,12 @@ extension AVPlayerItem {
         case .one:
             guard let firstSource = sources.first else { return sources }
             var updatedSources = sources
-            updatedSources.insert(.init(content: firstSource.content, item: nil), at: 1)
+            updatedSources.insert(.new(content: firstSource.content), at: 1)
             return updatedSources
         case .all:
             guard let firstContent else { return sources }
             var updatedSources = sources
-            updatedSources.append(.init(content: firstContent, item: nil))
+            updatedSources.append(.new(content: firstContent))
             return updatedSources
         }
     }
@@ -69,7 +69,7 @@ extension AVPlayerItem {
         if let currentIndex = matchingIndex(for: currentItem, in: currentContents) {
             let currentContent = currentContents[currentIndex]
             if findContent(currentContent, in: previousContents) {
-                return [.init(content: currentContent, item: currentItem)] + newItemSources(from: Array(currentContents.suffix(from: currentIndex + 1)))
+                return [.reused(content: currentContent, item: currentItem)] + newItemSources(from: Array(currentContents.suffix(from: currentIndex + 1)))
             }
             else {
                 return newItemSources(from: Array(currentContents.suffix(from: currentIndex)))
@@ -103,7 +103,7 @@ extension AVPlayerItem {
     }
 
     private static func newItemSources(from contents: [AssetContent]) -> [ItemSource] {
-        contents.map { .init(content: $0, item: nil) }
+        contents.map { .new(content: $0) }
     }
 
     private static func matchingIndex(for item: AVPlayerItem, in contents: [AssetContent]) -> Int? {

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -5,6 +5,7 @@
 //
 
 import AVFoundation
+import AVKit
 
 private var kIdKey: Void?
 

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -27,7 +27,7 @@ public extension Player {
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPreviousItem() {
-        guard let index = Self.index(before: currentItem, in: storedItems) else { return }
+        guard let index = index(before: currentItem, in: storedItems) else { return }
         queuePlayer.replaceItems(
             with: AVPlayerItem.playerItems(
                 from: Array(storedItems),
@@ -58,7 +58,7 @@ public extension Player {
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNextItem() {
-        guard let index = Self.index(after: currentItem, in: storedItems) else { return }
+        guard let index = index(after: currentItem, in: storedItems) else { return }
         queuePlayer.replaceItems(
             with: AVPlayerItem.playerItems(
                 from: Array(storedItems),
@@ -73,11 +73,11 @@ public extension Player {
 
 extension Player {
     func canReturnToItem(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Bool {
-        Self.index(before: item, in: items) != nil
+        index(before: item, in: items) != nil
     }
 
     func canAdvanceToItem(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Bool {
-        Self.index(after: item, in: items) != nil
+        index(after: item, in: items) != nil
     }
 
     func replaceCurrentItemWithItem(_ item: PlayerItem?) {
@@ -99,15 +99,25 @@ extension Player {
 }
 
 private extension Player {
-    static func index(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
+    func index(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
         guard let item, let index = items.firstIndex(of: item) else { return nil }
         let previousIndex = items.index(before: index)
-        return previousIndex >= 0 ? previousIndex : nil
+        switch repeatMode {
+        case .off, .one:
+            return previousIndex >= 0 ? previousIndex : nil
+        case .all:
+            return previousIndex >= 0 ? previousIndex : items.index(before: items.endIndex)
+        }
     }
 
-    static func index(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
+    func index(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
         guard let item, let index = items.firstIndex(of: item) else { return nil }
         let nextIndex = items.index(after: index)
-        return nextIndex < items.count ? nextIndex : nil
+        switch repeatMode {
+        case .off, .one:
+            return nextIndex < items.count ? nextIndex : nil
+        case .all:
+            return nextIndex < items.count ? nextIndex : 0
+        }
     }
 }

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -27,10 +27,11 @@ public extension Player {
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPreviousItem() {
-        guard canReturnToPreviousItem() else { return }
+        guard let index = Self.index(before: currentItem, in: storedItems) else { return }
         queuePlayer.replaceItems(
             with: AVPlayerItem.playerItems(
-                from: returningItems,
+                from: Array(storedItems),
+                after: index,
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
                 reload: true
@@ -57,10 +58,11 @@ public extension Player {
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNextItem() {
-        guard canAdvanceToNextItem() else { return }
+        guard let index = Self.index(after: currentItem, in: storedItems) else { return }
         queuePlayer.replaceItems(
             with: AVPlayerItem.playerItems(
-                from: advancingItems,
+                from: Array(storedItems),
+                after: index,
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
                 reload: true
@@ -71,17 +73,23 @@ public extension Player {
 
 extension Player {
     func canReturnToItem(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Bool {
-        !Self.items(before: item, in: items).isEmpty
+        Self.index(before: item, in: items) != nil
     }
 
     func canAdvanceToItem(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Bool {
-        !Self.items(after: item, in: items).isEmpty
+        Self.index(after: item, in: items) != nil
     }
 
     func replaceCurrentItemWithItem(_ item: PlayerItem?) {
         if let item {
             guard storedItems.contains(item), let index = storedItems.firstIndex(of: item) else { return }
-            let playerItems = AVPlayerItem.playerItems(from: Array(storedItems.suffix(from: index)), repeatMode: repeatMode, length: configuration.preloadedItems, reload: true)
+            let playerItems = AVPlayerItem.playerItems(
+                from: Array(storedItems),
+                after: index,
+                repeatMode: repeatMode,
+                length: configuration.preloadedItems,
+                reload: true
+            )
             queuePlayer.replaceItems(with: playerItems)
         }
         else {
@@ -91,27 +99,15 @@ extension Player {
 }
 
 private extension Player {
-    /// Returns the list of items to be loaded to return to the previous (playable) item.
-    var returningItems: [PlayerItem] {
-        Self.items(before: currentItem, in: storedItems)
-    }
-
-    /// Returns the list of items to be loaded to advance to the next (playable) item.
-    var advancingItems: [PlayerItem] {
-        Self.items(after: currentItem, in: storedItems)
-    }
-
-    static func items(before item: PlayerItem?, in items: Deque<PlayerItem>) -> [PlayerItem] {
-        guard let item, let index = items.firstIndex(of: item) else { return [] }
+    static func index(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
+        guard let item, let index = items.firstIndex(of: item) else { return nil }
         let previousIndex = items.index(before: index)
-        guard previousIndex >= 0 else { return [] }
-        return Array(items.suffix(from: previousIndex))
+        return previousIndex >= 0 ? previousIndex : nil
     }
 
-    static func items(after item: PlayerItem?, in items: Deque<PlayerItem>) -> [PlayerItem] {
-        guard let item, let index = items.firstIndex(of: item) else { return [] }
+    static func index(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
+        guard let item, let index = items.firstIndex(of: item) else { return nil }
         let nextIndex = items.index(after: index)
-        guard nextIndex < items.count else { return [] }
-        return Array(items.suffix(from: nextIndex))
+        return nextIndex < items.count ? nextIndex : nil
     }
 }

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -28,7 +28,14 @@ public extension Player {
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPreviousItem() {
         guard canReturnToPreviousItem() else { return }
-        queuePlayer.replaceItems(with: AVPlayerItem.playerItems(from: returningItems, length: configuration.preloadedItems, reload: true))
+        queuePlayer.replaceItems(
+            with: AVPlayerItem.playerItems(
+                from: returningItems,
+                repeatMode: repeatMode,
+                length: configuration.preloadedItems,
+                reload: true
+            )
+        )
     }
 
     /// Checks whether moving to the next item in the queue is possible.
@@ -51,7 +58,14 @@ public extension Player {
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNextItem() {
         guard canAdvanceToNextItem() else { return }
-        queuePlayer.replaceItems(with: AVPlayerItem.playerItems(from: advancingItems, length: configuration.preloadedItems, reload: true))
+        queuePlayer.replaceItems(
+            with: AVPlayerItem.playerItems(
+                from: advancingItems,
+                repeatMode: repeatMode,
+                length: configuration.preloadedItems,
+                reload: true
+            )
+        )
     }
 }
 
@@ -67,7 +81,7 @@ extension Player {
     func replaceCurrentItemWithItem(_ item: PlayerItem?) {
         if let item {
             guard storedItems.contains(item), let index = storedItems.firstIndex(of: item) else { return }
-            let playerItems = AVPlayerItem.playerItems(from: Array(storedItems.suffix(from: index)), length: configuration.preloadedItems, reload: true)
+            let playerItems = AVPlayerItem.playerItems(from: Array(storedItems.suffix(from: index)), repeatMode: repeatMode, length: configuration.preloadedItems, reload: true)
             queuePlayer.replaceItems(with: playerItems)
         }
         else {

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -12,12 +12,18 @@ public extension Player {
     ///
     /// - Returns: `true` if possible.
     ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canReturnToPreviousItem() -> Bool {
         canReturnToItem(before: currentItem, in: storedItems)
     }
 
     /// Returns to the previous item in the queue.
+    ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPreviousItem() {
@@ -29,12 +35,18 @@ public extension Player {
     ///
     /// - Returns: `true` if possible.
     ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canAdvanceToNextItem() -> Bool {
         canAdvanceToItem(after: currentItem, in: storedItems)
     }
 
     /// Moves to the next item in the queue.
+    ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNextItem() {

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -98,9 +98,10 @@ extension Player {
     }
 
     func reloadItems() {
+        let contents = Array(storedItems).map(\.content)
         let items = AVPlayerItem.playerItems(
-            for: Array(storedItems).map(\.content),
-            replacing: Array(storedItems).map(\.content),
+            for: contents,
+            replacing: contents,
             currentItem: queuePlayer.currentItem,
             repeatMode: repeatMode,
             length: configuration.preloadedItems

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -13,7 +13,7 @@ public extension Player {
     /// - Returns: `true` if possible.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canReturnToPreviousItem() -> Bool {
@@ -23,7 +23,7 @@ public extension Player {
     /// Returns to the previous item in the queue.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPreviousItem() {
@@ -44,7 +44,7 @@ public extension Player {
     /// - Returns: `true` if possible.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canAdvanceToNextItem() -> Bool {
@@ -54,7 +54,7 @@ public extension Player {
     /// Moves to the next item in the queue.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Ignores the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNextItem() {

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -96,6 +96,17 @@ extension Player {
             queuePlayer.removeAllItems()
         }
     }
+
+    func reloadItems() {
+        let items = AVPlayerItem.playerItems(
+            for: Array(storedItems).map(\.content),
+            replacing: Array(storedItems).map(\.content),
+            currentItem: queuePlayer.currentItem,
+            repeatMode: repeatMode,
+            length: configuration.preloadedItems
+        )
+        queuePlayer.replaceItems(with: items)
+    }
 }
 
 private extension Player {

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -113,22 +113,30 @@ private extension Player {
     func index(before item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
         guard let item, let index = items.firstIndex(of: item) else { return nil }
         let previousIndex = items.index(before: index)
-        switch repeatMode {
-        case .off, .one:
-            return previousIndex >= 0 ? previousIndex : nil
-        case .all:
-            return previousIndex >= 0 ? previousIndex : items.index(before: items.endIndex)
-        }
+        return previousIndex >= items.startIndex ? previousIndex : beforeIndex()
     }
 
     func index(after item: PlayerItem?, in items: Deque<PlayerItem>) -> Int? {
         guard let item, let index = items.firstIndex(of: item) else { return nil }
         let nextIndex = items.index(after: index)
+        return nextIndex < items.endIndex ? nextIndex : afterIndex()
+    }
+
+    func afterIndex() -> Int? {
         switch repeatMode {
         case .off, .one:
-            return nextIndex < items.count ? nextIndex : nil
+            return nil
         case .all:
-            return nextIndex < items.count ? nextIndex : 0
+            return items.startIndex
+        }
+    }
+
+    func beforeIndex() -> Int? {
+        switch repeatMode {
+        case .off, .one:
+            return nil
+        case .all:
+            return items.index(before: items.endIndex)
         }
     }
 }

--- a/Sources/Player/Player+Navigation.swift
+++ b/Sources/Player/Player+Navigation.swift
@@ -14,7 +14,7 @@ public extension Player {
     /// - Returns: `true` if possible.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canReturnToPrevious() -> Bool {
@@ -24,7 +24,7 @@ public extension Player {
     /// Returns to the previous content.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPrevious() {
@@ -41,7 +41,7 @@ public extension Player {
     /// - Returns: `true` if possible.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canAdvanceToNext() -> Bool {
@@ -51,7 +51,7 @@ public extension Player {
     /// Moves to the next content.
     ///
     /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
-    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    /// has been set to ``RepeatMode/all``.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNext() {

--- a/Sources/Player/Player+Navigation.swift
+++ b/Sources/Player/Player+Navigation.swift
@@ -13,12 +13,18 @@ public extension Player {
     ///
     /// - Returns: `true` if possible.
     ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canReturnToPrevious() -> Bool {
         canReturn(before: currentItem, in: storedItems, streamType: streamType)
     }
 
     /// Returns to the previous content.
+    ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func returnToPrevious() {
@@ -34,12 +40,18 @@ public extension Player {
     ///
     /// - Returns: `true` if possible.
     ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
+    ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func canAdvanceToNext() -> Bool {
         canAdvanceToNextItem()
     }
 
     /// Moves to the next content.
+    ///
+    /// The behavior of this method is adjusted to wrap around both ends of the item queue when ``Player/repeatMode``
+    /// has been set to ``RepeatMode/all``, provided the queue contains more than one item.
     ///
     /// > Important: Observes the ``PlayerConfiguration/navigationMode`` set in the ``Player/configuration``.
     func advanceToNext() {

--- a/Sources/Player/Player+Queue.swift
+++ b/Sources/Player/Player+Queue.swift
@@ -31,14 +31,15 @@ extension Player {
     func queuePlayerItemsPublisher() -> AnyPublisher<[AVPlayerItem], Never> {
         queuePublisher
             .withPrevious(.empty)
-            .compactMap { [configuration] previous, current in
-                guard let buffer = Queue.buffer(from: previous, to: current, length: configuration.preloadedItems) else {
+            .compactMap { [weak self, configuration] previous, current in
+                guard let self, let buffer = Queue.buffer(from: previous, to: current, length: configuration.preloadedItems) else {
                     return nil
                 }
                 return AVPlayerItem.playerItems(
                     for: current.elements.map(\.content),
                     replacing: previous.elements.map(\.content),
                     currentItem: buffer.item,
+                    repeatMode: repeatMode,
                     length: buffer.length
                 )
             }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -33,6 +33,20 @@ public final class Player: ObservableObject, Equatable {
     /// The metadata related to the item being played.
     @Published public private(set) var metadata: PlayerMetadata = .empty
 
+    /// The mode with which the player repeats playback of items in its queue.
+    @Published public var repeatMode: RepeatMode = .off {
+        didSet {
+            let items = AVPlayerItem.playerItems(
+                for: Array(storedItems).map(\.content),
+                replacing: Array(storedItems).map(\.content),
+                currentItem: queuePlayer.currentItem,
+                repeatMode: repeatMode,
+                length: configuration.preloadedItems
+            )
+            queuePlayer.replaceItems(with: items)
+        }
+    }
+
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
@@ -120,9 +134,6 @@ public final class Player: ObservableObject, Equatable {
             queuePlayer.isMuted = newValue
         }
     }
-
-    /// The mode with which the player repeats playback of items in its queue.
-    public var repeatMode: RepeatMode = .off
 
     /// A Boolean setting whether trackers must be enabled or not.
     ///

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -36,6 +36,7 @@ public final class Player: ObservableObject, Equatable {
     /// The mode with which the player repeats playback of items in its queue.
     @Published public var repeatMode: RepeatMode = .off {
         didSet {
+            guard !canReplay() else { return }
             reloadItems()
         }
     }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -121,6 +121,9 @@ public final class Player: ObservableObject, Equatable {
         }
     }
 
+    /// The mode with which the player repeats playback of items in its queue.
+    public var repeatMode: RepeatMode = .off
+
     /// A Boolean setting whether trackers must be enabled or not.
     ///
     /// This property only affects trackers having optional ``TrackingBehavior``, set when creating a corresponding

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -36,14 +36,7 @@ public final class Player: ObservableObject, Equatable {
     /// The mode with which the player repeats playback of items in its queue.
     @Published public var repeatMode: RepeatMode = .off {
         didSet {
-            let items = AVPlayerItem.playerItems(
-                for: Array(storedItems).map(\.content),
-                replacing: Array(storedItems).map(\.content),
-                currentItem: queuePlayer.currentItem,
-                repeatMode: repeatMode,
-                length: configuration.preloadedItems
-            )
-            queuePlayer.replaceItems(with: items)
+            reloadItems()
         }
     }
 

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -7,6 +7,8 @@
 import Foundation
 
 /// A player configuration.
+///
+/// The configuration controls behaviors set at player creation time and that cannot be changed afterwards.
 public struct PlayerConfiguration {
     /// The default configuration.
     public static let `default` = Self()

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -5,7 +5,6 @@
 //
 
 import AVFoundation
-import AVKit
 
 struct AssetContent {
     let id: UUID

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -22,30 +22,16 @@ struct AssetContent {
         .init(id: id, resource: .failing(error: error), metadata: .empty, configuration: .default, dateInterval: nil)
     }
 
-    func update(item: AVPlayerItem) {
-        item.externalMetadata = metadata.externalMetadata
-#if os(tvOS)
-        item.interstitialTimeRanges = metadata.blockedTimeRanges.map { timeRange in
-            .init(timeRange: timeRange)
-        }
-        item.navigationMarkerGroups = [
-            AVNavigationMarkersGroup(title: "chapters", timedNavigationMarkers: metadata.timedNavigationMarkers)
-        ]
-#endif
-    }
-
     func playerItem(reload: Bool = false) -> AVPlayerItem {
         if reload, resource.isFailing {
-            let item = Resource.loading.playerItem().withId(id)
+            let item = Resource.loading.playerItem().withId(id).updated(with: self)
             configure(item: item)
-            update(item: item)
             PlayerItem.reload(for: id)
             return item
         }
         else {
-            let item = resource.playerItem().withId(id)
+            let item = resource.playerItem().withId(id).updated(with: self)
             configure(item: item)
-            update(item: item)
             PlayerItem.load(for: id)
             return item
         }

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -22,4 +22,13 @@ struct ItemSource {
     static func reused(content: AssetContent, item: AVPlayerItem) -> Self {
         .init(content: content, item: item)
     }
+
+    func playerItem(reload: Bool) -> AVPlayerItem {
+        if let item {
+            return item.updated(with: content)
+        }
+        else {
+            return content.playerItem(reload: reload)
+        }
+    }
 }

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -9,4 +9,17 @@ import AVFoundation
 struct ItemSource {
     let content: AssetContent
     let item: AVPlayerItem?
+
+    private init(content: AssetContent, item: AVPlayerItem?) {
+        self.content = content
+        self.item = item
+    }
+
+    static func new(content: AssetContent) -> Self {
+        .init(content: content, item: nil)
+    }
+
+    static func reused(content: AssetContent, item: AVPlayerItem) -> Self {
+        .init(content: content, item: item)
+    }
 }

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -1,0 +1,12 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import AVFoundation
+
+struct ItemSource {
+    let content: AssetContent
+    let item: AVPlayerItem?
+}

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -7,13 +7,8 @@
 import AVFoundation
 
 struct ItemSource {
-    let content: AssetContent
-    let item: AVPlayerItem?
-
-    private init(content: AssetContent, item: AVPlayerItem?) {
-        self.content = content
-        self.item = item
-    }
+    private let content: AssetContent
+    private let item: AVPlayerItem?
 
     static func new(content: AssetContent) -> Self {
         .init(content: content, item: nil)
@@ -21,6 +16,10 @@ struct ItemSource {
 
     static func reused(content: AssetContent, item: AVPlayerItem) -> Self {
         .init(content: content, item: item)
+    }
+
+    func copy() -> Self {
+        .init(content: content, item: nil)
     }
 
     func playerItem(reload: Bool) -> AVPlayerItem {

--- a/Sources/Player/Types/RepeatMode.swift
+++ b/Sources/Player/Types/RepeatMode.swift
@@ -17,6 +17,6 @@ public enum RepeatMode {
     /// Repeat all items.
     ///
     /// The behavior of player advance and return navigation methods is adjusted to wrap around both ends of the item
-    /// queue, provided the queue contains more than one item.
+    /// queue..
     case all
 }

--- a/Sources/Player/Types/RepeatMode.swift
+++ b/Sources/Player/Types/RepeatMode.swift
@@ -17,6 +17,6 @@ public enum RepeatMode {
     /// Repeat all items.
     ///
     /// The behavior of player advance and return navigation methods is adjusted to wrap around both ends of the item
-    /// queue..
+    /// queue.
     case all
 }

--- a/Sources/Player/Types/RepeatMode.swift
+++ b/Sources/Player/Types/RepeatMode.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// A mode setting how a player repeats playback of items in its queue.
+public enum RepeatMode {
+    /// Disabled.
+    case off
+
+    /// Repeat the current item.
+    case one
+
+    /// Repeat all items.
+    ///
+    /// The behavior of player advance and return navigation methods is adjusted to wrap around both ends of the item
+    /// queue, provided the queue contains more than one item.
+    case all
+}

--- a/Tests/MonitoringTests/MetricsTrackerTests.swift
+++ b/Tests/MonitoringTests/MetricsTrackerTests.swift
@@ -210,4 +210,17 @@ final class MetricsTrackerTests: MonitoringTestCase {
             player.play()
         }
     }
+
+    func testRepeatOne() {
+        let player = Player(item: .simple(
+            url: Stream.shortOnDemand.url,
+            trackerAdapters: [
+                MetricsTracker.adapter(configuration: .test) { _ in .test }
+            ]
+        ))
+        player.repeatMode = .one
+        expectAtLeastHits(start(), heartbeat(), stop(), start(), heartbeat(), stop()) {
+            player.play()
+        }
+    }
 }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
@@ -8,6 +8,7 @@
 
 import AVFoundation
 import Nimble
+import PillarboxCircumspect
 import PillarboxStreams
 
 final class AVPlayerItemAssetContentUpdateTests: TestCase {
@@ -24,17 +25,14 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .off,
             length: currentContents.count
         )
-        expect(result.count).to(equal(currentContents.count))
-        expect(zip(result, currentContents)).to(allPass { item, content in
-            content.id == item.id
-        })
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
     }
 
     func testPlayerItemsWithPreservedCurrentItem() {
@@ -53,23 +51,15 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "C")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: currentContents.count
         )
-        let expected = [
-            currentItemContent,
-            .test(id: "B"),
-            .test(id: "C")
-        ]
-        expect(result.count).to(equal(expected.count))
-        expect(zip(result, expected)).to(allPass { item, content in
-            content.id == item.id
-        })
-        expect(result.first).to(equal(currentItem))
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
+        expect(items.first).to(equal(currentItem))
     }
 
     func testPlayerItemsWithPreservedCurrentItemAtEnd() {
@@ -88,21 +78,15 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             currentItemContent
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: currentContents.count
         )
-        let expected = [
-            currentItemContent
-        ]
-        expect(result.count).to(equal(expected.count))
-        expect(zip(result, expected)).to(allPass { item, content in
-            content.id == item.id
-        })
-        expect(result.first).to(equal(currentItem))
+        expect(items.map(\.id)).to(equalDiff([UUID("3")]))
+        expect(items.first).to(equal(currentItem))
     }
 
     func testPlayerItemsWithUnknownCurrentItem() {
@@ -115,17 +99,14 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "B")
         ]
         let unknownItem = AssetContent.test(id: "1").playerItem()
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .off,
             length: currentContents.count
         )
-        expect(result.count).to(equal(currentContents.count))
-        expect(zip(result, currentContents)).to(allPass { item, content in
-            content.id == item.id
-        })
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }
 
     func testPlayerItemsWithCurrentItemReplacedByAnotherItem() {
@@ -142,21 +123,14 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "C")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: currentContents.count
         )
-        let expected = [
-            otherContent,
-            .test(id: "C")
-        ]
-        expect(result.count).to(equal(expected.count))
-        expect(zip(result, expected)).to(allPass { item, content in
-            content.id == item.id
-        })
+        expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
     }
 
     func testPlayerItemsWithUpdatedCurrentItem() {
@@ -172,18 +146,15 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "3")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: currentContents.count
         )
-        expect(result.count).to(equal(currentContents.count))
-        expect(zip(result, currentContents)).to(allPass { item, content in
-            content.id == item.id
-        })
-        expect(result.first).to(equal(currentItem))
+        expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
+        expect(items.first).to(equal(currentItem))
     }
 
     func testPlayerItemsLength() {
@@ -196,14 +167,14 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let result = AVPlayerItem.playerItems(
+        let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .off,
             length: 2
         )
-        expect(result.count).to(equal(2))
+        expect(items.count).to(equal(2))
     }
 }
 

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
@@ -24,7 +24,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: nil, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: nil,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         expect(result.count).to(equal(currentContents.count))
         expect(zip(result, currentContents)).to(allPass { item, content in
             content.id == item.id
@@ -47,7 +53,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "C")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: currentItem, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         let expected = [
             currentItemContent,
             .test(id: "B"),
@@ -76,7 +88,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             currentItemContent
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: currentItem, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         let expected = [
             currentItemContent
         ]
@@ -97,7 +115,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "B")
         ]
         let unknownItem = AssetContent.test(id: "1").playerItem()
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: unknownItem, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: unknownItem,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         expect(result.count).to(equal(currentContents.count))
         expect(zip(result, currentContents)).to(allPass { item, content in
             content.id == item.id
@@ -118,7 +142,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "C")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: currentItem, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         let expected = [
             otherContent,
             .test(id: "C")
@@ -142,7 +172,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "3")
         ]
         let currentItem = currentItemContent.playerItem()
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: currentItem, length: currentContents.count)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: currentContents.count
+        )
         expect(result.count).to(equal(currentContents.count))
         expect(zip(result, currentContents)).to(allPass { item, content in
             content.id == item.id
@@ -160,7 +196,13 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let result = AVPlayerItem.playerItems(for: currentContents, replacing: previousContents, currentItem: nil, length: 2)
+        let result = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: nil,
+            repeatMode: .off,
+            length: 2
+        )
         expect(result.count).to(equal(2))
     }
 }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemAssetContentUpdateTests.swift
@@ -177,29 +177,3 @@ final class AVPlayerItemAssetContentUpdateTests: TestCase {
         expect(items.count).to(equal(2))
     }
 }
-
-private extension AssetContent {
-    static func test(id: Character) -> Self {
-        AssetContent(
-            id: UUID(id),
-            resource: .simple(url: Stream.onDemand.url),
-            metadata: .empty,
-            configuration: .default,
-            dateInterval: nil
-        )
-    }
-}
-
-private extension UUID {
-    init(_ char: Character) {
-        self.init(
-            uuidString: """
-                \(String(repeating: char, count: 8))\
-                -\(String(repeating: char, count: 4))\
-                -\(String(repeating: char, count: 4))\
-                -\(String(repeating: char, count: 4))\
-                -\(String(repeating: char, count: 12))
-                """
-        )!
-    }
-}

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
@@ -11,7 +11,7 @@ import Nimble
 import PillarboxCircumspect
 import PillarboxStreams
 
-final class AVPlayerItemUpdateTests: TestCase {
+final class AVPlayerItemRepeatAllUpdateTests: TestCase {
     func testPlayerItemsWithoutCurrentItem() {
         let previousContents: [AssetContent] = [
             .test(id: "1"),
@@ -29,10 +29,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: nil,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C"), UUID("A")]))
     }
 
     func testPlayerItemsWithPreservedCurrentItem() {
@@ -55,10 +55,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
     }
 
@@ -82,10 +82,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("3")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
     }
 
@@ -103,10 +103,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("A")]))
     }
 
     func testPlayerItemsWithCurrentItemReplacedByAnotherItem() {
@@ -127,10 +127,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C"), UUID("3")]))
     }
 
     func testPlayerItemsWithUpdatedCurrentItem() {
@@ -150,10 +150,10 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
-            repeatMode: .off,
+            repeatMode: .all,
             length: .max
         )
-        expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
+        expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3"), UUID("1")]))
         expect(items.first).to(equal(currentItem))
     }
 
@@ -168,7 +168,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             for: currentContents,
             replacing: [],
             currentItem: nil,
-            repeatMode: .off,
+            repeatMode: .all,
             length: 2
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
@@ -1,0 +1,176 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import AVFoundation
+import Nimble
+import PillarboxCircumspect
+import PillarboxStreams
+
+final class AVPlayerItemRepeatOffUpdateTests: TestCase {
+    func testPlayerItemsWithoutCurrentItem() {
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            .test(id: "3"),
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C")
+        ]
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: nil,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
+    }
+
+    func testPlayerItemsWithPreservedCurrentItem() {
+        let currentItemContent = AssetContent.test(id: "3")
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            currentItemContent,
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents = [
+            .test(id: "A"),
+            currentItemContent,
+            .test(id: "B"),
+            .test(id: "C")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsWithPreservedCurrentItemAtEnd() {
+        let currentItemContent = AssetContent.test(id: "3")
+        let previousContents = [
+            .test(id: "1"),
+            .test(id: "2"),
+            currentItemContent,
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C"),
+            currentItemContent
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("3")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsWithUnknownCurrentItem() {
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2")
+        ]
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B")
+        ]
+        let unknownItem = AssetContent.test(id: "1").playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: unknownItem,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
+    }
+
+    func testPlayerItemsWithCurrentItemReplacedByAnotherItem() {
+        let currentItemContent = AssetContent.test(id: "1")
+        let otherContent = AssetContent.test(id: "2")
+        let previousContents = [
+            currentItemContent,
+            otherContent,
+            .test(id: "3")
+        ]
+        let currentContents = [
+            .test(id: "3"),
+            otherContent,
+            .test(id: "C")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
+    }
+
+    func testPlayerItemsWithUpdatedCurrentItem() {
+        let currentItemContent = AssetContent.test(id: "1")
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            .test(id: "3")
+        ]
+        let currentContents = [
+            currentItemContent,
+            .test(id: "2"),
+            .test(id: "3")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .off,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsLength() {
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C"),
+            .test(id: "D")
+        ]
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: [],
+            currentItem: nil,
+            repeatMode: .off,
+            length: 2
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
+    }
+}

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
@@ -1,0 +1,176 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import AVFoundation
+import Nimble
+import PillarboxCircumspect
+import PillarboxStreams
+
+final class AVPlayerItemRepeatOneUpdateTests: TestCase {
+    func testPlayerItemsWithoutCurrentItem() {
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            .test(id: "3"),
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C")
+        ]
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: nil,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B"), UUID("C")]))
+    }
+
+    func testPlayerItemsWithPreservedCurrentItem() {
+        let currentItemContent = AssetContent.test(id: "3")
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            currentItemContent,
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents = [
+            .test(id: "A"),
+            currentItemContent,
+            .test(id: "B"),
+            .test(id: "C")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3"), UUID("B"), UUID("C")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsWithPreservedCurrentItemAtEnd() {
+        let currentItemContent = AssetContent.test(id: "3")
+        let previousContents = [
+            .test(id: "1"),
+            .test(id: "2"),
+            currentItemContent,
+            .test(id: "4"),
+            .test(id: "5")
+        ]
+        let currentContents = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C"),
+            currentItemContent
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsWithUnknownCurrentItem() {
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2")
+        ]
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B")
+        ]
+        let unknownItem = AssetContent.test(id: "1").playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: unknownItem,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B")]))
+    }
+
+    func testPlayerItemsWithCurrentItemReplacedByAnotherItem() {
+        let currentItemContent = AssetContent.test(id: "1")
+        let otherContent = AssetContent.test(id: "2")
+        let previousContents = [
+            currentItemContent,
+            otherContent,
+            .test(id: "3")
+        ]
+        let currentContents = [
+            .test(id: "3"),
+            otherContent,
+            .test(id: "C")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("2"), UUID("C")]))
+    }
+
+    func testPlayerItemsWithUpdatedCurrentItem() {
+        let currentItemContent = AssetContent.test(id: "1")
+        let previousContents: [AssetContent] = [
+            .test(id: "1"),
+            .test(id: "2"),
+            .test(id: "3")
+        ]
+        let currentContents = [
+            currentItemContent,
+            .test(id: "2"),
+            .test(id: "3")
+        ]
+        let currentItem = currentItemContent.playerItem()
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: previousContents,
+            currentItem: currentItem,
+            repeatMode: .one,
+            length: .max
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("1"), UUID("2"), UUID("3")]))
+        expect(items.first).to(equal(currentItem))
+    }
+
+    func testPlayerItemsLength() {
+        let currentContents: [AssetContent] = [
+            .test(id: "A"),
+            .test(id: "B"),
+            .test(id: "C"),
+            .test(id: "D")
+        ]
+        let items = AVPlayerItem.playerItems(
+            for: currentContents,
+            replacing: [],
+            currentItem: nil,
+            repeatMode: .one,
+            length: 2
+        )
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A")]))
+    }
+}

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
@@ -29,7 +29,7 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, repeatMode: .off, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .off, length: .max, reload: false).compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,
@@ -45,7 +45,7 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, repeatMode: .one, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .one, length: .max, reload: false).compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,
@@ -62,7 +62,7 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, repeatMode: .all, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .all, length: .max, reload: false).compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
@@ -22,19 +22,53 @@ final class AVPlayerItemTests: TestCase {
         expect(item.timeRange).toEventuallyNot(equal(.invalid))
     }
 
-    func testPlayerItems() {
+    func testPlayerItemsWithRepeatOff() {
         let items = [
             PlayerItem.simple(url: Stream.onDemand.url),
             PlayerItem.simple(url: Stream.shortOnDemand.url),
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, length: 3, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(from: items, repeatMode: .off, length: .max, reload: false).compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,
             Stream.shortOnDemand.url,
             Stream.live.url
+        ]))
+    }
+
+    func testPlayerItemsWithRepeatOne() {
+        let items = [
+            PlayerItem.simple(url: Stream.onDemand.url),
+            PlayerItem.simple(url: Stream.shortOnDemand.url),
+            PlayerItem.simple(url: Stream.live.url)
+        ]
+        expect {
+            AVPlayerItem.playerItems(from: items, repeatMode: .one, length: .max, reload: false).compactMap(\.url)
+        }
+        .toEventually(equal([
+            Stream.onDemand.url,
+            Stream.onDemand.url,
+            Stream.shortOnDemand.url,
+            Stream.live.url
+        ]))
+    }
+
+    func testPlayerItemsWithRepeatAll() {
+        let items = [
+            PlayerItem.simple(url: Stream.onDemand.url),
+            PlayerItem.simple(url: Stream.shortOnDemand.url),
+            PlayerItem.simple(url: Stream.live.url)
+        ]
+        expect {
+            AVPlayerItem.playerItems(from: items, repeatMode: .all, length: .max, reload: false).compactMap(\.url)
+        }
+        .toEventually(equal([
+            Stream.onDemand.url,
+            Stream.shortOnDemand.url,
+            Stream.live.url,
+            Stream.onDemand.url
         ]))
     }
 }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
@@ -158,22 +158,19 @@ final class AVPlayerItemUpdateTests: TestCase {
     }
 
     func testPlayerItemsLength() {
-        let previousContents: [AssetContent] = [
-            .test(id: "1"),
-            .test(id: "2"),
-            .test(id: "3")
-        ]
         let currentContents: [AssetContent] = [
             .test(id: "A"),
-            .test(id: "B")
+            .test(id: "B"),
+            .test(id: "C"),
+            .test(id: "D")
         ]
         let items = AVPlayerItem.playerItems(
             for: currentContents,
-            replacing: previousContents,
+            replacing: [],
             currentItem: nil,
             repeatMode: .off,
             length: 2
         )
-        expect(items.count).to(equal(2))
+        expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }
 }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
@@ -30,7 +30,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
     }
@@ -56,7 +56,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
         expect(items.first).to(equal(currentItem))
@@ -83,7 +83,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -104,7 +104,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }
@@ -128,7 +128,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
     }
@@ -151,7 +151,7 @@ final class AVPlayerItemUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: currentContents.count
+            length: .max
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
         expect(items.first).to(equal(currentItem))

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemUpdateTests.swift
@@ -11,7 +11,7 @@ import Nimble
 import PillarboxCircumspect
 import PillarboxStreams
 
-final class AVPlayerItemAssetContentUpdateTests: TestCase {
+final class AVPlayerItemUpdateTests: TestCase {
     func testPlayerItemsWithoutCurrentItem() {
         let previousContents: [AssetContent] = [
             .test(id: "1"),

--- a/Tests/PlayerTests/Extensions/AssetContent.swift
+++ b/Tests/PlayerTests/Extensions/AssetContent.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import Foundation
+import PillarboxStreams
+
+extension AssetContent {
+    static func test(id: Character) -> Self {
+        AssetContent(id: UUID(id), resource: .simple(url: Stream.onDemand.url), metadata: .empty, configuration: .default)
+    }
+}

--- a/Tests/PlayerTests/Extensions/AssetContent.swift
+++ b/Tests/PlayerTests/Extensions/AssetContent.swift
@@ -11,6 +11,6 @@ import PillarboxStreams
 
 extension AssetContent {
     static func test(id: Character) -> Self {
-        AssetContent(id: UUID(id), resource: .simple(url: Stream.onDemand.url), metadata: .empty, configuration: .default)
+        AssetContent(id: UUID(id), resource: .simple(url: Stream.onDemand.url), metadata: .empty, configuration: .default, dateInterval: nil)
     }
 }

--- a/Tests/PlayerTests/Extensions/UUID.swift
+++ b/Tests/PlayerTests/Extensions/UUID.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+extension UUID {
+    init(_ char: Character) {
+        self.init(
+            uuidString: """
+                \(String(repeating: char, count: 8))\
+                -\(String(repeating: char, count: 4))\
+                -\(String(repeating: char, count: 4))\
+                -\(String(repeating: char, count: 4))\
+                -\(String(repeating: char, count: 12))
+                """
+        )!
+    }
+}

--- a/Tests/PlayerTests/Playlist/ItemNavigationBackwardChecksTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationBackwardChecksTests.swift
@@ -29,4 +29,10 @@ final class ItemNavigationBackwardChecksTests: TestCase {
         let player = Player()
         expect(player.canReturnToPreviousItem()).to(beFalse())
     }
+
+    func testRepeatAll() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        player.repeatMode = .all
+        expect(player.canReturnToPreviousItem()).to(beTrue())
+    }
 }

--- a/Tests/PlayerTests/Playlist/ItemNavigationBackwardChecksTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationBackwardChecksTests.swift
@@ -30,7 +30,7 @@ final class ItemNavigationBackwardChecksTests: TestCase {
         expect(player.canReturnToPreviousItem()).to(beFalse())
     }
 
-    func testRepeatAll() {
+    func testWrapAtFrontWithRepeatAll() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         player.repeatMode = .all
         expect(player.canReturnToPreviousItem()).to(beTrue())

--- a/Tests/PlayerTests/Playlist/ItemNavigationBackwardTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationBackwardTests.swift
@@ -37,7 +37,7 @@ final class ItemNavigationBackwardTests: TestCase {
         expect(player.currentItem).to(equal(item1))
     }
 
-    func testRepeatAll() {
+    func testWrapAtFrontWithRepeatAll() {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(items: [item1, item2])

--- a/Tests/PlayerTests/Playlist/ItemNavigationBackwardTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationBackwardTests.swift
@@ -36,4 +36,13 @@ final class ItemNavigationBackwardTests: TestCase {
         player.returnToPreviousItem()
         expect(player.currentItem).to(equal(item1))
     }
+
+    func testRepeatAll() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(items: [item1, item2])
+        player.repeatMode = .all
+        player.returnToPreviousItem()
+        expect(player.currentItem).to(equal(item2))
+    }
 }

--- a/Tests/PlayerTests/Playlist/ItemNavigationForwardChecksTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationForwardChecksTests.swift
@@ -29,4 +29,10 @@ final class ItemNavigationForwardChecksTests: TestCase {
         let player = Player()
         expect(player.canAdvanceToNextItem()).to(beFalse())
     }
+
+    func testRepeatAll() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        player.repeatMode = .all
+        expect(player.canAdvanceToNextItem()).to(beTrue())
+    }
 }

--- a/Tests/PlayerTests/Playlist/ItemNavigationForwardChecksTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationForwardChecksTests.swift
@@ -30,7 +30,7 @@ final class ItemNavigationForwardChecksTests: TestCase {
         expect(player.canAdvanceToNextItem()).to(beFalse())
     }
 
-    func testRepeatAll() {
+    func testWrapAtBackWithRepeatAll() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         player.repeatMode = .all
         expect(player.canAdvanceToNextItem()).to(beTrue())

--- a/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
@@ -51,7 +51,7 @@ final class ItemNavigationForwardTests: TestCase {
         expect(items.count).to(equal(player.configuration.preloadedItems))
     }
 
-    func testRepeatAll() {
+    func testWrapAtBackWithRepeatAll() {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(items: [item1, item2])

--- a/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
@@ -50,4 +50,14 @@ final class ItemNavigationForwardTests: TestCase {
         let items = player.queuePlayer.items()
         expect(items.count).to(equal(player.configuration.preloadedItems))
     }
+
+    func testRepeatAll() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(items: [item1, item2])
+        player.repeatMode = .all
+        player.advanceToNextItem()
+        player.advanceToNextItem()
+        expect(player.currentItem).to(equal(item1))
+    }
 }

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -42,4 +42,12 @@ final class RepeatModeTests: TestCase {
         player.repeatMode = .one
         expect(player.streamType).toNever(equal(.unknown), until: .milliseconds(100))
     }
+
+    func testRepeatModeUpdateDoesNotReplay() {
+        let player = Player(item: .simple(url: Stream.shortOnDemand.url))
+        player.play()
+        expect(player.currentItem).toEventually(beNil())
+        player.repeatMode = .one
+        expect(player.currentItem).toAlways(beNil(), until: .milliseconds(100))
+    }
 }

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -21,7 +21,5 @@ final class RepeatModeTests: TestCase {
         expect(player.currentItem).toEventually(equal(item2))
     }
 
-    func testRepeatAll() {
-
-    }
+    func testRepeatAll() {}
 }

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -35,7 +35,7 @@ final class RepeatModeTests: TestCase {
         expect(player.currentItem).toEventually(beNil())
     }
 
-    func testStreamTypeNotUpdated() {
+    func testRepeatModeUpdateDoesNotRestartPlayback() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         player.play()
         expect(player.streamType).toEventually(equal(.onDemand))

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -21,5 +21,17 @@ final class RepeatModeTests: TestCase {
         expect(player.currentItem).toEventually(equal(item2))
     }
 
-    func testRepeatAll() {}
+    func testRepeatAll() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let player = Player(items: [item1, item2])
+        player.repeatMode = .all
+        player.play()
+        expect(player.currentItem).toEventually(equal(item1))
+        expect(player.currentItem).toEventually(equal(item2))
+        expect(player.currentItem).toEventually(equal(item1))
+        player.repeatMode = .off
+        expect(player.currentItem).toEventually(equal(item2))
+        expect(player.currentItem).toNever(equal(item1), until: .seconds(2))
+    }
 }

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import Nimble
+import PillarboxStreams
+
+final class RepeatModeTests: TestCase {
+    func testRepeatOne() {
+        let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
+        let item2 = PlayerItem.simple(url: Stream.onDemand.url)
+        let player = Player(items: [item1, item2])
+        player.repeatMode = .one
+        player.play()
+        expect(player.currentItem).toAlways(equal(item1), until: .seconds(2))
+        player.repeatMode = .off
+        expect(player.currentItem).toEventually(equal(item2))
+    }
+
+    func testRepeatAll() {
+
+    }
+}

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -32,6 +32,6 @@ final class RepeatModeTests: TestCase {
         expect(player.currentItem).toEventually(equal(item1))
         player.repeatMode = .off
         expect(player.currentItem).toEventually(equal(item2))
-        expect(player.currentItem).toNever(equal(item1), until: .seconds(2))
+        expect(player.currentItem).toEventually(beNil())
     }
 }

--- a/Tests/PlayerTests/Playlist/RepeatModeTests.swift
+++ b/Tests/PlayerTests/Playlist/RepeatModeTests.swift
@@ -34,4 +34,12 @@ final class RepeatModeTests: TestCase {
         expect(player.currentItem).toEventually(equal(item2))
         expect(player.currentItem).toEventually(beNil())
     }
+
+    func testStreamTypeNotUpdated() {
+        let player = Player(item: .simple(url: Stream.onDemand.url))
+        player.play()
+        expect(player.streamType).toEventually(equal(.onDemand))
+        player.repeatMode = .one
+        expect(player.streamType).toNever(equal(.unknown), until: .milliseconds(100))
+    }
 }


### PR DESCRIPTION
# Description

This PR introduces options to repeat playback of the current item or of the entire playlist.

# Changes made

- A player property `repeatMode` has been introduced.
- Update Nimble.
- Update `MetricsTracker` to have one session per loop.
- Update stories with looping content (and enable looping on the corresponding players).
- The stories in the demo have been updated with some **Tataki** content, and looping on the same content enabled.

# Implementation considerations

The implementation of this feature was made based on how `AVPlayerLooper` works, but without actually using it since it would have introduced more complexity.

The core idea is quite simple. We basically introduce a second `AVPlayerItem` identical to the current one for _Repeat one_, or append an `AVPlayerItem` corresponding to the first `PlayerItem` for _Repeat all_.

Of course the implementation itself is a bit more complicated since `AVPlayerItem`s must sometimes be reused or generated. An `ItemSource` was introduced to model this behavior in a more expressive way.

We also have to truncate the number of items to generate to the preloading length. This means that in general we:

1. Create the list of `ItemSources` that match a playlist update.
2. Expand this list by inserting additional sources if a repeat mode is enabled.
3. Apply truncation.
4. Generate `AVPlayerItem`s as needed.
5. Update the `AVQueuePlayer` queue accordingly.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
