### PR TITLE
Set LSMinimumSystemVersion to 14.0

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -26,13 +26,19 @@
 	<array>
 		<string>github</string>
 	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MMFServiceURL</key>
+	<string>$(MMF_SERVICE_URL)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>TestFlightApplicationIdentifier</key>
+	<string>$(TEST_FLIGHT_APPLICATION_IDENTIFIER)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -62,9 +68,5 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
-	<key>TestFlightApplicationIdentifier</key>
-	<string>$(TEST_FLIGHT_APPLICATION_IDENTIFIER)</string>
-	<key>MMFServiceURL</key>
-	<string>$(MMF_SERVICE_URL)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

This PR allows us to fix the `LSMinimumSystemVersion` to avoid Apple warning message.

> [!WARNING]
> ITMS-90899: Macs with Apple silicon support issue - The app isn‘t compatible with the provided minimum macOS version of 13.0. It can run on macOS 14.0 or later. Please specify an LSMinimumSystemVersion value of 14.0 or later in a new build, or select a compatible version in App Store Connect

## Changes made

- `LSMinimumSystemVersion` has been added to the **Info.plist** and set to **14.0**.

## Checklist

- [X] APIs have been properly documented (if relevant).
- [X] The documentation has been updated (if relevant).
- [X] New unit tests have been written (if relevant).
- [X] The demo has been updated (if relevant).
