### PR TITLE
Monitor SRG SSR content

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -79,7 +79,6 @@
 		6F59E8A329CF31E20093E6FB /* ExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E87729CF31E10093E6FB /* ExamplesView.swift */; };
 		6F59E8A429CF31E20093E6FB /* ExamplesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59E87829CF31E10093E6FB /* ExamplesViewModel.swift */; };
 		6F6643D92A61140600BFD644 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6643D82A61140600BFD644 /* URL.swift */; };
-		6F691D7A2C66C1C600C70BB8 /* PillarboxMonitoring in Frameworks */ = {isa = PBXBuildFile; productRef = 6F691D792C66C1C600C70BB8 /* PillarboxMonitoring */; };
 		6F7DDB5F2C20360F00B48A67 /* StallsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DDB5E2C20360B00B48A67 /* StallsChart.swift */; };
 		6F7DDB612C20388800B48A67 /* FrameDropsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DDB602C20388200B48A67 /* FrameDropsChart.swift */; };
 		6F7DDB632C20395100B48A67 /* DataVolumeChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7DDB622C20394600B48A67 /* DataVolumeChart.swift */; };
@@ -229,7 +228,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */,
-				6F691D7A2C66C1C600C70BB8 /* PillarboxMonitoring in Frameworks */,
 				0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */,
 				6F9B5BC928CF8C530074B9E0 /* OrderedCollections in Frameworks */,
 				6F09A2922B48744000700365 /* PillarboxCoreBusiness in Frameworks */,
@@ -613,7 +611,6 @@
 				6FCA4746292CBEC7008C2812 /* ShowTime */,
 				0EF42CB529AE513400553165 /* SRGDataProviderCombine */,
 				6F09A2912B48744000700365 /* PillarboxCoreBusiness */,
-				6F691D792C66C1C600C70BB8 /* PillarboxMonitoring */,
 			);
 			productName = PillarboxDemo;
 			productReference = 6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */;
@@ -1102,10 +1099,6 @@
 		6F09A2912B48744000700365 /* PillarboxCoreBusiness */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PillarboxCoreBusiness;
-		};
-		6F691D792C66C1C600C70BB8 /* PillarboxMonitoring */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PillarboxMonitoring;
 		};
 		6F9B5BC828CF8C530074B9E0 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -222,6 +222,7 @@ struct MetricsView: View {
                     Text(identifier)
 #if os(iOS)
                         .textSelection(.enabled)
+                        .swipeActions { CopyButton(text: identifier) }
 #endif
                 }
             } header: {

--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,8 @@ let package = Package(
         .target(
             name: "PillarboxCoreBusiness",
             dependencies: [
-                .target(name: "PillarboxAnalytics")
+                .target(name: "PillarboxAnalytics"),
+                .target(name: "PillarboxMonitoring")
             ],
             path: "Sources/CoreBusiness",
             resources: [

--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -34,7 +34,7 @@ public extension PlayerItem {
                 CommandersActTracker.adapter { $0.analyticsMetadata },
                 MetricsTracker.adapter(
                     configuration: .init(
-                        serviceUrl: URL(string: "http://sse-broker-alb-1501344577.eu-central-1.elb.amazonaws.com/api/events")!
+                        serviceUrl: URL(string: "https://monitoring.pillarbox.ch/api/events")!
                     ),
                     behavior: .mandatory
                 ) { metadata in

--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -39,7 +39,7 @@ public extension PlayerItem {
                     behavior: .mandatory
                 ) { metadata in
                     MetricsTracker.Metadata(
-                        identifier: metadata.mediaComposition.mainChapter.urn,
+                        identifier: metadata.mainChapter.urn,
                         metadataUrl: metadata.mediaCompositionUrl,
                         assetUrl: metadata.resource.url
                     )

--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -7,6 +7,7 @@
 import AVFoundation
 import Combine
 import PillarboxAnalytics
+import PillarboxMonitoring
 import PillarboxPlayer
 
 public extension PlayerItem {
@@ -30,7 +31,19 @@ public extension PlayerItem {
             publisher: publisher(forUrn: urn, server: server, configuration: configuration),
             trackerAdapters: [
                 ComScoreTracker.adapter { $0.analyticsData },
-                CommandersActTracker.adapter { $0.analyticsMetadata }
+                CommandersActTracker.adapter { $0.analyticsMetadata },
+                MetricsTracker.adapter(
+                    configuration: .init(
+                        serviceUrl: URL(string: "http://sse-broker-alb-1501344577.eu-central-1.elb.amazonaws.com/api/events")!
+                    ),
+                    behavior: .mandatory
+                ) { metadata in
+                    MetricsTracker.Metadata(
+                        identifier: metadata.mediaComposition.mainChapter.urn,
+                        metadataUrl: metadata.mediaCompositionUrl,
+                        assetUrl: metadata.resource.url
+                    )
+                }
             ] + trackerAdapters
         )
     }

--- a/Sources/Monitoring/Extensions/Double.swift
+++ b/Sources/Monitoring/Extensions/Double.swift
@@ -4,8 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import Foundation
-
 extension Double {
     var toMilliseconds: Int {
         Int((self * 1000).rounded())

--- a/Sources/Player/Publishers/PlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/PlayerItemPublishers.swift
@@ -6,7 +6,6 @@
 
 import Combine
 import Foundation
-import PillarboxCore
 
 extension PlayerItem {
     private static func experience(fromService service: DateInterval, startDate: Date) -> DateInterval {

--- a/Sources/Player/Types/RepeatMode.swift
+++ b/Sources/Player/Types/RepeatMode.swift
@@ -4,8 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import Foundation
-
 /// A mode setting how a player repeats playback of items in its queue.
 public enum RepeatMode {
     /// Disabled.

--- a/Sources/Player/Types/Viewport.swift
+++ b/Sources/Player/Types/Viewport.swift
@@ -4,8 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import SceneKit
-
 /// A video viewport.
 public enum Viewport {
     /// Standard viewport.

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -25,7 +25,7 @@ final class DataProviderTests: XCTestCase {
 
     func testBlockedMediaMetadata() {
         expectFailure(
-            DataError.blocked(withMessage: "Some message"),
+            DataError.blocked(withMessage: ""),
             from: DataProvider().mediaMetadataPublisher(forUrn: "urn:rts:video:13382911")
         )
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Nimble
 import PillarboxCircumspect
-import PillarboxStreams
 
 final class AVPlayerItemRepeatAllUpdateTests: TestCase {
     func testPlayerItemsWithoutCurrentItem() {

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Nimble
 import PillarboxCircumspect
-import PillarboxStreams
 
 final class AVPlayerItemRepeatOffUpdateTests: TestCase {
     func testPlayerItemsWithoutCurrentItem() {

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Nimble
 import PillarboxCircumspect
-import PillarboxStreams
 
 final class AVPlayerItemRepeatOneUpdateTests: TestCase {
     func testPlayerItemsWithoutCurrentItem() {

--- a/Tests/PlayerTests/Player/PlaybackTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackTests.swift
@@ -7,7 +7,6 @@
 @testable import PillarboxPlayer
 
 import Combine
-import Nimble
 import PillarboxCircumspect
 import PillarboxStreams
 import XCTest

--- a/Tests/PlayerTests/Player/PlaybackTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackTests.swift
@@ -4,23 +4,23 @@
 //  License information is available from the LICENSE file.
 //
 
-@testable import PillarboxCoreBusiness
 @testable import PillarboxPlayer
 
 import Combine
 import Nimble
 import PillarboxCircumspect
+import PillarboxStreams
 import XCTest
 
-final class PlayerItemTests: XCTestCase {
+final class PlaybackTests: XCTestCase {
     private func playbackStatePublisher(for player: Player) -> AnyPublisher<PlaybackState, Never> {
         player.propertiesPublisher
             .slice(at: \.playbackState)
             .eraseToAnyPublisher()
     }
 
-    func testUrnPlaybackHLS() {
-        let item = PlayerItem.urn("urn:rts:video:6820736")
+    func testHLS() {
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
         let player = Player(item: item)
         expectAtLeastEqualPublished(
             values: [.idle, .paused],
@@ -28,8 +28,8 @@ final class PlayerItemTests: XCTestCase {
         )
     }
 
-    func testUrnPlaybackMP3() {
-        let item = PlayerItem.urn("urn:rsi:audio:1861947")
+    func testMP3() {
+        let item = PlayerItem.simple(url: Stream.mp3.url)
         let player = Player(item: item)
         expectAtLeastEqualPublished(
             values: [.idle, .paused],
@@ -37,18 +37,8 @@ final class PlayerItemTests: XCTestCase {
         )
     }
 
-    func testUrnPlaybackUnknown() {
-        let item = PlayerItem.urn("urn:srf:video:unknown")
-        let player = Player(item: item)
-        expectEqualPublished(
-            values: [.idle],
-            from: playbackStatePublisher(for: player),
-            during: .seconds(1)
-        )
-    }
-
-    func testUrnPlaybackNotAvailableAnymore() {
-        let item = PlayerItem.urn("urn:rts:video:13382911")
+    func testUnknown() {
+        let item = PlayerItem.simple(url: Stream.unavailable.url)
         let player = Player(item: item)
         expectEqualPublished(
             values: [.idle],

--- a/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerItemTrackerMetricPublisherTests.swift
@@ -6,7 +6,6 @@
 
 @testable import PillarboxPlayer
 
-import Nimble
 import PillarboxCircumspect
 import PillarboxStreams
 

--- a/Tests/PlayerTests/Tracking/PlayerItemTrackerSessionTests.swift
+++ b/Tests/PlayerTests/Tracking/PlayerItemTrackerSessionTests.swift
@@ -7,7 +7,6 @@
 @testable import PillarboxPlayer
 
 import Nimble
-import PillarboxCircumspect
 import PillarboxStreams
 
 final class PlayerItemTrackerSessionTests: TestCase {


### PR DESCRIPTION
## Description

This PR allows us to monitor all **SRG SSR** content.

## Changes made

- `PillarboxCoreBusiness` now depends on `PillarboxMonitoring`.
- **SRG SSR** content is monitored via `https://monitoring.pillarbox.ch/api/events`
- Some tests have been cleaned.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
