### PR TITLE
Expose method to start Picture in Picture if possible

### DIFF
--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -31,6 +31,16 @@ public final class PictureInPicture {
         custom.delegate = self
         system.delegate = self
     }
+
+    /// Attempts to start Picture in Picture if possible.
+    ///
+    /// Only `VideoView` is currently supported. The method does nothing if no video view is currently available for
+    /// Picture in Picture.
+    ///
+    /// > Important: This method must only be started in response to some form of user interaction.
+    public func startIfPossible() {
+        custom.start()
+    }
 }
 
 extension PictureInPicture: PictureInPictureDelegate {

--- a/Sources/Player/Player.docc/Articles/picture-in-picture/picture-in-picture-article.md
+++ b/Sources/Player/Player.docc/Articles/picture-in-picture/picture-in-picture-article.md
@@ -44,8 +44,6 @@ Advanced integration is more involved and requires additional integration steps 
 - Dismiss and restore your player user interface when appropriate.
 - Continue playing even when the player user interface has been dismissed.
 
-> Important: Only begin PiP playback in response to user interaction and never programmatically. The App Store review team rejects apps that fail to follow this requirement.
-
 Advanced integration is available both for ``VideoView`` as well as ``SystemVideoView`` and is usually achieved as follows:
 
 1. Apply ``VideoView/supportsPictureInPicture(_:)`` on your ``VideoView`` or ``SystemVideoView/supportsPictureInPicture(_:)`` on your ``SystemVideoView``.


### PR DESCRIPTION
# Description

This PR adds a method to start PiP playback if possible. In the past I remember that rules were quite strict to avoid rejection by the App Review team. Nowadays the [only rule](https://developer.apple.com/documentation/avkit/adopting-picture-in-picture-in-a-custom-player#Handle-User-Initiated-Requests) is:

> Only begin PiP playback in response to user interaction and never programmatically. The App Store review team rejects apps that fail to follow this requirement.

What a _user interaction_ means is never explicitly stated. I checked App Review guidelines and HIG, nothing is specified. Moreover the tv+ app is enabling PiP when tapping on the _Details_ button, which has no PiP icon and does not explicitly inform that PiP will be enabled (but can of course be identified with a user interaction). The Twitch app enables it when tapping on the player minimization button and was validated by App Review. So I guess that the tolerance has increased over the past years.

Note that there is no way to start PiP with `AVPlayerViewController`, at least not with any public API. I therefore propose we name the method `startIfPossible`, therefore clearly stating that PiP might or not be started depending on availability.

# Changes made

- Add `PictureInPicture.startIfPossible()` method.
- Update documentation.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
