### PR TITLE
Reduce unit test flakiness

### DIFF
--- a/Tests/CoreBusinessTests/PlayerItemTests.swift
+++ b/Tests/CoreBusinessTests/PlayerItemTests.swift
@@ -56,11 +56,4 @@ final class PlayerItemTests: XCTestCase {
             during: .seconds(1)
         )
     }
-
-    func testLoadNotLooping() {
-        let item = PlayerItem.urn("urn:swisstxt:video:rts:1793518")
-        _ = Player(item: item)
-        let output = collectOutput(from: item.$content, during: .seconds(1))
-        expect(output.count).to(equal(2))
-    }
 }

--- a/Tests/PlayerTests/Player/SpeedTests.swift
+++ b/Tests/PlayerTests/Player/SpeedTests.swift
@@ -86,10 +86,9 @@ final class SpeedTests: TestCase {
 
     func testSpeedUpdateWhenStartingPlayback() {
         let player = Player(item: .simple(url: Stream.dvr.url))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [1, 0.5],
-            from: player.changePublisher(at: \.effectivePlaybackSpeed).removeDuplicates(),
-            during: .seconds(2)
+            from: player.changePublisher(at: \.effectivePlaybackSpeed).removeDuplicates()
         ) {
             player.setDesiredPlaybackSpeed(0.5)
         }
@@ -97,10 +96,9 @@ final class SpeedTests: TestCase {
 
     func testSpeedRangeUpdateWhenStartingPlayback() {
         let player = Player(item: .simple(url: Stream.dvr.url))
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [1...1, 0.1...1],
-            from: player.changePublisher(at: \.playbackSpeedRange).removeDuplicates(),
-            during: .seconds(2)
+            from: player.changePublisher(at: \.playbackSpeedRange).removeDuplicates()
         ) {
             player.setDesiredPlaybackSpeed(0.5)
         }

--- a/Tests/PlayerTests/Playlist/CurrentItemTests.swift
+++ b/Tests/PlayerTests/Playlist/CurrentItemTests.swift
@@ -16,10 +16,9 @@ final class CurrentItemTests: TestCase {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [item1, item2, nil],
-            from: player.changePublisher(at: \.currentItem).removeDuplicates(),
-            during: .seconds(3)
+            from: player.changePublisher(at: \.currentItem).removeDuplicates()
         ) {
             player.play()
         }
@@ -56,10 +55,9 @@ final class CurrentItemTests: TestCase {
         let item1 = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let item2 = PlayerItem.simple(url: Stream.unavailable.url)
         let player = Player(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [item1, item2],
-            from: player.changePublisher(at: \.currentItem).removeDuplicates(),
-            during: .seconds(2)
+            from: player.changePublisher(at: \.currentItem).removeDuplicates()
         ) {
             player.play()
         }
@@ -105,10 +103,9 @@ final class CurrentItemTests: TestCase {
         let item1 = PlayerItem.mock(url: Stream.shortOnDemand.url, loadedAfter: 1)
         let item2 = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(items: [item1, item2])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [item1, item2],
-            from: player.changePublisher(at: \.currentItem).removeDuplicates(),
-            during: .seconds(3)
+            from: player.changePublisher(at: \.currentItem).removeDuplicates()
         ) {
             player.play()
         }
@@ -117,10 +114,9 @@ final class CurrentItemTests: TestCase {
     func testCurrentItemAfterPlayerEnded() {
         let item = PlayerItem.simple(url: Stream.shortOnDemand.url)
         let player = Player(items: [item])
-        expectEqualPublished(
+        expectAtLeastEqualPublished(
             values: [item, nil],
-            from: player.changePublisher(at: \.currentItem).removeDuplicates(),
-            during: .seconds(2)
+            from: player.changePublisher(at: \.currentItem).removeDuplicates()
         ) {
             player.play()
         }

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -99,13 +99,14 @@ final class VisibilityTrackerTests: TestCase {
     }
 
     func testResetAutoHide() {
-        let visibilityTracker = VisibilityTracker(delay: 0.5)
+        let visibilityTracker = VisibilityTracker(delay: 0.3)
         let player = Player(item: PlayerItem.simple(url: Stream.onDemand.url))
-        player.play()
         visibilityTracker.player = player
-        expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(400))
+        player.play()
+        expect(player.playbackState).toEventually(equal(.playing))
+        expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(200))
         visibilityTracker.reset()
-        expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(400))
+        expect(visibilityTracker.isUserInterfaceHidden).toAlways(beFalse(), until: .milliseconds(200))
     }
 
     func testResetDoesNotShowControls() {


### PR DESCRIPTION
# Description

This PR allows us to make some of our tests more robust and less flaky.

# Changes made

- A useless test has been removed.
- Some tests included timing have been revisited.
- A visibility tracker test has been made more stable.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
