### PR TITLE
Replace lists with forms where appropriate

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -607,14 +607,13 @@ private struct TimeSlider: View {
     var body: some View {
         PlaybackSlider(
             progressTracker: progressTracker,
+            timeRanges: player.metadata.timeRanges,
             minimumValueLabel: {
                 label(withText: formattedElapsedTime)
             },
             maximumValueLabel: {
                 label(withText: formattedTotalTime)
             },
-            timeRanges: player.metadata.timeRanges,
-            // swiftlint:disable:next trailing_closure
             onDragging: {
                 if UserDefaults.standard.seekBehavior == .deferred {
                     visibilityTracker.reset()

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -45,9 +45,7 @@ private struct InfoCell: View {
 
     var body: some View {
 #if os(tvOS)
-        Button(action: {}) {
-            content()
-        }
+        Button(action: {}, label: content)
 #else
         content()
 #endif

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -44,6 +44,16 @@ private struct InfoCell: View {
     let value: String
 
     var body: some View {
+#if os(tvOS)
+        Button(action: {}) {
+            content()
+        }
+#else
+        content()
+#endif
+    }
+
+    private func content() -> some View {
         HStack {
             Text(title)
             Spacer()

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -94,10 +94,10 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        CustomList {
+        Form {
             content()
-                .padding(.horizontal, constant(iOS: 0, tvOS: 20))
         }
+        .padding(.horizontal, constant(iOS: 0, tvOS: 40))
         .scrollDismissesKeyboard(.immediately)
         .animation(.defaultLinear, value: playbackHudEnabled)
         .tracked(name: "settings")

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -45,7 +45,6 @@ struct OptInView: View {
                     Text("Use a proxy tool to observe events.")
                 }
             }
-            .padding(.horizontal, constant(iOS: 0, tvOS: 40))
         }
         .onChange(of: isActive) { isActive in
             if isActive {

--- a/Demo/Sources/Showcase/OptInView.swift
+++ b/Demo/Sources/Showcase/OptInView.swift
@@ -27,7 +27,7 @@ struct OptInView: View {
             PlaybackView(player: player)
                 .supportsPictureInPicture(supportsPictureInPicture)
                 .background(.black)
-            List {
+            Form {
                 Toggle(isOn: $isActive) {
                     Text("Active (AirPlay / Control Center)")
                 }
@@ -45,6 +45,7 @@ struct OptInView: View {
                     Text("Use a proxy tool to observe events.")
                 }
             }
+            .padding(.horizontal, constant(iOS: 0, tvOS: 40))
         }
         .onChange(of: isActive) { isActive in
             if isActive {

--- a/Demo/Sources/Views/CustomList.swift
+++ b/Demo/Sources/Views/CustomList.swift
@@ -14,7 +14,8 @@ struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
 #if os(iOS)
         if !data.isEmpty {
             List(data, id: \.self, rowContent: content)
-        } else {
+        }
+        else {
             List { content(nil) }
         }
 #else
@@ -24,7 +25,8 @@ struct CustomList<Content, Data>: View where Content: View, Data: Hashable {
                     ForEach(data, id: \.self, content: content)
                 }
                 .padding(.horizontal, 50)
-            } else {
+            }
+            else {
                 VStack(alignment: .leading) {
                     content(nil)
                 }

--- a/Demo/Sources/Views/PlaybackSlider~ios.swift
+++ b/Demo/Sources/Views/PlaybackSlider~ios.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
     @ObservedObject var progressTracker: ProgressTracker
 
+    let timeRanges: [TimeRange]
     let minimumValueLabel: () -> ValueLabel
     let maximumValueLabel: () -> ValueLabel
-    let timeRanges: [TimeRange]
     let onEditingChanged: (Bool) -> Void
     let onDragging: () -> Void
 
@@ -50,16 +50,16 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
     init(
         progressTracker: ProgressTracker,
+        timeRanges: [TimeRange],
         @ViewBuilder minimumValueLabel: @escaping () -> ValueLabel,
         @ViewBuilder maximumValueLabel: @escaping () -> ValueLabel,
-        timeRanges: [TimeRange],
         onEditingChanged: @escaping (Bool) -> Void = { _ in },
         onDragging: @escaping () -> Void = {}
     ) {
         self.progressTracker = progressTracker
+        self.timeRanges = timeRanges
         self.minimumValueLabel = minimumValueLabel
         self.maximumValueLabel = maximumValueLabel
-        self.timeRanges = timeRanges
         self.onEditingChanged = onEditingChanged
         self.onDragging = onDragging
     }
@@ -135,7 +135,7 @@ struct PlaybackSlider<ValueLabel>: View where ValueLabel: View {
 
 extension PlaybackSlider where ValueLabel == EmptyView {
     init(progressTracker: ProgressTracker) {
-        self.init(progressTracker: progressTracker, minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() }, timeRanges: [])
+        self.init(progressTracker: progressTracker, timeRanges: [], minimumValueLabel: { EmptyView() }, maximumValueLabel: { EmptyView() })
     }
 }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -116,11 +116,10 @@ public final class PlayerItem: Hashable {
                 Just(Date()).setFailureType(to: P.Failure.self)
             )
             .handleEvents(receiveOutput: { asset, _ in
-                // swiftlint:disable:previous trailing_closure
                 trackerAdapters.forEach { adapter in
                     adapter.updateMetadata(to: asset.metadata)
                 }
-            })
+            }, receiveCompletion: nil)
             .map { asset, startDate in
                 Publishers.CombineLatest3(
                     Just(asset),

--- a/Sources/Player/Tracking/Tracker.swift
+++ b/Sources/Player/Tracking/Tracker.swift
@@ -83,9 +83,8 @@ final class Tracker {
             }
             .switchToLatest()
             .handleEvents(receiveOutput: { [weak self] properties in
-                // swiftlint:disable:previous trailing_closure
                 self?.updateTrackersProperties(to: properties)
-            })
+            }, receiveCompletion: nil)
             .weakAssign(to: \.properties, on: self)
             .store(in: &cancellables)
         metricEventCollector.$metricEvents


### PR DESCRIPTION
# Description

`Form` should be preferred over `List` for settings sheets.

# Changes made

- Replace `List` with `Form` in settings and opt-in view. Note that the opt-in view has existing usability issues on its own, but we will do better when we rewrite the demo anyway.
- Make version information cells reachable on tvOS.
- Fix linting issues.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
