### PR TITLE
Remove nested layers to avoid animation issues

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "54b4e52183f16fe806014cbfd63718a84f8ba072",
-        "version" : "13.4.0"
+        "revision" : "cecacf00ddf36c1efff8d14beb65087f2a676be9",
+        "version" : "13.5.0"
       }
     },
     {

--- a/Sources/Player/UserInterface/PictureInPictureSupportingVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingVideoView.swift
@@ -12,12 +12,12 @@ struct PictureInPictureSupportingVideoView: UIViewRepresentable {
     let gravity: AVLayerVideoGravity
 
     static func dismantleUIView(_ uiView: VideoLayerView, coordinator: Void) {
-        PictureInPicture.shared.custom.relinquish(for: uiView.playerLayer)
+        PictureInPicture.shared.custom.relinquish(for: uiView)
     }
 
     func makeUIView(context: Context) -> VideoLayerView {
-        let view = VideoLayerView(from: PictureInPicture.shared.custom.playerLayer)
-        PictureInPicture.shared.custom.acquire(for: view.playerLayer)
+        let view = PictureInPicture.shared.custom.view ?? VideoLayerView()
+        PictureInPicture.shared.custom.acquire(for: view)
         return view
     }
 

--- a/Sources/Player/UserInterface/VideoLayerView.swift
+++ b/Sources/Player/UserInterface/VideoLayerView.swift
@@ -8,44 +8,16 @@ import AVFoundation
 import UIKit
 
 final class VideoLayerView: UIView {
-    let playerLayer: AVPlayerLayer
+    override static var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    var playerLayer: AVPlayerLayer {
+        layer as! AVPlayerLayer
+    }
 
     var player: AVPlayer? {
         get { playerLayer.player }
         set { playerLayer.player = newValue }
-    }
-
-    init(from playerLayer: AVPlayerLayer? = nil) {
-        self.playerLayer = playerLayer ?? .init()
-        super.init(frame: .zero)
-        layer.addSublayer(self.playerLayer)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layoutSublayers(of layer: CALayer) {
-        super.layoutSublayers(of: layer)
-        layer.synchronizeLayoutChanges {
-            playerLayer.frame = layer.bounds
-        }
-    }
-}
-
-private extension CALayer {
-    func synchronizeLayoutChanges(_ changes: () -> Void) {
-        if let positionAnimation = animation(forKey: "position") {
-            CATransaction.begin()
-            CATransaction.setAnimationDuration(positionAnimation.duration)
-            CATransaction.setAnimationTimingFunction(positionAnimation.timingFunction)
-            changes()
-            CATransaction.commit()
-        }
-        else {
-            changes()
-            sublayers?.forEach { $0.removeAllAnimations() }
-        }
     }
 }


### PR DESCRIPTION
# Description

This PR fixes video view lagging animation issues we recently noticed when updating our Podcastator sandbox app.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/9bea2bb7-0f98-41d0-85ba-4eb34c077d49"/> | <video src="https://github.com/user-attachments/assets/0b54bfaf-a2da-46bb-9697-a7d411c1dc38"/> | 

# Changes made

- Use video layer as layer class of `VideoLayerView`.
- Update PiP implementation to store and restore a `VideoLayerView` instead of a layer.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
