### PR TITLE
Fix Picture in Picture button documentation

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -192,7 +192,9 @@ private struct MainView: View {
         HStack {
             HStack(spacing: 20) {
                 CloseButton()
-                PiPButton()
+                if supportsPictureInPicture {
+                    PiPButton()
+                }
                 routePickerView()
             }
             .opacity(shouldHideInterface ? 0 : 1)

--- a/Demo/Sources/Showcase/PiP/TransitionPiPView.swift
+++ b/Demo/Sources/Showcase/PiP/TransitionPiPView.swift
@@ -35,7 +35,7 @@ struct TransitionPiPView: View {
     var body: some View {
         VStack {
             PlaybackView(player: model.player)
-                .supportsPictureInPicture(supportsPictureInPicture)
+                .supportsPictureInPicture(supportsPictureInPicture && !isPresented)
 
             VStack(spacing: 20) {
                 Toggle("Supports PiP", isOn: $supportsPictureInPicture)

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -11,8 +11,8 @@ import SwiftUI
 /// The button is automatically hidden when Picture in Picture is not available. The body closure is provided a
 /// Boolean indicating when Picture in Picture is active.
 ///
-/// For the button to be visible one of its parents must be enabled for in-app Picture in Picture by applying the
-/// `View/enabledForInAppPictureInPicture(persisting:)` modifier.
+/// For the button to be visible at least one `VideoView` or `SystemVideoView` must be enabled for in-app Picture in
+/// Picture by applying the `View/enabledForInAppPictureInPicture(persisting:)` modifier to one of its parent views.
 public struct PictureInPictureButton<Content>: View where Content: View {
     private let content: (Bool) -> Content
 


### PR DESCRIPTION
## Description

This PR fixes misleading Picture in Picture button documentation (button availability is global and not tied to the parent view hierarchy).

## Changes made

- Fix Picture in Picture documentation.
- Manage button visibility locally in a better way, as suggested by @waliid.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
