### PR TITLE
Video view animation removal

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -246,6 +246,7 @@ private struct MainView: View {
                     .supportsPictureInPicture(supportsPictureInPicture)
             }
         }
+        .opacity(player.mediaType != .unknown ? 1 : 0)
         .animation(.easeIn(duration: 0.2), values: player.mediaType, player.isExternalPlaybackActive)
     }
 

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -39,7 +39,6 @@ public struct VideoView: View {
                 MonoscopicVideoView(player: player, orientation: orientation)
             }
         }
-        .opacity(player.mediaType != .unknown ? 1 : 0)
         .onAppear {
             PictureInPicture.shared.system.detach(with: player.queuePlayer)
             PictureInPicture.shared.custom.onAppear(


### PR DESCRIPTION
# Description

This PR removes internal `VideoView` opacity animations, based on media type availability, which should not be a library decision:

- The first frame is often loaded before the media type is known. The perceived loading time is therefore smaller without this animation.
- This leads to animations which sometimes might not be desired (e.g. in our playlist demo).
- The `SystemVideoView` works this way.
- The app can ultimately decide to implement such an animation if desired.

# Changes made

- Remove `VideoView` internal animations.
- Implement the same animation at the demo level.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
