### PR TITLE
Avoid pausing playback when a monoscopic view is destroyed

### DIFF
--- a/Sources/Player/Types/VideoNode.swift
+++ b/Sources/Player/Types/VideoNode.swift
@@ -9,7 +9,16 @@ import SpriteKit
 
 /// Lightweight video node subclass to disable automatic un-pause when waking the application from the background.
 final class VideoNode: SKVideoNode {
-    private static let _playerKey = "12_34p9l3a23y4e5r76".components(separatedBy: .decimalDigits).joined(separator: "")
+    private let _player: AVPlayer
+
+    override init(avPlayer player: AVPlayer) {
+        _player = player
+        super.init(avPlayer: player)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override var isPaused: Bool {
         get {
@@ -19,8 +28,9 @@ final class VideoNode: SKVideoNode {
     }
 
     deinit {
-        if #available(iOS 18, tvOS 18, *) {
-            setValue(nil, forKey: Self._playerKey)
+        let player = _player
+        DispatchQueue.main.async {
+            player.play()
         }
     }
 }

--- a/Sources/Player/Types/VideoNode.swift
+++ b/Sources/Player/Types/VideoNode.swift
@@ -11,20 +11,21 @@ import SpriteKit
 final class VideoNode: SKVideoNode {
     private let _player: AVPlayer
 
-    override init(avPlayer player: AVPlayer) {
-        _player = player
-        super.init(avPlayer: player)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override var isPaused: Bool {
         get {
             super.isPaused
         }
         set {}
+    }
+
+    override init(avPlayer player: AVPlayer) {
+        _player = player
+        super.init(avPlayer: player)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     deinit {

--- a/Sources/Player/Types/VideoNode.swift
+++ b/Sources/Player/Types/VideoNode.swift
@@ -4,14 +4,33 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import SpriteKit
 
 /// Lightweight video node subclass to disable automatic un-pause when waking the application from the background.
 final class VideoNode: SKVideoNode {
+    private let _player: AVPlayer
+
+    override init(avPlayer player: AVPlayer) {
+        _player = player
+        super.init(avPlayer: player)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override var isPaused: Bool {
         get {
             super.isPaused
         }
         set {}
+    }
+
+    deinit {
+        let player = _player
+        DispatchQueue.main.async {
+            player.play()
+        }
     }
 }

--- a/Sources/Player/Types/VideoNode.swift
+++ b/Sources/Player/Types/VideoNode.swift
@@ -28,9 +28,9 @@ final class VideoNode: SKVideoNode {
     }
 
     deinit {
-        let player = _player
-        DispatchQueue.main.async {
-            player.play()
+        let rate = _player.rate
+        DispatchQueue.main.async { [_player] in
+            _player.rate = rate
         }
     }
 }

--- a/Sources/Player/Types/VideoNode.swift
+++ b/Sources/Player/Types/VideoNode.swift
@@ -9,16 +9,7 @@ import SpriteKit
 
 /// Lightweight video node subclass to disable automatic un-pause when waking the application from the background.
 final class VideoNode: SKVideoNode {
-    private let _player: AVPlayer
-
-    override init(avPlayer player: AVPlayer) {
-        _player = player
-        super.init(avPlayer: player)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    private static let _playerKey = "12_34p9l3a23y4e5r76".components(separatedBy: .decimalDigits).joined(separator: "")
 
     override var isPaused: Bool {
         get {
@@ -28,9 +19,8 @@ final class VideoNode: SKVideoNode {
     }
 
     deinit {
-        let player = _player
-        DispatchQueue.main.async {
-            player.play()
+        if #available(iOS 18, tvOS 18, *) {
+            setValue(nil, forKey: Self._playerKey)
         }
     }
 }

--- a/Sources/Player/UserInterface/MonoscopicVideoView.swift
+++ b/Sources/Player/UserInterface/MonoscopicVideoView.swift
@@ -24,6 +24,8 @@ private struct _MonoscopicVideoView: UIViewRepresentable {
     let orientation: SCNQuaternion
 
     static func dismantleUIView(_ uiView: SCNView, coordinator: Coordinator) {
+        uiView.scene = nil
+        
         if let player = coordinator.player {
             DisplaySleep.shared.allow(for: player)
         }

--- a/Sources/Player/UserInterface/MonoscopicVideoView.swift
+++ b/Sources/Player/UserInterface/MonoscopicVideoView.swift
@@ -25,7 +25,7 @@ private struct _MonoscopicVideoView: UIViewRepresentable {
 
     static func dismantleUIView(_ uiView: SCNView, coordinator: Coordinator) {
         uiView.scene = nil
-        
+
         if let player = coordinator.player {
             DisplaySleep.shared.allow(for: player)
         }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -116,14 +116,6 @@ Seeks might feel sluggish when Spatial audio is enabled for connected AirPods. T
 
 No workaround is available yet.
 
-## Playback is paused when switching between 360° and standard videos in a playlist
-
-Playback is paused when switching between 360° and standard videos in a playlist. This results from the deallocation of video nodes in monoscopic scenes.
-
-### Workaround
-
-Playback can be resumed, either programmatically or by providing the user with playback controls.
-
 ## Control Center playback button state is incorrect in multi-player configurations (FB13684239)
 
 When mutiple player instances are used and one of them has been made active, the  Control Center playback button state does not always correctly reflect the state of the active player, but is altered by the state of the other available players as well.


### PR DESCRIPTION
# Description

This PR mitigates an issue affecting monoscopic views, whose destruction pauses playback of the associated player. It also fixes a minor resource leak associated with monoscopic views.

# Changes made

- Restore player rate after a monoscopic view is destroyed.
- Force node cleanup when a monoscopic view is dismantled.
- Remove associated known issue.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
