### PR TITLE
Never display route selection for iPad apps run on macOS or Catalyst

### DIFF
--- a/Sources/Player/Player.docc/Articles/airplay/airplay-article.md
+++ b/Sources/Player/Player.docc/Articles/airplay/airplay-article.md
@@ -9,7 +9,7 @@ Enable video and audio wireless sharing to Apple TV or AirPlay‑enabled receive
 
 ## Overview
 
-> Important: AirPlay integration is only meaningful for iOS apps.
+> Important: AirPlay integration is only meaningful for iOS apps. Note that iPad apps run on macOS or using Catalyst do not support AirPlay either.
 
 ``Player`` natively supports [AirPlay](https://developer.apple.com/airplay/) to compatible receivers. Enabling AirPlay in your app requires some general setup as well as activation on a player basis.
 

--- a/Sources/Player/UserInterface/RoutePickerView.swift
+++ b/Sources/Player/UserInterface/RoutePickerView.swift
@@ -7,12 +7,37 @@
 import AVKit
 import SwiftUI
 
+private struct _RoutePickerView: UIViewRepresentable {
+    let prioritizesVideoDevices: Bool
+    let activeTintColor: Color?
+
+    func makeUIView(context: Context) -> AVRoutePickerView {
+        AVRoutePickerView()
+    }
+
+    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {
+        uiView.prioritizesVideoDevices = prioritizesVideoDevices
+        if let activeTintColor {
+            uiView.activeTintColor = UIColor(activeTintColor)
+        }
+    }
+}
+
 /// A button to pick a playback route.
 ///
-/// Behavior: h-exp, v-exp
-public struct RoutePickerView: UIViewRepresentable {
+/// > Important: This button is not available for iPad applications run on macOS or using Catalyst.
+public struct RoutePickerView: View {
     private var prioritizesVideoDevices: Bool
     private var activeTintColor: Color?
+
+    public var body: some View {
+        if !ProcessInfo.processInfo.isRunningOnMac {
+            _RoutePickerView(prioritizesVideoDevices: prioritizesVideoDevices, activeTintColor: activeTintColor)
+        }
+        else {
+            EmptyView()
+        }
+    }
 
     /// Creates a route picker button.
     ///
@@ -21,17 +46,6 @@ public struct RoutePickerView: UIViewRepresentable {
     ///   show a videocentric icon.
     public init(prioritizesVideoDevices: Bool = false) {
         self.prioritizesVideoDevices = prioritizesVideoDevices
-    }
-
-    public func makeUIView(context: Context) -> AVRoutePickerView {
-        AVRoutePickerView()
-    }
-
-    public func updateUIView(_ uiView: AVRoutePickerView, context: Context) {
-        uiView.prioritizesVideoDevices = prioritizesVideoDevices
-        if let activeTintColor {
-            uiView.activeTintColor = UIColor(activeTintColor)
-        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR prevents route selection from being made in iPad apps run on macOS or using Catalyst. AirPlay simply does not work in such cases and, even though the route picker can be displayed, playback will simply fail when an AirPlay receiver has been selected.

Note that AirPlay works in full-fledged macOS apps, but sadly Pillarbox does not yet support this platform.

## Changes made

- Replace route picker button with an empty view on desktop iPad targets.
- Update documentation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
