### PR TITLE
Avoid having the Playlist component directly update the current item

### DIFF
--- a/Sources/Player/UserInterface/Playlist.swift
+++ b/Sources/Player/UserInterface/Playlist.swift
@@ -14,10 +14,14 @@ public struct Playlist<RowContent>: View where RowContent: View {
 
     private let editActions: EditActions<[PlayerItem]>
     private let rowContent: (_ source: Any?, _ isCurrent: Bool) -> RowContent
+    @State private var selection: PlayerItem?
 
     public var body: some View {
-        List($player.items, id: \.self, editActions: editActions, selection: $player.currentItem) { item in
+        List($player.items, id: \.self, editActions: editActions, selection: $selection) { item in
             rowContent(item.wrappedValue.source, item.wrappedValue == player.currentItem)
+        }
+        .onChange(of: selection) { selection in
+            player.currentItem = selection
         }
     }
 


### PR DESCRIPTION
# Description

This PR allows us to resolve an issue related to the `Playlist`.

We encountered an issue with the playlist and the playback speed. 
Specifically, when a playback speed was chosen for the current item and another item was selected, the previously selected speed was lost.
We have observed that **SwiftUI** can set the binding variable briefly to `nil` when passed as the `selection` parameter of a `List` before to final value. 
This is likely part of the process SwiftUI uses to manage the selection and deselection of elements.
It’s just a supposition, since we couldn’t find any documentation about that behavior.

# Changes made

- We avoided passing the current item directly as a binding. Instead, we used an intermediate variable and we updated the current item in the `onChange` modifier.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
