### PR TITLE
Provide no playlist edit actions by default

### DIFF
--- a/Sources/Player/UserInterface/Playlist.swift
+++ b/Sources/Player/UserInterface/Playlist.swift
@@ -30,7 +30,11 @@ public struct Playlist<RowContent>: View where RowContent: View {
     ///     parameters:
     ///       - The ``PlayerItem/source`` associated with the item, if any.
     ///       - A Boolean indicating whether this source is associated with the current item.
-    public init(player: Player, editActions: EditActions<[PlayerItem]>, @ViewBuilder rowContent: @escaping (_ source: Any?, _ isCurrent: Bool) -> RowContent) {
+    public init(
+        player: Player,
+        editActions: EditActions<[PlayerItem]> = [],
+        @ViewBuilder rowContent: @escaping (_ source: Any?, _ isCurrent: Bool) -> RowContent
+    ) {
         self.player = player
         self.editActions = editActions
         self.rowContent = rowContent


### PR DESCRIPTION
# Description

This PR adds a default value for `Playlist` edit actions (no actions). This is in agreement with `List` APIs that, usually, provide no actions (but some API variants provide edit actions optionally, though the default path is not supported via default values but rather via specialization).

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
