### PR TITLE
Fix date retrieval performance issue with some content

### DIFF
--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -35,6 +35,8 @@ extension ItemProperties {
     }
 
     func date() -> Date? {
+        // Check cached duration validity first. This avoids potentially costly date retrieval when playing some
+        // content (e.g. MP3).
         duration.isValid ? item?.currentDate() : nil
     }
 

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -35,7 +35,7 @@ extension ItemProperties {
     }
 
     func date() -> Date? {
-        item?.currentDate()
+        duration.isValid ? item?.currentDate() : nil
     }
 
     func metrics() -> Metrics? {


### PR DESCRIPTION
# Description

This PR fixes performance issues associated with date retrieval when some type of content (e.g. MP3) is involved.

| Before | After |
|--------|--------|
| <video src='https://github.com/user-attachments/assets/e2d983b5-44fd-46ab-81e5-d45e36b97286' width=400/> | <video src='https://github.com/user-attachments/assets/214943bd-8be8-4b1e-bc41-d5a9f440499d' width=400/> | 

Until recently there was no performance issue, given the work we did in #766. But #994 introduced systematic `date()` retrieval in our custom player UI, which can be slow for some content. As a result navigating between items became sluggish.

I noticed that this sluggishness mostly occurs when we try to get the item `currentDate()` while the stream type is still unknown. This type itself is derived from the item duration, which we listen to and store in item properties. Since checking this cached value is fast, returning `nil` when it is invalid fixes the performance issue. Note that checking the duration on `AVPlayerItem` directly is not an option, as this approach is similarly slow.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
