### PR TITLE
Update monitoring payload according to the specifications

### DIFF
--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -133,8 +133,8 @@ private extension MetricsTracker {
                 metadataUrl: metadata?.metadataUrl,
                 origin: Bundle.main.bundleIdentifier
             ),
-            qoeMetrics: .init(events: events),
-            qosMetrics: .init(events: events)
+            qoeTimings: .init(events: events),
+            qosTimings: .init(events: events)
         )
     }
 

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -13,8 +13,8 @@ struct MetricStartData: Encodable {
     let screen: Screen
     let player: Player
     let media: Media
-    let qoeMetrics: ExperienceMetrics?
-    let qosMetrics: ServiceMetrics?
+    let qoeTimings: ExperienceTimings?
+    let qosTimings: ServiceTimings?
 }
 
 extension MetricStartData {
@@ -42,7 +42,7 @@ extension MetricStartData {
         let version: String
     }
 
-    struct ExperienceMetrics: Encodable {
+    struct ExperienceTimings: Encodable {
         let metadata: Int?
         let asset: Int?
         let total: Int
@@ -83,7 +83,7 @@ extension MetricStartData {
         }
     }
 
-    struct ServiceMetrics: Encodable {
+    struct ServiceTimings: Encodable {
         let metadata: Int?
 
         init?(events: [MetricEvent]) {


### PR DESCRIPTION
## Description

This PR allows us to update the payload accordingly to the [documentation](https://srgssr.github.io/pillarbox-documentation/#/specifications/monitoring/MONITORING?id=start-event-data).

## Changes

- `qoeMetrics` and `qosMetrics` have been respectively updated to `qoeTimings` and `qosTimings`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
