### PR TITLE
Make the player custom slider accessible via VoiceOver

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -225,6 +225,9 @@
     "Presenter mode" : {
 
     },
+    "Progress" : {
+
+    },
     "Project" : {
 
     },

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -34,6 +34,17 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
                 }
         )
         .frame(maxWidth: .infinity)
+        .accessibilityRepresentation {
+            Slider(
+                progressTracker: progressTracker,
+                label: {
+                    Text("Progress")
+                },
+                minimumValueLabel: minimumValueLabel,
+                maximumValueLabel: maximumValueLabel
+            )
+        }
+        .accessibilityAddTraits(.updatesFrequently)
         .onReceive(player: progressTracker.player, assign: \.buffer, to: $buffer)
     }
 


### PR DESCRIPTION
# Description

This PR makes our demo custom player slider accessible via VoiceOver.

# Changes made

Self-explanatory. More changes can be expected as part of #578 but the demo will likely be revisited first.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
