### PR TITLE
Fix performance issue

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "ec5b7d6192ce5ecd1ab40a8f7a6aa75a19f7d1c7",
-        "version" : "5.4.11"
+        "revision" : "24ffbad1da8467b615958be9d0dd1e92c4396699",
+        "version" : "5.4.12"
       }
     },
     {

--- a/Sources/Analytics/ComScore/Capture/ComScoreHitInterceptor.swift
+++ b/Sources/Analytics/ComScore/Capture/ComScoreHitInterceptor.swift
@@ -56,7 +56,7 @@ enum ComScoreHitInterceptor {
 }
 
 private extension Notification.Name {
-    static let didReceiveComScoreRequest = Notification.Name("URLSessionDidReceiveComScoreRequestNotification")
+    static let didReceiveComScoreRequest = Notification.Name("PillarboxAnalytics_didReceiveComScoreRequest")
 }
 
 private extension URLSession {

--- a/Sources/Monitoring/Types/Notification.Name.swift
+++ b/Sources/Monitoring/Types/Notification.Name.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 enum MetricRequestInfoKey: String {
-    case identifier = "MetricRequestIdentifier"
-    case payload = "MetricRequestIdentifierPayload"
+    case identifier = "MetricRequestInfoKey_identifier"
+    case payload = "MetricRequestInfoKey_payload"
 }
 
 extension Notification.Name {
-    static let didSendMetricRequest = Notification.Name(rawValue: "MetricsTrackerDidSendMetricRequestNotification")
+    static let didSendMetricRequest = Notification.Name(rawValue: "PillarboxMonitoring_didSendMetricRequest")
 }

--- a/Sources/Player/Extensions/AVAudioSession.swift
+++ b/Sources/Player/Extensions/AVAudioSession.swift
@@ -70,5 +70,5 @@ extension AVAudioSession {
 }
 
 extension Notification.Name {
-    static let didUpdateAudioSessionOptions = Notification.Name("PillarboxPlayerDidUpdateAudioSessionOptionsNotification")
+    static let didUpdateAudioSessionOptions = Notification.Name("PillarboxPlayer_didUpdateAudioSessionOptions")
 }

--- a/Sources/Player/Extensions/Notification.Name.swift
+++ b/Sources/Player/Extensions/Notification.Name.swift
@@ -11,6 +11,6 @@ enum SeekKey: String {
 }
 
 extension Notification.Name {
-    static let willSeek = Notification.Name("QueuePlayerWillSeekNotification")
-    static let didSeek = Notification.Name("QueuePlayerDidSeekNotification")
+    static let willSeek = Notification.Name("PillarboxPlayer_willSeekNotification")
+    static let didSeek = Notification.Name("PillarboxPlayer_didSeekNotification")
 }

--- a/Sources/Player/Player+PlaybackSpeed.swift
+++ b/Sources/Player/Player+PlaybackSpeed.swift
@@ -44,7 +44,7 @@ extension Player {
         Publishers.Merge3(
             desiredPlaybackSpeedUpdatePublisher(),
             supportedPlaybackSpeedPublisher(),
-            avPlayerViewControllerPlaybackSpeedUpdatePublisher()
+            defaultRateSpeedUpdatePublisher()
         )
         .removeDuplicates()
         .eraseToAnyPublisher()
@@ -92,14 +92,8 @@ private extension Player {
         .eraseToAnyPublisher()
     }
 
-    func avPlayerViewControllerPlaybackSpeedUpdatePublisher() -> AnyPublisher<PlaybackSpeedUpdate, Never> {
-        propertiesPublisher
-            .slice(at: \.rate)
-            .filter { rate in
-                rate != 0 && Thread.callStackSymbols.contains { symbol in
-                    symbol.contains("AVPlayerController")
-                }
-            }
+    func defaultRateSpeedUpdatePublisher() -> AnyPublisher<PlaybackSpeedUpdate, Never> {
+        queuePlayer.publisher(for: \.defaultRate)
             .removeDuplicates()
             .map { .value($0) }
             .eraseToAnyPublisher()


### PR DESCRIPTION
## Description

This PR fixes a performance issue associated with a trick that was neither the most reliable, nor the most efficient way to find whether a rate change was initiated from the system player UI.

## Changes made

- Detect changes made to the playback speed via `defaultRate` changes instead of `rate` changes triggered from a specific call stack (unreliable).
- Update Commanders Act dependency (in the hope of possible optimizations, but none made).
- Improve internal notification names (less consistent with how first-party notifications are internally named but less likely to be exposed to naming conflicts).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
