### PR TITLE
feat: Support playback of Media Composition URL

### DIFF
--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -7,34 +7,6 @@
 import Combine
 import Foundation
 
-final class DataProvider {
-    private let server: Server
-    private let session: URLSession
-
-    init(server: Server = .production) {
-        self.server = server
-        session = URLSession(configuration: .default)
-    }
-
-    static func decoder() -> JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return decoder
-    }
-
-    func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaCompositionResponse, Error> {
-        session.dataTaskPublisher(for: server.mediaCompositionRequest(forUrn: urn))
-            .mapHttpErrors()
-            .tryMap { data, response in
-                MediaCompositionResponse(
-                    mediaComposition: try Self.decoder().decode(MediaComposition.self, from: data),
-                    response: response
-                )
-            }
-            .eraseToAnyPublisher()
-    }
-
-    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
-        server.resizedImageUrl(url, width: width)
-    }
+protocol DataProvider {
+    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL
 }

--- a/Sources/CoreBusiness/DataProvider/MediaCompositionDataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/MediaCompositionDataProvider.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Foundation
+
+final class MediaCompositionDataProvider : DataProvider {
+    private let session: URLSession
+
+    init() {
+        session = URLSession(configuration: .default)
+    }
+
+    static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func mediaCompositionPublisher(forUrl url: URL) -> AnyPublisher<MediaCompositionResponse, Error> {
+        session.dataTaskPublisher(for: URLRequest.init(url: url))
+            .mapHttpErrors()
+            .tryMap { data, response in
+                let a = try MediaCompositionDataProvider.decoder().decode(MediaComposition.self, from: data)
+                return MediaCompositionResponse(
+                    mediaComposition: try Self.decoder().decode(MediaComposition.self, from: data),
+                    response: response
+                )
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
+        // Media Compositions don't provide resize capability
+        return url
+    }
+}

--- a/Sources/CoreBusiness/DataProvider/UrnDataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/UrnDataProvider.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Combine
+import Foundation
+
+final class UrnDataProvider : DataProvider {
+    private let server: Server
+    private let session: URLSession
+
+    init(server: Server = .production) {
+        self.server = server
+        session = URLSession(configuration: .default)
+    }
+
+    static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaCompositionResponse, Error> {
+        session.dataTaskPublisher(for: server.mediaCompositionRequest(forUrn: urn))
+            .mapHttpErrors()
+            .tryMap { data, response in
+                MediaCompositionResponse(
+                    mediaComposition: try Self.decoder().decode(MediaComposition.self, from: data),
+                    response: response
+                )
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
+        server.resizedImageUrl(url, width: width)
+    }
+}


### PR DESCRIPTION
## Description

Support Media Composition for Business.
Media Compositions were already supported in the Letterbox on Web, and are also supported on `pillarbox-android`, so it would be awesome to have these also available on the apple platform.

## Changes made

> Added a DataProvider and source handler for a media composition url endpoint.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
