### PR TITLE
Inform persisted objects when Picture is Picture is closed from its overlay

### DIFF
--- a/Sources/Player/Interfaces/PictureInPicturePersistable.swift
+++ b/Sources/Player/Interfaces/PictureInPicturePersistable.swift
@@ -21,6 +21,9 @@ public protocol PictureInPicturePersistable: AnyObject {
 
     /// Called when Picture in Picture has stopped.
     func pictureInPictureDidStop()
+
+    /// Called when Picture is Picture has been closed from its overlay.
+    func pictureInPictureDidClose()
 }
 
 public extension PictureInPicturePersistable {
@@ -40,4 +43,7 @@ public extension PictureInPicturePersistable {
 
     /// Default implementation. Does nothing.
     func pictureInPictureDidStop() {}
+
+    /// Default implementation. Does nothing.
+    func pictureInPictureDidClose() {}
 }

--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -27,6 +27,8 @@ public final class PictureInPicture {
     // Strong to retain when acquired.
     private(set) var persisted: PictureInPicturePersistable?
 
+    private var isRestored = false
+
     private init() {
         custom.delegate = self
         system.delegate = self
@@ -61,6 +63,7 @@ extension PictureInPicture: PictureInPictureDelegate {
     }
 
     public func pictureInPictureRestoreUserInterfaceForStop(with completion: @escaping (Bool) -> Void) {
+        isRestored = true
         if let delegate {
             delegate.pictureInPictureRestoreUserInterfaceForStop { finished in
                 // The Picture in Picture overlay restoration animation should always occur slightly after the playback
@@ -83,7 +86,10 @@ extension PictureInPicture: PictureInPictureDelegate {
 
     public func pictureInPictureDidStop() {
         delegate?.pictureInPictureDidStop()
-        persisted?.pictureInPictureDidStop()
+        if !isRestored {
+            persisted?.pictureInPictureDidClose()
+        }
+        isRestored = false
         persisted = nil
     }
 }


### PR DESCRIPTION
# Description

This PR adds a method to the `PictureInPicturePersistable` protocol, called when PiP is closed from its overlay.

# Changes made

Self-explanatory.

# Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
