### PR TITLE
Add support for Low Data Mode and bandwidth / resolution limits

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		6F0E5CD52B33A41F0031E313 /* MonoscopicVideoView~ios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0E5CD42B33A41F0031E313 /* MonoscopicVideoView~ios.swift */; };
 		6F12A9522BD2B8A300AD6DDB /* IntegratingWithControlCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F12A9512BD2B8A300AD6DDB /* IntegratingWithControlCenter.swift */; };
 		6F26F35E2B33B73900392ED4 /* SupportingBasicPictureInPicture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F26F35D2B33B73900392ED4 /* SupportingBasicPictureInPicture.swift */; };
+		6F32EED12CD415E700285694 /* QualitySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F32EED02CD415E700285694 /* QualitySetting.swift */; };
 		6F3724A42C74D6E90091C488 /* UnbufferedURLMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3724A32C74D6E90091C488 /* UnbufferedURLMedia.swift */; };
 		6F3724A62C74D6F30091C488 /* URNMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3724A52C74D6F30091C488 /* URNMedia.swift */; };
 		6F3724A82C74E3130091C488 /* PlaylistSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3724A72C74E3130091C488 /* PlaylistSelectionView.swift */; };
@@ -136,6 +137,7 @@
 		6F0E5CD42B33A41F0031E313 /* MonoscopicVideoView~ios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MonoscopicVideoView~ios.swift"; sourceTree = "<group>"; };
 		6F12A9512BD2B8A300AD6DDB /* IntegratingWithControlCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegratingWithControlCenter.swift; sourceTree = "<group>"; };
 		6F26F35D2B33B73900392ED4 /* SupportingBasicPictureInPicture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportingBasicPictureInPicture.swift; sourceTree = "<group>"; };
+		6F32EED02CD415E700285694 /* QualitySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualitySetting.swift; sourceTree = "<group>"; };
 		6F3724A32C74D6E90091C488 /* UnbufferedURLMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnbufferedURLMedia.swift; sourceTree = "<group>"; };
 		6F3724A52C74D6F30091C488 /* URNMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URNMedia.swift; sourceTree = "<group>"; };
 		6F3724A72C74E3130091C488 /* PlaylistSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistSelectionView.swift; sourceTree = "<group>"; };
@@ -341,17 +343,18 @@
 		6F59E84529CF31E10093E6FB /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				6F3724A52C74D6F30091C488 /* URNMedia.swift */,
-				6F3724A32C74D6E90091C488 /* UnbufferedURLMedia.swift */,
 				6F59E84B29CF31E10093E6FB /* Media.swift */,
 				6F59E84C29CF31E10093E6FB /* MediaDescription.swift */,
+				6F59E84A29CF31E10093E6FB /* MediaList.swift */,
 				6FF7C9842C0084CE00FBDADB /* PlaybackHudColor.swift */,
 				6FF7C9822C0084BC00FBDADB /* PlaybackHudFontSize.swift */,
-				6F59E84A29CF31E10093E6FB /* MediaList.swift */,
+				6F32EED02CD415E700285694 /* QualitySetting.swift */,
 				6F59E84929CF31E10093E6FB /* RadioChannel.swift */,
 				6FF7C9862C0084DD00FBDADB /* SeekBehaviorSetting.swift */,
 				6F59E84729CF31E10093E6FB /* ServerSetting.swift */,
+				6F3724A32C74D6E90091C488 /* UnbufferedURLMedia.swift */,
 				6F59E84829CF31E10093E6FB /* URLMedia.swift */,
+				6F3724A52C74D6F30091C488 /* URNMedia.swift */,
 				6F59E84629CF31E10093E6FB /* Vendor.swift */,
 			);
 			path = Model;
@@ -770,6 +773,7 @@
 				6F59E89029CF31E20093E6FB /* Story.swift in Sources */,
 				6F9A86162CA153D10007D287 /* MultiPiPViewModel.swift in Sources */,
 				6F59E89D29CF31E20093E6FB /* VanillaPlayerView.swift in Sources */,
+				6F32EED12CD415E700285694 /* QualitySetting.swift in Sources */,
 				6FB077172C9AABCF0027148A /* TransitionPiPView.swift in Sources */,
 				6FB077192C9AABCF0027148A /* TwinsPiPView.swift in Sources */,
 			);

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -234,6 +234,9 @@
     "Project" : {
 
     },
+    "Quality" : {
+
+    },
     "Red" : {
 
     },

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -144,7 +144,7 @@ extension Media: AssetMetadata {
             return .image(image)
         }
         else if let imageUrl {
-            return .url(imageUrl)
+            return .url(standardResolution: imageUrl)
         }
         else {
             return .none

--- a/Demo/Sources/Model/QualitySetting.swift
+++ b/Demo/Sources/Model/QualitySetting.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import PillarboxPlayer
+
+@objc
+enum QualitySetting: Int, CaseIterable {
+    case low
+    case medium
+    case high
+
+    var name: String {
+        switch self {
+        case .low:
+            return "Low"
+        case .medium:
+            return "Medium"
+        case .high:
+            return "High"
+        }
+    }
+
+    var limits: PlayerLimits {
+        switch self {
+        case .low:
+            return .init(preferredPeakBitRate: 500_000)
+        case .medium:
+            return .init(preferredPeakBitRate: 2_000_000)
+        case .high:
+            return .none
+        }
+    }
+}

--- a/Demo/Sources/Model/SeekBehaviorSetting.swift
+++ b/Demo/Sources/Model/SeekBehaviorSetting.swift
@@ -7,7 +7,16 @@
 import Foundation
 
 @objc
-enum SeekBehaviorSetting: Int {
+enum SeekBehaviorSetting: Int, CaseIterable {
     case immediate
     case deferred
+
+    var name: String {
+        switch self {
+        case .immediate:
+            return "Immediate"
+        case .deferred:
+            return "Deferred"
+        }
+    }
 }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -445,6 +445,7 @@ private struct SettingsMenu: View {
     var body: some View {
         Menu {
             player.standardSettingMenu()
+            QualityMenu(player: player)
             metricsMenu()
         } label: {
             Image(systemName: "ellipsis.circle")
@@ -465,6 +466,29 @@ private struct SettingsMenu: View {
 
     private func showMetrics() {
         isPresentingMetrics = true
+    }
+}
+
+private struct QualityMenu: View {
+    let player: Player
+
+    @AppStorage(UserDefaults.DemoSettingKey.qualitySetting.rawValue)
+    private var qualitySetting: QualitySetting = .high
+
+    var body: some View {
+        Menu {
+            Picker("Quality", selection: $qualitySetting) {
+                ForEach(QualitySetting.allCases, id: \.self) { quality in
+                    Text(quality.name).tag(quality)
+                }
+            }
+        } label: {
+            Label {
+                Text("Quality")
+            } icon: {
+                Image(systemName: "person.and.background.dotted")
+            }
+        }
     }
 }
 
@@ -843,6 +867,9 @@ struct PlaybackView: View {
     @Binding private var layout: Layout
     @State private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 1))
 
+    @AppStorage(UserDefaults.DemoSettingKey.qualitySetting.rawValue)
+    private var qualitySetting: QualitySetting = .high
+
     private var supportsPictureInPicture = false
 
     var body: some View {
@@ -861,6 +888,12 @@ struct PlaybackView: View {
                         CloseButton(topBarStyle: true)
                     }
             }
+        }
+        .onChange(of: qualitySetting) { newValue in
+            player.limits = newValue.limits
+        }
+        .onAppear {
+            player.limits = qualitySetting.limits
         }
         .background(.black)
         .bind(progressTracker, to: player)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -867,9 +867,6 @@ struct PlaybackView: View {
     @Binding private var layout: Layout
     @State private var progressTracker = ProgressTracker(interval: CMTime(value: 1, timescale: 1))
 
-    @AppStorage(UserDefaults.DemoSettingKey.qualitySetting.rawValue)
-    private var qualitySetting: QualitySetting = .high
-
     private var supportsPictureInPicture = false
 
     var body: some View {
@@ -888,12 +885,6 @@ struct PlaybackView: View {
                         CloseButton(topBarStyle: true)
                     }
             }
-        }
-        .onChange(of: qualitySetting) { newValue in
-            player.limits = newValue.limits
-        }
-        .onAppear {
-            player.limits = qualitySetting.limits
         }
         .background(.black)
         .bind(progressTracker, to: player)

--- a/Demo/Sources/Players/PlayerViewModel.swift
+++ b/Demo/Sources/Players/PlayerViewModel.swift
@@ -5,6 +5,7 @@
 //
 
 import Combine
+import Foundation
 import PillarboxPlayer
 
 final class PlayerViewModel: ObservableObject, PictureInPicturePersistable {
@@ -23,9 +24,20 @@ final class PlayerViewModel: ObservableObject, PictureInPicturePersistable {
     @Published var layout: PlaybackView.Layout = .minimized
 
     let player = Player(configuration: .standard)
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        configureLimitsPublisher()
+    }
 
     func play() {
         player.becomeActive()
         player.play()
+    }
+
+    private func configureLimitsPublisher() {
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player)
+            .store(in: &cancellables)
     }
 }

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -73,6 +73,9 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.DemoSettingKey.seekBehaviorSetting.rawValue)
     private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
 
+    @AppStorage(UserDefaults.DemoSettingKey.qualitySetting.rawValue)
+    private var qualitySetting: QualitySetting = .high
+
     @AppStorage(UserDefaults.PlaybackHudSettingKey.enabled.rawValue, store: .playbackHud)
     private var playbackHudEnabled = false
 
@@ -162,6 +165,7 @@ struct SettingsView: View {
                 Text("Improves playlist navigation so that it feels more natural.").font(.footnote)
             }
             seekBehaviorPicker()
+            qualityPicker()
         } header: {
              Text("Player")
                 .headerStyle()
@@ -171,8 +175,21 @@ struct SettingsView: View {
     @ViewBuilder
     private func seekBehaviorPicker() -> some View {
         Picker("Seek behavior", selection: $seekBehaviorSetting) {
-            Text("Immediate").tag(SeekBehaviorSetting.immediate)
-            Text("Deferred").tag(SeekBehaviorSetting.deferred)
+            ForEach(SeekBehaviorSetting.allCases, id: \.self) { setting in
+                Text(setting.name).tag(setting)
+            }
+        }
+#if os(tvOS)
+        .pickerStyle(.navigationLink)
+#endif
+    }
+
+    @ViewBuilder
+    private func qualityPicker() -> some View {
+        Picker("Quality", selection: $qualitySetting) {
+            ForEach(QualitySetting.allCases, id: \.self) { setting in
+                Text(setting.name).tag(setting)
+            }
         }
 #if os(tvOS)
         .pickerStyle(.navigationLink)

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import Combine
 import Foundation
 import PillarboxPlayer
 
@@ -57,6 +58,12 @@ extension UserDefaults {
             DemoSettingKey.serverSetting.rawValue: ServerSetting.ilProduction.rawValue,
             DemoSettingKey.qualitySetting.rawValue: QualitySetting.high.rawValue
         ])
+    }
+
+    func limitsPublisher() -> AnyPublisher<PlayerLimits, Never> {
+        publisher(for: \.qualitySetting)
+            .map(\.limits)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -17,6 +17,7 @@ extension UserDefaults {
         case smartNavigationEnabled
         case seekBehaviorSetting
         case serverSetting
+        case qualitySetting
     }
 
     @objc dynamic var presenterModeEnabled: Bool {
@@ -44,12 +45,17 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: DemoSettingKey.serverSetting.rawValue)) ?? .ilProduction
     }
 
+    @objc dynamic var qualitySetting: QualitySetting {
+        .init(rawValue: integer(forKey: DemoSettingKey.qualitySetting.rawValue)) ?? .high
+    }
+
     private static func registerDefaultDemoSettings() {
         UserDefaults.standard.register(defaults: [
             DemoSettingKey.presenterModeEnabled.rawValue: false,
             DemoSettingKey.seekBehaviorSetting.rawValue: SeekBehaviorSetting.immediate.rawValue,
             DemoSettingKey.smartNavigationEnabled.rawValue: true,
-            DemoSettingKey.serverSetting.rawValue: ServerSetting.ilProduction.rawValue
+            DemoSettingKey.serverSetting.rawValue: ServerSetting.ilProduction.rawValue,
+            DemoSettingKey.qualitySetting.rawValue: QualitySetting.high.rawValue
         ])
     }
 }

--- a/Demo/Sources/Showcase/Multi/MultiViewModel.swift
+++ b/Demo/Sources/Showcase/Multi/MultiViewModel.swift
@@ -5,6 +5,7 @@
 //
 
 import Combine
+import Foundation
 import PillarboxPlayer
 
 enum PlayerPosition {
@@ -13,6 +14,8 @@ enum PlayerPosition {
 }
 
 final class MultiViewModel: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+
     @Published var media1: Media? {
         didSet {
             guard media1 != oldValue else { return }
@@ -80,6 +83,7 @@ final class MultiViewModel: ObservableObject {
 
     init() {
         Self.make(activePlayer: player1, inactivePlayer: player2)
+        configureLimitsPublisher()
     }
 
     private static func update(player: Player, with media: Media?) {
@@ -107,6 +111,15 @@ final class MultiViewModel: ObservableObject {
 
     func swap() {
         isSwapped.toggle()
+    }
+
+    private func configureLimitsPublisher() {
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player1)
+            .store(in: &cancellables)
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player2)
+            .store(in: &cancellables)
     }
 }
 

--- a/Demo/Sources/Showcase/PiP/MultiPiPViewModel.swift
+++ b/Demo/Sources/Showcase/PiP/MultiPiPViewModel.swift
@@ -5,9 +5,12 @@
 //
 
 import Combine
+import Foundation
 import PillarboxPlayer
 
 final class MultiPiPViewModel: ObservableObject, PictureInPicturePersistable {
+    private var cancellables = Set<AnyCancellable>()
+
     @Published var media1: Media? {
         didSet {
             guard media1 != oldValue else { return }
@@ -28,6 +31,10 @@ final class MultiPiPViewModel: ObservableObject, PictureInPicturePersistable {
     let player1 = Player(configuration: .externalPlaybackDisabled)
     let player2 = Player(configuration: .externalPlaybackDisabled)
 
+    init() {
+        configureLimitsPublisher()
+    }
+
     private static func update(player: Player, with media: Media?) {
         if let item = media?.item() {
             player.items = [item]
@@ -40,5 +47,14 @@ final class MultiPiPViewModel: ObservableObject, PictureInPicturePersistable {
     func play() {
         player1.play()
         player2.play()
+    }
+
+    private func configureLimitsPublisher() {
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player1)
+            .store(in: &cancellables)
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player2)
+            .store(in: &cancellables)
     }
 }

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -11,6 +11,7 @@ import PillarboxPlayer
 
 final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
     let player = Player(configuration: .standard)
+    private var cancellables = Set<AnyCancellable>()
 
     @Published var layout: PlaybackView.Layout = .minimized
 
@@ -42,6 +43,7 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
 
     init() {
         configureCurrentMediaPublisher()
+        configureLimitsPublisher()
     }
 
     private static func updated(
@@ -91,6 +93,12 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
                 return media(for: item)
             }
             .assign(to: &$currentMedia)
+    }
+
+    private func configureLimitsPublisher() {
+        UserDefaults.standard.limitsPublisher()
+            .assign(to: \.limits, on: player)
+            .store(in: &cancellables)
     }
 
     private func media(for item: PlayerItem) -> Media? {

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -44,7 +44,10 @@ public struct MediaMetadata {
             .init(
                 identifier: chapter.urn,
                 title: chapter.title,
-                imageSource: .url(standardResolution: imageUrl(for: chapter)),
+                imageSource: .url(
+                    standardResolution: standardResolutionImageUrl(for: chapter),
+                    lowResolution: lowResolutionImageUrl(for: chapter)
+                ),
                 timeRange: chapter.timeRange
             )
         }
@@ -96,7 +99,10 @@ extension MediaMetadata: AssetMetadata {
             title: title,
             subtitle: subtitle,
             description: description,
-            imageSource: .url(standardResolution: imageUrl(for: mainChapter)),
+            imageSource: .url(
+                standardResolution: standardResolutionImageUrl(for: mainChapter),
+                lowResolution: lowResolutionImageUrl(for: mainChapter)
+            ),
             viewport: viewport,
             episodeInformation: episodeInformation,
             chapters: chapters,
@@ -179,7 +185,11 @@ extension MediaMetadata: AssetMetadata {
         }
     }
 
-    private func imageUrl(for chapter: MediaComposition.Chapter) -> URL {
+    private func standardResolutionImageUrl(for chapter: MediaComposition.Chapter) -> URL {
         dataProvider.resizedImageUrl(chapter.imageUrl, width: .width720)
+    }
+
+    private func lowResolutionImageUrl(for chapter: MediaComposition.Chapter) -> URL {
+        dataProvider.resizedImageUrl(chapter.imageUrl, width: .width320)
     }
 }

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -44,7 +44,7 @@ public struct MediaMetadata {
             .init(
                 identifier: chapter.urn,
                 title: chapter.title,
-                imageSource: .url(imageUrl(for: chapter)),
+                imageSource: .url(standardResolution: imageUrl(for: chapter)),
                 timeRange: chapter.timeRange
             )
         }
@@ -96,7 +96,7 @@ extension MediaMetadata: AssetMetadata {
             title: title,
             subtitle: subtitle,
             description: description,
-            imageSource: .url(imageUrl(for: mainChapter)),
+            imageSource: .url(standardResolution: imageUrl(for: mainChapter)),
             viewport: viewport,
             episodeInformation: episodeInformation,
             chapters: chapters,

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -37,11 +37,12 @@ extension AVPlayerItem {
         replacing previousContents: [AssetContent],
         currentItem: AVPlayerItem?,
         repeatMode: RepeatMode,
-        length: Int
+        length: Int,
+        configuration: PlayerConfiguration
     ) -> [AVPlayerItem] {
         let sources = itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem)
         let updatedSources = updatedItemSources(sources, repeatMode: repeatMode, firstContent: currentContents.first)
-        return playerItems(from: updatedSources, length: length, reload: false)
+        return playerItems(from: updatedSources, length: length, reload: false, configuration: configuration)
     }
 
     private static func updatedItemSources(_ sources: [ItemSource], repeatMode: RepeatMode, firstContent: AssetContent?) -> [ItemSource] {
@@ -84,16 +85,28 @@ extension AVPlayerItem {
         }
     }
 
-    static func playerItems(from items: [PlayerItem], after index: Int, repeatMode: RepeatMode, length: Int, reload: Bool) -> [AVPlayerItem] {
+    static func playerItems(
+        from items: [PlayerItem],
+        after index: Int,
+        repeatMode: RepeatMode,
+        length: Int,
+        reload: Bool,
+        configuration: PlayerConfiguration
+    ) -> [AVPlayerItem] {
         let afterContents = items.suffix(from: index).map(\.content)
         let sources = updatedItemSources(newItemSources(from: afterContents), repeatMode: repeatMode, firstContent: items.first?.content)
-        return playerItems(from: sources, length: length, reload: reload)
+        return playerItems(from: sources, length: length, reload: reload, configuration: configuration)
     }
 
-    private static func playerItems(from sources: [ItemSource], length: Int, reload: Bool) -> [AVPlayerItem] {
+    private static func playerItems(
+        from sources: [ItemSource],
+        length: Int,
+        reload: Bool,
+        configuration: PlayerConfiguration
+    ) -> [AVPlayerItem] {
         sources
             .prefix(length)
-            .map { $0.playerItem(reload: reload) }
+            .map { $0.playerItem(reload: reload, configuration: configuration) }
     }
 
     private static func newItemSources(from contents: [AssetContent]) -> [ItemSource] {

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -31,6 +31,8 @@ extension AVPlayerItem {
     ///   - currentItem: The item currently being played by the player.
     ///   - repeatMode: The current repeat mode setting.
     ///   - length: The maximum number of items to return.
+    ///   - configuration: The player configuration.
+    ///   - limits: Limits applied by the player.
     /// - Returns: The list of player items to load into the player.
     static func playerItems(
         for currentContents: [AssetContent],
@@ -38,11 +40,12 @@ extension AVPlayerItem {
         currentItem: AVPlayerItem?,
         repeatMode: RepeatMode,
         length: Int,
-        configuration: PlayerConfiguration
+        configuration: PlayerConfiguration,
+        limits: PlayerLimits
     ) -> [AVPlayerItem] {
         let sources = itemSources(for: currentContents, replacing: previousContents, currentItem: currentItem)
         let updatedSources = updatedItemSources(sources, repeatMode: repeatMode, firstContent: currentContents.first)
-        return playerItems(from: updatedSources, length: length, reload: false, configuration: configuration)
+        return playerItems(from: updatedSources, length: length, reload: false, configuration: configuration, limits: limits)
     }
 
     private static func updatedItemSources(_ sources: [ItemSource], repeatMode: RepeatMode, firstContent: AssetContent?) -> [ItemSource] {
@@ -91,22 +94,24 @@ extension AVPlayerItem {
         repeatMode: RepeatMode,
         length: Int,
         reload: Bool,
-        configuration: PlayerConfiguration
+        configuration: PlayerConfiguration,
+        limits: PlayerLimits
     ) -> [AVPlayerItem] {
         let afterContents = items.suffix(from: index).map(\.content)
         let sources = updatedItemSources(newItemSources(from: afterContents), repeatMode: repeatMode, firstContent: items.first?.content)
-        return playerItems(from: sources, length: length, reload: reload, configuration: configuration)
+        return playerItems(from: sources, length: length, reload: reload, configuration: configuration, limits: limits)
     }
 
     private static func playerItems(
         from sources: [ItemSource],
         length: Int,
         reload: Bool,
-        configuration: PlayerConfiguration
+        configuration: PlayerConfiguration,
+        limits: PlayerLimits
     ) -> [AVPlayerItem] {
         sources
             .prefix(length)
-            .map { $0.playerItem(reload: reload, configuration: configuration) }
+            .map { $0.playerItem(reload: reload, configuration: configuration, limits: limits) }
     }
 
     private static func newItemSources(from contents: [AssetContent]) -> [ItemSource] {

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -35,7 +35,8 @@ public extension Player {
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
                 reload: true,
-                configuration: configuration
+                configuration: configuration,
+                limits: limits
             )
         )
     }
@@ -67,7 +68,8 @@ public extension Player {
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
                 reload: true,
-                configuration: configuration
+                configuration: configuration,
+                limits: limits
             )
         )
     }
@@ -91,7 +93,8 @@ extension Player {
                     repeatMode: repeatMode,
                     length: configuration.preloadedItems,
                     reload: true,
-                    configuration: configuration
+                    configuration: configuration,
+                    limits: limits
                 )
                 queuePlayer.replaceItems(with: playerItems)
             }
@@ -112,7 +115,8 @@ extension Player {
             currentItem: queuePlayer.currentItem,
             repeatMode: repeatMode,
             length: configuration.preloadedItems,
-            configuration: configuration
+            configuration: configuration,
+            limits: limits
         )
         queuePlayer.replaceItems(with: items)
     }

--- a/Sources/Player/Player+ItemNavigation.swift
+++ b/Sources/Player/Player+ItemNavigation.swift
@@ -34,7 +34,8 @@ public extension Player {
                 after: index,
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
-                reload: true
+                reload: true,
+                configuration: configuration
             )
         )
     }
@@ -65,7 +66,8 @@ public extension Player {
                 after: index,
                 repeatMode: repeatMode,
                 length: configuration.preloadedItems,
-                reload: true
+                reload: true,
+                configuration: configuration
             )
         )
     }
@@ -88,7 +90,8 @@ extension Player {
                     after: index,
                     repeatMode: repeatMode,
                     length: configuration.preloadedItems,
-                    reload: true
+                    reload: true,
+                    configuration: configuration
                 )
                 queuePlayer.replaceItems(with: playerItems)
             }
@@ -108,7 +111,8 @@ extension Player {
             replacing: contents,
             currentItem: queuePlayer.currentItem,
             repeatMode: repeatMode,
-            length: configuration.preloadedItems
+            length: configuration.preloadedItems,
+            configuration: configuration
         )
         queuePlayer.replaceItems(with: items)
     }

--- a/Sources/Player/Player+Queue.swift
+++ b/Sources/Player/Player+Queue.swift
@@ -40,7 +40,8 @@ extension Player {
                     replacing: previous.elements.map(\.content),
                     currentItem: buffer.item,
                     repeatMode: repeatMode,
-                    length: buffer.length
+                    length: buffer.length,
+                    configuration: configuration
                 )
             }
             .removeDuplicates()

--- a/Sources/Player/Player+Queue.swift
+++ b/Sources/Player/Player+Queue.swift
@@ -31,8 +31,8 @@ extension Player {
     func queuePlayerItemsPublisher() -> AnyPublisher<[AVPlayerItem], Never> {
         queuePublisher
             .withPrevious(.empty)
-            .compactMap { [weak self, configuration, limits] previous, current in
-                guard let self, let buffer = Queue.buffer(from: previous, to: current, length: configuration.preloadedItems) else {
+            .compactMap { [weak self] previous, current in
+                guard let self, let buffer = Queue.buffer(from: previous, to: current, length: self.configuration.preloadedItems) else {
                     return nil
                 }
                 return AVPlayerItem.playerItems(
@@ -41,8 +41,8 @@ extension Player {
                     currentItem: buffer.item,
                     repeatMode: repeatMode,
                     length: buffer.length,
-                    configuration: configuration,
-                    limits: limits
+                    configuration: self.configuration,
+                    limits: self.limits
                 )
             }
             .removeDuplicates()

--- a/Sources/Player/Player+Queue.swift
+++ b/Sources/Player/Player+Queue.swift
@@ -31,7 +31,7 @@ extension Player {
     func queuePlayerItemsPublisher() -> AnyPublisher<[AVPlayerItem], Never> {
         queuePublisher
             .withPrevious(.empty)
-            .compactMap { [weak self, configuration] previous, current in
+            .compactMap { [weak self, configuration, limits] previous, current in
                 guard let self, let buffer = Queue.buffer(from: previous, to: current, length: configuration.preloadedItems) else {
                     return nil
                 }
@@ -41,7 +41,8 @@ extension Player {
                     currentItem: buffer.item,
                     repeatMode: repeatMode,
                     length: buffer.length,
-                    configuration: configuration
+                    configuration: configuration,
+                    limits: limits
                 )
             }
             .removeDuplicates()

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -46,8 +46,8 @@ public final class Player: ObservableObject, Equatable {
         }
     }
 
-    /// Limits applied by the player.
-    @Published public var limits: PlayerLimits = .none {
+    /// The limits applied by the player.
+    public var limits: PlayerLimits = .none {
         didSet {
             limits.apply(to: queuePlayer.items())
         }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -49,12 +49,7 @@ public final class Player: ObservableObject, Equatable {
     /// Limits applied by the player.
     @Published public var limits: PlayerLimits = .none {
         didSet {
-            queuePlayer.items().forEach { item in
-                item.preferredPeakBitRate = limits.preferredPeakBitRate
-                item.preferredPeakBitRateForExpensiveNetworks = limits.preferredPeakBitRateForExpensiveNetworks
-                item.preferredMaximumResolution = limits.preferredMaximumResolution
-                item.preferredMaximumResolutionForExpensiveNetworks = limits.preferredMaximumResolutionForExpensiveNetworks
-            }
+            limits.apply(to: queuePlayer.items())
         }
     }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -46,6 +46,9 @@ public final class Player: ObservableObject, Equatable {
         }
     }
 
+    /// Limits applied by the player.
+    @Published public var limits: PlayerLimits = .none
+
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -47,7 +47,16 @@ public final class Player: ObservableObject, Equatable {
     }
 
     /// Limits applied by the player.
-    @Published public var limits: PlayerLimits = .none
+    @Published public var limits: PlayerLimits = .none {
+        didSet {
+            queuePlayer.items().forEach { item in
+                item.preferredPeakBitRate = limits.preferredPeakBitRate
+                item.preferredPeakBitRateForExpensiveNetworks = limits.preferredPeakBitRateForExpensiveNetworks
+                item.preferredMaximumResolution = limits.preferredMaximumResolution
+                item.preferredMaximumResolutionForExpensiveNetworks = limits.preferredMaximumResolutionForExpensiveNetworks
+            }
+        }
+    }
 
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import CoreGraphics
 import Foundation
 
 /// A player configuration.
@@ -36,6 +37,36 @@ public struct PlayerConfiguration {
     /// The number of items to preload.
     let preloadedItems = 2
 
+    /// A Boolean value that indicates whether the player is allowed to play content on networks enabled for Low Data
+    /// Mode.
+    ///
+    /// A player which cannot is not allowed access to constrained networks will report the network as being
+    /// unreachable. You should only enable this option on players which play non-essential content, e.g. animated
+    /// background videos.
+    public let allowsConstrainedNetworkAccess: Bool
+
+    /// A limit of network bandwidth consumption observed by the player on all networks.
+    ///
+    /// Disabled when set to zero.
+    public let preferredPeakBitRate: Double
+
+    /// A limit of network bandwidth consumption observed by the player when connecting over
+    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
+    ///
+    /// Disabled when set to zero.
+    public let preferredPeakBitRateForExpensiveNetworks: Double
+
+    /// A limit of resolution observed by the player on all networks.
+    ///
+    /// Disabled when set to `.zero`.
+    public let preferredMaximumResolution: CGSize
+
+    /// A limit of resolution observed by the player when connecting over
+    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
+    ///
+    /// Disabled when set to `.zero`.
+    public let preferredMaximumResolutionForExpensiveNetworks: CGSize
+
     /// Creates a player configuration.
     public init(
         allowsExternalPlayback: Bool = true,
@@ -43,7 +74,12 @@ public struct PlayerConfiguration {
         preventsDisplaySleepDuringVideoPlayback: Bool = true,
         navigationMode: NavigationMode = .smart(interval: 3),
         backwardSkipInterval: TimeInterval = 10,
-        forwardSkipInterval: TimeInterval = 10
+        forwardSkipInterval: TimeInterval = 10,
+        allowsConstrainedNetworkAccess: Bool = true,
+        preferredPeakBitRate: Double = 0,
+        preferredPeakBitRateForExpensiveNetworks: Double = 0,
+        preferredMaximumResolution: CGSize = .zero,
+        preferredMaximumResolutionForExpensiveNetworks: CGSize = .zero
     ) {
         assert(backwardSkipInterval > 0)
         assert(forwardSkipInterval > 0)
@@ -53,5 +89,10 @@ public struct PlayerConfiguration {
         self.navigationMode = navigationMode
         self.backwardSkipInterval = backwardSkipInterval
         self.forwardSkipInterval = forwardSkipInterval
+        self.allowsConstrainedNetworkAccess = allowsConstrainedNetworkAccess
+        self.preferredPeakBitRate = preferredPeakBitRate
+        self.preferredPeakBitRateForExpensiveNetworks = preferredPeakBitRateForExpensiveNetworks
+        self.preferredMaximumResolution = preferredMaximumResolution
+        self.preferredMaximumResolutionForExpensiveNetworks = preferredMaximumResolutionForExpensiveNetworks
     }
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A player configuration.
@@ -45,28 +44,6 @@ public struct PlayerConfiguration {
     /// background videos.
     public let allowsConstrainedNetworkAccess: Bool
 
-    /// A limit of network bandwidth consumption observed by the player on all networks.
-    ///
-    /// Disabled when set to zero.
-    public let preferredPeakBitRate: Double
-
-    /// A limit of network bandwidth consumption observed by the player when connecting over
-    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
-    ///
-    /// Disabled when set to zero.
-    public let preferredPeakBitRateForExpensiveNetworks: Double
-
-    /// A limit of resolution observed by the player on all networks.
-    ///
-    /// Disabled when set to `.zero`.
-    public let preferredMaximumResolution: CGSize
-
-    /// A limit of resolution observed by the player when connecting over
-    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
-    ///
-    /// Disabled when set to `.zero`.
-    public let preferredMaximumResolutionForExpensiveNetworks: CGSize
-
     /// Creates a player configuration.
     public init(
         allowsExternalPlayback: Bool = true,
@@ -75,11 +52,7 @@ public struct PlayerConfiguration {
         navigationMode: NavigationMode = .smart(interval: 3),
         backwardSkipInterval: TimeInterval = 10,
         forwardSkipInterval: TimeInterval = 10,
-        allowsConstrainedNetworkAccess: Bool = true,
-        preferredPeakBitRate: Double = 0,
-        preferredPeakBitRateForExpensiveNetworks: Double = 0,
-        preferredMaximumResolution: CGSize = .zero,
-        preferredMaximumResolutionForExpensiveNetworks: CGSize = .zero
+        allowsConstrainedNetworkAccess: Bool = true
     ) {
         assert(backwardSkipInterval > 0)
         assert(forwardSkipInterval > 0)
@@ -90,9 +63,5 @@ public struct PlayerConfiguration {
         self.backwardSkipInterval = backwardSkipInterval
         self.forwardSkipInterval = forwardSkipInterval
         self.allowsConstrainedNetworkAccess = allowsConstrainedNetworkAccess
-        self.preferredPeakBitRate = preferredPeakBitRate
-        self.preferredPeakBitRateForExpensiveNetworks = preferredPeakBitRateForExpensiveNetworks
-        self.preferredMaximumResolution = preferredMaximumResolution
-        self.preferredMaximumResolutionForExpensiveNetworks = preferredMaximumResolutionForExpensiveNetworks
     }
 }

--- a/Sources/Player/PlayerConfiguration.swift
+++ b/Sources/Player/PlayerConfiguration.swift
@@ -36,12 +36,12 @@ public struct PlayerConfiguration {
     /// The number of items to preload.
     let preloadedItems = 2
 
-    /// A Boolean value that indicates whether the player is allowed to play content on networks enabled for Low Data
-    /// Mode.
+    /// A Boolean value indicating whether the player is permitted to play content on networks with Low Data Mode
+    /// enabled.
     ///
-    /// A player which cannot is not allowed access to constrained networks will report the network as being
-    /// unreachable. You should only enable this option on players which play non-essential content, e.g. animated
-    /// background videos.
+    /// When this property is set to `false`, playback fails with a network availability error on constrained networks.
+    /// This option is therefore mostly useful for players associated with non-essential content, such as animated
+    /// background videos used purely for visual enhancement.
     public let allowsConstrainedNetworkAccess: Bool
 
     /// Creates a player configuration.

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -24,12 +24,12 @@ enum Resource {
         )
     }
 
-    func playerItem(configuration: PlayerConfiguration) -> AVPlayerItem {
+    func playerItem(configuration: PlayerConfiguration, limits: PlayerLimits) -> AVPlayerItem {
         let item = rawPlayerItem(configuration: configuration)
-        item.preferredPeakBitRate = configuration.preferredPeakBitRate
-        item.preferredPeakBitRateForExpensiveNetworks = configuration.preferredPeakBitRateForExpensiveNetworks
-        item.preferredMaximumResolution = configuration.preferredMaximumResolution
-        item.preferredMaximumResolutionForExpensiveNetworks = configuration.preferredMaximumResolutionForExpensiveNetworks
+        item.preferredPeakBitRate = limits.preferredPeakBitRate
+        item.preferredPeakBitRateForExpensiveNetworks = limits.preferredPeakBitRateForExpensiveNetworks
+        item.preferredMaximumResolution = limits.preferredMaximumResolution
+        item.preferredMaximumResolutionForExpensiveNetworks = limits.preferredMaximumResolutionForExpensiveNetworks
         return item
     }
 

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -18,19 +18,18 @@ enum Resource {
     private static let logger = Logger(category: "Resource")
 
     private func asset(for url: URL, with configuration: PlayerConfiguration) -> AVURLAsset {
-        .init(
-            url: url,
-            options: [AVURLAssetAllowsConstrainedNetworkAccessKey: configuration.allowsConstrainedNetworkAccess]
-        )
+        .init(url: url, options: [
+            AVURLAssetAllowsConstrainedNetworkAccessKey: configuration.allowsConstrainedNetworkAccess
+        ])
     }
 
     func playerItem(configuration: PlayerConfiguration, limits: PlayerLimits) -> AVPlayerItem {
-        let item = rawPlayerItem(configuration: configuration)
+        let item = unlimitedPlayerItem(configuration: configuration)
         limits.apply(to: item)
         return item
     }
 
-    private func rawPlayerItem(configuration: PlayerConfiguration) -> AVPlayerItem {
+    private func unlimitedPlayerItem(configuration: PlayerConfiguration) -> AVPlayerItem {
         switch self {
         case let .simple(url: url):
             return AVPlayerItem(asset: asset(for: url, with: configuration))

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -26,10 +26,7 @@ enum Resource {
 
     func playerItem(configuration: PlayerConfiguration, limits: PlayerLimits) -> AVPlayerItem {
         let item = rawPlayerItem(configuration: configuration)
-        item.preferredPeakBitRate = limits.preferredPeakBitRate
-        item.preferredPeakBitRateForExpensiveNetworks = limits.preferredPeakBitRateForExpensiveNetworks
-        item.preferredMaximumResolution = limits.preferredMaximumResolution
-        item.preferredMaximumResolutionForExpensiveNetworks = limits.preferredMaximumResolutionForExpensiveNetworks
+        limits.apply(to: item)
         return item
     }
 

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -17,7 +17,7 @@ enum Resource {
 
     private static let logger = Logger(category: "Resource")
 
-    func playerItem() -> AVPlayerItem {
+    func playerItem(configuration: PlayerConfiguration) -> AVPlayerItem {
         switch self {
         case let .simple(url: url):
             return AVPlayerItem(url: url)

--- a/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
+++ b/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
@@ -13,9 +13,8 @@ final class ResourceLoadedPlayerItem: AVPlayerItem {
     // swiftlint:disable:next weak_delegate
     private let resourceLoaderDelegate: AVAssetResourceLoaderDelegate
 
-    init(url: URL, resourceLoaderDelegate: AVAssetResourceLoaderDelegate) {
+    init(asset: AVURLAsset, resourceLoaderDelegate: AVAssetResourceLoaderDelegate) {
         self.resourceLoaderDelegate = resourceLoaderDelegate
-        let asset = AVURLAsset(url: url)
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: kResourceLoaderQueue)
         // Provide same key as for a standard asset, see `AVPlayerItem.init(asset:)` documentation.
         super.init(asset: asset, automaticallyLoadedAssetKeys: ["duration"])

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -21,15 +21,15 @@ struct AssetContent {
         .init(id: id, resource: .failing(error: error), metadata: .empty, configuration: .default, dateInterval: nil)
     }
 
-    func playerItem(reload: Bool = false) -> AVPlayerItem {
+    func playerItem(reload: Bool = false, configuration: PlayerConfiguration) -> AVPlayerItem {
         if reload, resource.isFailing {
-            let item = Resource.loading.playerItem().withId(id).updated(with: self)
+            let item = Resource.loading.playerItem(configuration: configuration).withId(id).updated(with: self)
             configure(item: item)
             PlayerItem.reload(for: id)
             return item
         }
         else {
-            let item = resource.playerItem().withId(id).updated(with: self)
+            let item = resource.playerItem(configuration: configuration).withId(id).updated(with: self)
             configure(item: item)
             PlayerItem.load(for: id)
             return item

--- a/Sources/Player/Types/AssetContent.swift
+++ b/Sources/Player/Types/AssetContent.swift
@@ -21,15 +21,27 @@ struct AssetContent {
         .init(id: id, resource: .failing(error: error), metadata: .empty, configuration: .default, dateInterval: nil)
     }
 
-    func playerItem(reload: Bool = false, configuration: PlayerConfiguration) -> AVPlayerItem {
+    func playerItem(reload: Bool = false, configuration: PlayerConfiguration, limits: PlayerLimits) -> AVPlayerItem {
         if reload, resource.isFailing {
-            let item = Resource.loading.playerItem(configuration: configuration).withId(id).updated(with: self)
+            let item = Resource.loading.playerItem(
+                configuration: configuration,
+                limits: limits
+            )
+            .withId(id)
+            .updated(with: self)
+
             configure(item: item)
             PlayerItem.reload(for: id)
             return item
         }
         else {
-            let item = resource.playerItem(configuration: configuration).withId(id).updated(with: self)
+            let item = resource.playerItem(
+                configuration: configuration,
+                limits: limits
+            )
+            .withId(id)
+            .updated(with: self)
+
             configure(item: item)
             PlayerItem.load(for: id)
             return item

--- a/Sources/Player/Types/ImageSource.swift
+++ b/Sources/Player/Types/ImageSource.swift
@@ -31,9 +31,9 @@ public struct ImageSource: Equatable {
     /// An image retrieved from a URL.
     ///
     /// - Parameters:
-    ///   - standardResolutionUrl: The URL where an image with standard resolution can be retrieved.
-    ///   - lowResolutionUrl: The URL where an image with low resolution can be retrieved when Low Data Mode has been
-    ///     enabled. If not specified the standard resolution URL is used instead.
+    ///   - standardResolutionUrl: The URL where a variant with standard resolution can be retrieved.
+    ///   - lowResolutionUrl: The URL where a variant with low resolution can be retrieved when Low Data Mode has been
+    ///     enabled. If omitted the standard resolution URL is used.
     public static func url(standardResolution standardResolutionUrl: URL, lowResolution lowResolutionUrl: URL? = nil) -> Self {
         Self(kind: .url(standardResolution: standardResolutionUrl, lowResolution: lowResolutionUrl ?? standardResolutionUrl))
     }

--- a/Sources/Player/Types/ImageSource.swift
+++ b/Sources/Player/Types/ImageSource.swift
@@ -32,7 +32,7 @@ public struct ImageSource: Equatable {
     ///
     /// - Parameters:
     ///   - standardResolutionUrl: The URL where an image with standard resolution can be retrieved.
-    ///   - lowResolutionUrl: The URL where an image with low resolution can be retrieved when low-data mode has been
+    ///   - lowResolutionUrl: The URL where an image with low resolution can be retrieved when Low Data Mode has been
     ///     enabled. If not specified the standard resolution URL is used instead.
     public static func url(standardResolution standardResolutionUrl: URL, lowResolution lowResolutionUrl: URL? = nil) -> Self {
         Self(kind: .url(standardResolution: standardResolutionUrl, lowResolution: lowResolutionUrl ?? standardResolutionUrl))

--- a/Sources/Player/Types/ImageSource.swift
+++ b/Sources/Player/Types/ImageSource.swift
@@ -82,7 +82,7 @@ extension ImageSource {
                 guard error.networkUnavailableReason == .constrained else {
                     throw error
                 }
-                return kSession.dataTaskPublisher(for: lowResolutionUrl).eraseToAnyPublisher()
+                return kSession.dataTaskPublisher(for: lowResolutionUrl)
             }
             .map { data, _ in
                 guard let image = UIImage(data: data) else { return .none }

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -22,12 +22,12 @@ struct ItemSource {
         .init(content: content, item: nil)
     }
 
-    func playerItem(reload: Bool, configuration: PlayerConfiguration) -> AVPlayerItem {
+    func playerItem(reload: Bool, configuration: PlayerConfiguration, limits: PlayerLimits) -> AVPlayerItem {
         if let item {
             return item.updated(with: content)
         }
         else {
-            return content.playerItem(reload: reload, configuration: configuration)
+            return content.playerItem(reload: reload, configuration: configuration, limits: limits)
         }
     }
 }

--- a/Sources/Player/Types/ItemSource.swift
+++ b/Sources/Player/Types/ItemSource.swift
@@ -22,12 +22,12 @@ struct ItemSource {
         .init(content: content, item: nil)
     }
 
-    func playerItem(reload: Bool) -> AVPlayerItem {
+    func playerItem(reload: Bool, configuration: PlayerConfiguration) -> AVPlayerItem {
         if let item {
             return item.updated(with: content)
         }
         else {
-            return content.playerItem(reload: reload)
+            return content.playerItem(reload: reload, configuration: configuration)
         }
     }
 }

--- a/Sources/Player/Types/PlayerLimits.swift
+++ b/Sources/Player/Types/PlayerLimits.swift
@@ -4,6 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
+import AVFoundation
 import CoreGraphics
 
 /// A set of limits applied by the player during playback.
@@ -44,5 +45,18 @@ public struct PlayerLimits: Equatable {
         self.preferredPeakBitRateForExpensiveNetworks = preferredPeakBitRateForExpensiveNetworks
         self.preferredMaximumResolution = preferredMaximumResolution
         self.preferredMaximumResolutionForExpensiveNetworks = preferredMaximumResolutionForExpensiveNetworks
+    }
+
+    func apply(to playerItem: AVPlayerItem) {
+        playerItem.preferredPeakBitRate = preferredPeakBitRate
+        playerItem.preferredPeakBitRateForExpensiveNetworks = preferredPeakBitRateForExpensiveNetworks
+        playerItem.preferredMaximumResolution = preferredMaximumResolution
+        playerItem.preferredMaximumResolutionForExpensiveNetworks = preferredMaximumResolutionForExpensiveNetworks
+    }
+
+    func apply(to playerItems: [AVPlayerItem]) {
+        playerItems.forEach { playerItem in
+            apply(to: playerItem)
+        }
     }
 }

--- a/Sources/Player/Types/PlayerLimits.swift
+++ b/Sources/Player/Types/PlayerLimits.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import CoreGraphics
+
+/// A set of limits applied by the player during playback.
+public struct PlayerLimits: Equatable {
+    /// No limits.
+    public static let none = Self()
+
+    /// A limit of network bandwidth consumption observed by the player on all networks.
+    ///
+    /// Disabled when set to zero.
+    public let preferredPeakBitRate: Double
+
+    /// A limit of network bandwidth consumption observed by the player when connecting over
+    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
+    ///
+    /// Disabled when set to zero.
+    public let preferredPeakBitRateForExpensiveNetworks: Double
+
+    /// A limit of resolution observed by the player on all networks.
+    ///
+    /// Disabled when set to `.zero`.
+    public let preferredMaximumResolution: CGSize
+
+    /// A limit of resolution observed by the player when connecting over
+    /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
+    ///
+    /// Disabled when set to `.zero`.
+    public let preferredMaximumResolutionForExpensiveNetworks: CGSize
+
+    /// Creates a set of limits.
+    public init(
+        preferredPeakBitRate: Double = 0,
+        preferredPeakBitRateForExpensiveNetworks: Double = 0,
+        preferredMaximumResolution: CGSize = .zero,
+        preferredMaximumResolutionForExpensiveNetworks: CGSize = .zero
+    ) {
+        self.preferredPeakBitRate = preferredPeakBitRate
+        self.preferredPeakBitRateForExpensiveNetworks = preferredPeakBitRateForExpensiveNetworks
+        self.preferredMaximumResolution = preferredMaximumResolution
+        self.preferredMaximumResolutionForExpensiveNetworks = preferredMaximumResolutionForExpensiveNetworks
+    }
+}

--- a/Sources/Player/Types/PlayerLimits.swift
+++ b/Sources/Player/Types/PlayerLimits.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import CoreGraphics
 
 /// A set of limits applied by the player during playback.
-public struct PlayerLimits: Equatable {
+public struct PlayerLimits {
     /// No limits.
     public static let none = Self()
 

--- a/Sources/Player/Types/PlayerLimits.swift
+++ b/Sources/Player/Types/PlayerLimits.swift
@@ -12,12 +12,12 @@ public struct PlayerLimits {
     /// No limits.
     public static let none = Self()
 
-    /// A limit of network bandwidth consumption observed by the player on all networks.
+    /// A limit of network bandwidth consumption, in bits per second, observed by the player on all networks.
     ///
     /// Disabled when set to zero.
     public let preferredPeakBitRate: Double
 
-    /// A limit of network bandwidth consumption observed by the player when connecting over
+    /// A limit of network bandwidth consumption, in bits per second, observed by the player when connecting over
     /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
     ///
     /// Disabled when set to zero.

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -61,7 +61,7 @@ private struct MediaSelectionMenuContent: View {
 
 @available(iOS 16.0, tvOS 17.0, *)
 private struct SettingsMenuContent: View {
-    var player: Player
+    let player: Player
 
     var body: some View {
         playbackSpeedMenu()

--- a/Tests/CoreBusinessTests/MediaMetadataTests.swift
+++ b/Tests/CoreBusinessTests/MediaMetadataTests.swift
@@ -54,7 +54,7 @@ final class MediaMetadataTests: XCTestCase {
 
     func testChapters() throws {
         let metadata = try Self.metadata(.mixed)
-        expect(metadata.chapters.count).to(equal(10))
+        expect(metadata.chapters).to(haveCount(10))
     }
 
     func testAudioChapterRemoval() throws {

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
@@ -30,7 +30,8 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C"), UUID("A")]))
     }
@@ -50,14 +51,15 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
@@ -78,14 +80,15 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
@@ -100,14 +103,15 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("A")]))
     }
@@ -125,14 +129,15 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C"), UUID("3")]))
     }
@@ -149,14 +154,15 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3"), UUID("1")]))
         expect(items.first).to(equal(currentItem))
@@ -175,7 +181,8 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .all,
             length: 2,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatAllUpdateTests.swift
@@ -29,7 +29,8 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C"), UUID("A")]))
     }
@@ -49,13 +50,14 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
@@ -76,13 +78,14 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("A")]))
         expect(items.first).to(equal(currentItem))
@@ -97,13 +100,14 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem()
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("A")]))
     }
@@ -121,13 +125,14 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C"), UUID("3")]))
     }
@@ -144,13 +149,14 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .all,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3"), UUID("1")]))
         expect(items.first).to(equal(currentItem))
@@ -168,7 +174,8 @@ final class AVPlayerItemRepeatAllUpdateTests: TestCase {
             replacing: [],
             currentItem: nil,
             repeatMode: .all,
-            length: 2
+            length: 2,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
@@ -29,7 +29,8 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
     }
@@ -49,13 +50,14 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
         expect(items.first).to(equal(currentItem))
@@ -76,13 +78,14 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -97,13 +100,14 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem()
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }
@@ -121,13 +125,14 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
     }
@@ -144,13 +149,14 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -168,7 +174,8 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             replacing: [],
             currentItem: nil,
             repeatMode: .off,
-            length: 2
+            length: 2,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOffUpdateTests.swift
@@ -30,7 +30,8 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B"), UUID("C")]))
     }
@@ -50,14 +51,15 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("B"), UUID("C")]))
         expect(items.first).to(equal(currentItem))
@@ -78,14 +80,15 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -100,14 +103,15 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }
@@ -125,14 +129,15 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("C")]))
     }
@@ -149,14 +154,15 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .off,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("2"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -175,7 +181,8 @@ final class AVPlayerItemRepeatOffUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .off,
             length: 2,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("B")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
@@ -30,7 +30,8 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B"), UUID("C")]))
     }
@@ -50,14 +51,15 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3"), UUID("B"), UUID("C")]))
         expect(items.first).to(equal(currentItem))
@@ -78,14 +80,15 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -100,14 +103,15 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B")]))
     }
@@ -125,14 +129,15 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("2"), UUID("C")]))
     }
@@ -149,14 +154,15 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem(configuration: .default)
+        let currentItem = currentItemContent.playerItem(configuration: .default, limits: .none)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
             length: .max,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("1"), UUID("2"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -175,7 +181,8 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             currentItem: nil,
             repeatMode: .one,
             length: 2,
-            configuration: .default
+            configuration: .default,
+            limits: .none
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemRepeatOneUpdateTests.swift
@@ -29,7 +29,8 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             replacing: previousContents,
             currentItem: nil,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B"), UUID("C")]))
     }
@@ -49,13 +50,14 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "B"),
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3"), UUID("B"), UUID("C")]))
         expect(items.first).to(equal(currentItem))
@@ -76,13 +78,14 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "C"),
             currentItemContent
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("3"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -97,13 +100,14 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "A"),
             .test(id: "B")
         ]
-        let unknownItem = AssetContent.test(id: "1").playerItem()
+        let unknownItem = AssetContent.test(id: "1").playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: unknownItem,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A"), UUID("B")]))
     }
@@ -121,13 +125,14 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             otherContent,
             .test(id: "C")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("2"), UUID("2"), UUID("C")]))
     }
@@ -144,13 +149,14 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             .test(id: "2"),
             .test(id: "3")
         ]
-        let currentItem = currentItemContent.playerItem()
+        let currentItem = currentItemContent.playerItem(configuration: .default)
         let items = AVPlayerItem.playerItems(
             for: currentContents,
             replacing: previousContents,
             currentItem: currentItem,
             repeatMode: .one,
-            length: .max
+            length: .max,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("1"), UUID("1"), UUID("2"), UUID("3")]))
         expect(items.first).to(equal(currentItem))
@@ -168,7 +174,8 @@ final class AVPlayerItemRepeatOneUpdateTests: TestCase {
             replacing: [],
             currentItem: nil,
             repeatMode: .one,
-            length: 2
+            length: 2,
+            configuration: .default
         )
         expect(items.map(\.id)).to(equalDiff([UUID("A"), UUID("A")]))
     }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
@@ -35,7 +35,8 @@ final class AVPlayerItemTests: TestCase {
                 repeatMode: .off,
                 length: .max,
                 reload: false,
-                configuration: .default
+                configuration: .default,
+                limits: .none
             )
             .compactMap(\.url)
         }
@@ -59,7 +60,8 @@ final class AVPlayerItemTests: TestCase {
                 repeatMode: .one,
                 length: .max,
                 reload: false,
-                configuration: .default
+                configuration: .default,
+                limits: .none
             )
             .compactMap(\.url)
         }
@@ -84,7 +86,8 @@ final class AVPlayerItemTests: TestCase {
                 repeatMode: .all,
                 length: .max,
                 reload: false,
-                configuration: .default
+                configuration: .default,
+                limits: .none
             )
             .compactMap(\.url)
         }

--- a/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
+++ b/Tests/PlayerTests/AVPlayer/AVPlayerItemTests.swift
@@ -29,7 +29,15 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .off, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(
+                from: items,
+                after: 0,
+                repeatMode: .off,
+                length: .max,
+                reload: false,
+                configuration: .default
+            )
+            .compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,
@@ -45,7 +53,15 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .one, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(
+                from: items,
+                after: 0,
+                repeatMode: .one,
+                length: .max,
+                reload: false,
+                configuration: .default
+            )
+            .compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,
@@ -62,7 +78,15 @@ final class AVPlayerItemTests: TestCase {
             PlayerItem.simple(url: Stream.live.url)
         ]
         expect {
-            AVPlayerItem.playerItems(from: items, after: 0, repeatMode: .all, length: .max, reload: false).compactMap(\.url)
+            AVPlayerItem.playerItems(
+                from: items,
+                after: 0,
+                repeatMode: .all,
+                length: .max,
+                reload: false,
+                configuration: .default
+            )
+            .compactMap(\.url)
         }
         .toEventually(equal([
             Stream.onDemand.url,

--- a/Tests/PlayerTests/Asset/ResourceItemTests.swift
+++ b/Tests/PlayerTests/Asset/ResourceItemTests.swift
@@ -12,7 +12,7 @@ import PillarboxStreams
 
 final class ResourceItemTests: TestCase {
     func testNativePlayerItem() {
-        let item = Resource.simple(url: Stream.onDemand.url).playerItem()
+        let item = Resource.simple(url: Stream.onDemand.url).playerItem(configuration: .default)
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false, true],
@@ -21,7 +21,7 @@ final class ResourceItemTests: TestCase {
     }
 
     func testLoadingPlayerItem() {
-        let item = Resource.loading.playerItem()
+        let item = Resource.loading.playerItem(configuration: .default)
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false],
@@ -30,7 +30,7 @@ final class ResourceItemTests: TestCase {
     }
 
     func testFailingPlayerItem() {
-        let item = Resource.failing(error: StructError()).playerItem()
+        let item = Resource.failing(error: StructError()).playerItem(configuration: .default)
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [.unknown],

--- a/Tests/PlayerTests/Asset/ResourceItemTests.swift
+++ b/Tests/PlayerTests/Asset/ResourceItemTests.swift
@@ -12,7 +12,7 @@ import PillarboxStreams
 
 final class ResourceItemTests: TestCase {
     func testNativePlayerItem() {
-        let item = Resource.simple(url: Stream.onDemand.url).playerItem(configuration: .default)
+        let item = Resource.simple(url: Stream.onDemand.url).playerItem(configuration: .default, limits: .none)
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false, true],
@@ -21,7 +21,7 @@ final class ResourceItemTests: TestCase {
     }
 
     func testLoadingPlayerItem() {
-        let item = Resource.loading.playerItem(configuration: .default)
+        let item = Resource.loading.playerItem(configuration: .default, limits: .none)
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false],
@@ -30,7 +30,7 @@ final class ResourceItemTests: TestCase {
     }
 
     func testFailingPlayerItem() {
-        let item = Resource.failing(error: StructError()).playerItem(configuration: .default)
+        let item = Resource.failing(error: StructError()).playerItem(configuration: .default, limits: .none)
         _ = AVPlayer(playerItem: item)
         expectEqualPublished(
             values: [.unknown],

--- a/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/MediaSelectionTests.swift
@@ -69,7 +69,7 @@ final class MediaSelectionTests: TestCase {
     func testLegibleOptionsMustNotContainForcedSubtitles() {
         let player = Player(item: .simple(url: Stream.onDemandWithForcedAndUnforcedLegibleOptions.url))
         expect(player.mediaSelectionCharacteristics).toEventually(equal([.audible, .legible]))
-        expect(player.mediaSelectionOptions(for: .legible).count).to(equal(6))
+        expect(player.mediaSelectionOptions(for: .legible)).to(haveCount(6))
     }
 
     func testInitialAudibleOption() {

--- a/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
@@ -14,14 +14,14 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url, configuration: .init(preferredForwardBufferDuration: 4))
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
     func testSimpleItemWithoutConfiguration() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(0))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
     }
 
     func testCustomItem() {
@@ -29,7 +29,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate, configuration: .init(preferredForwardBufferDuration: 4))
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
     func testCustomItemWithoutConfiguration() {
@@ -37,7 +37,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(0))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
     }
 
     func testEncryptedItem() {
@@ -45,7 +45,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate, configuration: .init(preferredForwardBufferDuration: 4))
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
     func testEncryptedItemWithoutConfiguration() {
@@ -53,6 +53,6 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem().preferredForwardBufferDuration).to(equal(0))
+        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
     }
 }

--- a/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
@@ -10,49 +10,114 @@ import Nimble
 import PillarboxStreams
 
 final class PlayerItemTests: TestCase {
+    private static let playerConfiguration = PlayerConfiguration(
+        preferredPeakBitRate: 100,
+        preferredPeakBitRateForExpensiveNetworks: 200,
+        preferredMaximumResolution: .init(width: 100, height: 200),
+        preferredMaximumResolutionForExpensiveNetworks: .init(width: 300, height: 400)
+    )
+
     func testSimpleItem() {
+        let item = PlayerItem.simple(url: Stream.onDemand.url)
+        PlayerItem.load(for: item.id)
+        expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
+        let playerItem = item.content.playerItem(configuration: .default)
+        expect(playerItem.preferredForwardBufferDuration).to(equal(0))
+        expect(playerItem.preferredPeakBitRate).to(equal(0))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+        expect(playerItem.preferredMaximumResolution).to(equal(.zero))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+    }
+
+    func testSimpleItemWithConfiguration() {
         let item = PlayerItem.simple(url: Stream.onDemand.url, configuration: .init(preferredForwardBufferDuration: 4))
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
         expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
-    func testSimpleItemWithoutConfiguration() {
+    func testSimpleItemWithNonStandardPlayerConfiguration() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
+        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        expect(playerItem.preferredPeakBitRate).to(equal(100))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+        expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
     }
 
     func testCustomItem() {
         let delegate = ResourceLoaderDelegateMock()
-        let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate, configuration: .init(preferredForwardBufferDuration: 4))
+        let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate)
+        PlayerItem.load(for: item.id)
+        expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
+        let playerItem = item.content.playerItem(configuration: .default)
+        expect(playerItem.preferredForwardBufferDuration).to(equal(0))
+        expect(playerItem.preferredPeakBitRate).to(equal(0))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+        expect(playerItem.preferredMaximumResolution).to(equal(.zero))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+    }
+
+    func testCustomItemWithConfiguration() {
+        let delegate = ResourceLoaderDelegateMock()
+        let item = PlayerItem.custom(
+            url: Stream.onDemand.url,
+            delegate: delegate,
+            configuration: .init(preferredForwardBufferDuration: 4)
+        )
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
         expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
-    func testCustomItemWithoutConfiguration() {
+    func testCustomItemWithNonStandardPlayerConfiguration() {
         let delegate = ResourceLoaderDelegateMock()
         let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
+        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        expect(playerItem.preferredPeakBitRate).to(equal(100))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+        expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
     }
 
     func testEncryptedItem() {
         let delegate = ContentKeySessionDelegateMock()
-        let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate, configuration: .init(preferredForwardBufferDuration: 4))
+        let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate)
+        PlayerItem.load(for: item.id)
+        expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
+        let playerItem = item.content.playerItem(configuration: .default)
+        expect(playerItem.preferredForwardBufferDuration).to(equal(0))
+        expect(playerItem.preferredPeakBitRate).to(equal(0))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+        expect(playerItem.preferredMaximumResolution).to(equal(.zero))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+    }
+
+    func testEncryptedItemWithConfiguration() {
+        let delegate = ContentKeySessionDelegateMock()
+        let item = PlayerItem.encrypted(
+            url: Stream.onDemand.url,
+            delegate: delegate,
+            configuration: .init(preferredForwardBufferDuration: 4)
+        )
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
         expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
     }
 
-    func testEncryptedItemWithoutConfiguration() {
+    func testEncryptedItemWithNonStandardPlayerConfiguration() {
         let delegate = ContentKeySessionDelegateMock()
         let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(0))
+        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        expect(playerItem.preferredPeakBitRate).to(equal(100))
+        expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+        expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+        expect(playerItem.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
     }
 }

--- a/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
+++ b/Tests/PlayerTests/PlayerItem/PlayerItemTests.swift
@@ -10,7 +10,7 @@ import Nimble
 import PillarboxStreams
 
 final class PlayerItemTests: TestCase {
-    private static let playerConfiguration = PlayerConfiguration(
+    private static let limits = PlayerLimits(
         preferredPeakBitRate: 100,
         preferredPeakBitRateForExpensiveNetworks: 200,
         preferredMaximumResolution: .init(width: 100, height: 200),
@@ -21,7 +21,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        let playerItem = item.content.playerItem(configuration: .default)
+        let playerItem = item.content.playerItem(configuration: .default, limits: .none)
         expect(playerItem.preferredForwardBufferDuration).to(equal(0))
         expect(playerItem.preferredPeakBitRate).to(equal(0))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
@@ -33,14 +33,14 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.simple(url: Stream.onDemand.url, configuration: .init(preferredForwardBufferDuration: 4))
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(configuration: .default, limits: .none).preferredForwardBufferDuration).to(equal(4))
     }
 
-    func testSimpleItemWithNonStandardPlayerConfiguration() {
+    func testSimpleItemWithLimits() {
         let item = PlayerItem.simple(url: Stream.onDemand.url)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.simple(url: Stream.onDemand.url)))
-        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        let playerItem = item.content.playerItem(configuration: .default, limits: Self.limits)
         expect(playerItem.preferredPeakBitRate).to(equal(100))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
         expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
@@ -52,7 +52,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        let playerItem = item.content.playerItem(configuration: .default)
+        let playerItem = item.content.playerItem(configuration: .default, limits: .none)
         expect(playerItem.preferredForwardBufferDuration).to(equal(0))
         expect(playerItem.preferredPeakBitRate).to(equal(0))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
@@ -69,15 +69,18 @@ final class PlayerItemTests: TestCase {
         )
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(
+            configuration: .default,
+            limits: .none
+        ).preferredForwardBufferDuration).to(equal(4))
     }
 
-    func testCustomItemWithNonStandardPlayerConfiguration() {
+    func testCustomItemWithLimits() {
         let delegate = ResourceLoaderDelegateMock()
         let item = PlayerItem.custom(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.custom(url: Stream.onDemand.url, delegate: delegate)))
-        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        let playerItem = item.content.playerItem(configuration: .default, limits: Self.limits)
         expect(playerItem.preferredPeakBitRate).to(equal(100))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
         expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
@@ -89,7 +92,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        let playerItem = item.content.playerItem(configuration: .default)
+        let playerItem = item.content.playerItem(configuration: .default, limits: .none)
         expect(playerItem.preferredForwardBufferDuration).to(equal(0))
         expect(playerItem.preferredPeakBitRate).to(equal(0))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
@@ -106,7 +109,10 @@ final class PlayerItemTests: TestCase {
         )
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        expect(item.content.playerItem(configuration: .default).preferredForwardBufferDuration).to(equal(4))
+        expect(item.content.playerItem(
+            configuration: .default,
+            limits: .none
+        ).preferredForwardBufferDuration).to(equal(4))
     }
 
     func testEncryptedItemWithNonStandardPlayerConfiguration() {
@@ -114,7 +120,7 @@ final class PlayerItemTests: TestCase {
         let item = PlayerItem.encrypted(url: Stream.onDemand.url, delegate: delegate)
         PlayerItem.load(for: item.id)
         expect(item.content.resource).toEventually(equal(.encrypted(url: Stream.onDemand.url, delegate: delegate)))
-        let playerItem = item.content.playerItem(configuration: Self.playerConfiguration)
+        let playerItem = item.content.playerItem(configuration: .default, limits: Self.limits)
         expect(playerItem.preferredPeakBitRate).to(equal(100))
         expect(playerItem.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
         expect(playerItem.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))

--- a/Tests/PlayerTests/Playlist/CurrentItemTests.swift
+++ b/Tests/PlayerTests/Playlist/CurrentItemTests.swift
@@ -153,7 +153,7 @@ final class CurrentItemTests: TestCase {
         player.currentItem = item3
 
         let items = player.queuePlayer.items()
-        expect(items.count).to(equal(player.configuration.preloadedItems))
+        expect(items).to(haveCount(player.configuration.preloadedItems))
     }
 
     func testSetCurrentItemWithUnknownItem() {

--- a/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
+++ b/Tests/PlayerTests/Playlist/ItemNavigationForwardTests.swift
@@ -48,7 +48,7 @@ final class ItemNavigationForwardTests: TestCase {
         player.advanceToNextItem()
 
         let items = player.queuePlayer.items()
-        expect(items.count).to(equal(player.configuration.preloadedItems))
+        expect(items).to(haveCount(player.configuration.preloadedItems))
     }
 
     func testWrapAtBackWithRepeatAll() {

--- a/Tests/PlayerTests/Playlist/NavigationBackwardTests.swift
+++ b/Tests/PlayerTests/Playlist/NavigationBackwardTests.swift
@@ -132,6 +132,6 @@ final class NavigationBackwardTests: TestCase {
         player.returnToPrevious()
 
         let items = player.queuePlayer.items()
-        expect(items.count).to(equal(player.configuration.preloadedItems))
+        expect(items).to(haveCount(player.configuration.preloadedItems))
     }
 }

--- a/Tests/PlayerTests/Tools/Similarity.swift
+++ b/Tests/PlayerTests/Tools/Similarity.swift
@@ -15,7 +15,16 @@ extension ImageSource: Similar {
         switch (lhs.kind, rhs.kind) {
         case (.none, .none):
             return true
-        case let (.url(standardResolution: lhsStandardResolutionUrl, lowResolution: lhsLowResolutionUrl), .url(standardResolution: rhsStandardResolutionUrl, lowResolution: rhsLowResolutionUrl)):
+        case let (
+            .url(
+                standardResolution: lhsStandardResolutionUrl,
+                lowResolution: lhsLowResolutionUrl
+            ),
+            .url(
+                standardResolution: rhsStandardResolutionUrl,
+                lowResolution: rhsLowResolutionUrl
+            )
+        ):
             return lhsStandardResolutionUrl == rhsStandardResolutionUrl && lhsLowResolutionUrl == rhsLowResolutionUrl
         case let (.image(lhsImage), .image(rhsImage)):
             return lhsImage.pngData() == rhsImage.pngData()

--- a/Tests/PlayerTests/Tools/Similarity.swift
+++ b/Tests/PlayerTests/Tools/Similarity.swift
@@ -15,8 +15,8 @@ extension ImageSource: Similar {
         switch (lhs.kind, rhs.kind) {
         case (.none, .none):
             return true
-        case let (.url(lhsUrl), .url(rhsUrl)):
-            return lhsUrl == rhsUrl
+        case let (.url(standardResolution: lhsStandardResolutionUrl, lowResolution: lhsLowResolutionUrl), .url(standardResolution: rhsStandardResolutionUrl, lowResolution: rhsLowResolutionUrl)):
+            return lhsStandardResolutionUrl == rhsStandardResolutionUrl && lhsLowResolutionUrl == rhsLowResolutionUrl
         case let (.image(lhsImage), .image(rhsImage)):
             return lhsImage.pngData() == rhsImage.pngData()
         default:

--- a/Tests/PlayerTests/Types/ImageSourceTests.swift
+++ b/Tests/PlayerTests/Types/ImageSourceTests.swift
@@ -29,9 +29,9 @@ final class ImageSourceTests: TestCase {
 
     func testNonLoadedImageForValidUrl() {
         let url = Bundle.module.url(forResource: "pixel", withExtension: "jpg")!
-        let source = ImageSource.url(url)
+        let source = ImageSource.url(standardResolution: url)
         expectSimilarPublished(
-            values: [.url(url)],
+            values: [.url(standardResolution: url)],
             from: source.imageSourcePublisher(),
             during: .milliseconds(100)
         )
@@ -40,9 +40,9 @@ final class ImageSourceTests: TestCase {
     func testLoadedImageForValidUrl() {
         let url = Bundle.module.url(forResource: "pixel", withExtension: "jpg")!
         let image = UIImage(contentsOfFile: url.path())!
-        let source = ImageSource.url(url)
+        let source = ImageSource.url(standardResolution: url)
         expectSimilarPublished(
-            values: [.url(url), .image(image)],
+            values: [.url(standardResolution: url), .image(image)],
             from: source.imageSourcePublisher(),
             during: .milliseconds(100)
         ) {
@@ -52,9 +52,9 @@ final class ImageSourceTests: TestCase {
 
     func testInvalidImageFormat() {
         let url = Bundle.module.url(forResource: "invalid", withExtension: "jpg")!
-        let source = ImageSource.url(url)
+        let source = ImageSource.url(standardResolution: url)
         expectSimilarPublished(
-            values: [.url(url), .none],
+            values: [.url(standardResolution: url), .none],
             from: source.imageSourcePublisher(),
             during: .milliseconds(100)
         ) {
@@ -64,9 +64,9 @@ final class ImageSourceTests: TestCase {
 
     func testFailingUrl() {
         let url = URL(string: "https://localhost:8123/missing.jpg")!
-        let source = ImageSource.url(url)
+        let source = ImageSource.url(standardResolution: url)
         expectSimilarPublished(
-            values: [.url(url), .none],
+            values: [.url(standardResolution: url), .none],
             from: source.imageSourcePublisher(),
             during: .seconds(1)
         ) {

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -9,7 +9,7 @@
 import Nimble
 
 final class PlayerConfigurationTests: TestCase {
-    func testPlayerConfigurationDefaultValues() {
+    func testDefaultValues() {
         let configuration = PlayerConfiguration()
         expect(configuration.allowsExternalPlayback).to(beTrue())
         expect(configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
@@ -21,7 +21,7 @@ final class PlayerConfigurationTests: TestCase {
         expect(configuration.allowsConstrainedNetworkAccess).to(beTrue())
     }
 
-    func testPlayerConfigurationCustomValues() {
+    func testCustomValues() {
         let configuration = PlayerConfiguration(
             allowsExternalPlayback: false,
             usesExternalPlaybackWhileMirroring: true,

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -19,6 +19,11 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.backwardSkipInterval).to(equal(10))
         expect(player.configuration.forwardSkipInterval).to(equal(10))
         expect(player.configuration.preloadedItems).to(equal(2))
+        expect(player.configuration.allowsConstrainedNetworkAccess).to(beTrue())
+        expect(player.configuration.preferredPeakBitRate).to(equal(0))
+        expect(player.configuration.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+        expect(player.configuration.preferredMaximumResolution).to(equal(.zero))
+        expect(player.configuration.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
     }
 
     func testPlayerConfigurationInit() {
@@ -28,7 +33,12 @@ final class PlayerConfigurationTests: TestCase {
             preventsDisplaySleepDuringVideoPlayback: false,
             navigationMode: .immediate,
             backwardSkipInterval: 42,
-            forwardSkipInterval: 47
+            forwardSkipInterval: 47,
+            allowsConstrainedNetworkAccess: false,
+            preferredPeakBitRate: 100,
+            preferredPeakBitRateForExpensiveNetworks: 200,
+            preferredMaximumResolution: .init(width: 100, height: 200),
+            preferredMaximumResolutionForExpensiveNetworks: .init(width: 300, height: 400)
         )
         let player = Player(configuration: configuration)
         expect(player.configuration.allowsExternalPlayback).to(beFalse())
@@ -37,5 +47,10 @@ final class PlayerConfigurationTests: TestCase {
         expect(player.configuration.navigationMode).to(equal(.immediate))
         expect(player.configuration.backwardSkipInterval).to(equal(42))
         expect(player.configuration.forwardSkipInterval).to(equal(47))
+        expect(player.configuration.allowsConstrainedNetworkAccess).to(beFalse())
+        expect(player.configuration.preferredPeakBitRate).to(equal(100))
+        expect(player.configuration.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+        expect(player.configuration.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+        expect(player.configuration.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
     }
 }

--- a/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
+++ b/Tests/PlayerTests/Types/PlayerConfigurationTests.swift
@@ -11,22 +11,17 @@ import Nimble
 final class PlayerConfigurationTests: TestCase {
     func testPlayerConfigurationDefaultValues() {
         let configuration = PlayerConfiguration()
-        let player = Player(configuration: configuration)
-        expect(player.configuration.allowsExternalPlayback).to(beTrue())
-        expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
-        expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beTrue())
-        expect(player.configuration.navigationMode).to(equal(.smart(interval: 3)))
-        expect(player.configuration.backwardSkipInterval).to(equal(10))
-        expect(player.configuration.forwardSkipInterval).to(equal(10))
-        expect(player.configuration.preloadedItems).to(equal(2))
-        expect(player.configuration.allowsConstrainedNetworkAccess).to(beTrue())
-        expect(player.configuration.preferredPeakBitRate).to(equal(0))
-        expect(player.configuration.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
-        expect(player.configuration.preferredMaximumResolution).to(equal(.zero))
-        expect(player.configuration.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+        expect(configuration.allowsExternalPlayback).to(beTrue())
+        expect(configuration.usesExternalPlaybackWhileMirroring).to(beFalse())
+        expect(configuration.preventsDisplaySleepDuringVideoPlayback).to(beTrue())
+        expect(configuration.navigationMode).to(equal(.smart(interval: 3)))
+        expect(configuration.backwardSkipInterval).to(equal(10))
+        expect(configuration.forwardSkipInterval).to(equal(10))
+        expect(configuration.preloadedItems).to(equal(2))
+        expect(configuration.allowsConstrainedNetworkAccess).to(beTrue())
     }
 
-    func testPlayerConfigurationInit() {
+    func testPlayerConfigurationCustomValues() {
         let configuration = PlayerConfiguration(
             allowsExternalPlayback: false,
             usesExternalPlaybackWhileMirroring: true,
@@ -34,23 +29,14 @@ final class PlayerConfigurationTests: TestCase {
             navigationMode: .immediate,
             backwardSkipInterval: 42,
             forwardSkipInterval: 47,
-            allowsConstrainedNetworkAccess: false,
-            preferredPeakBitRate: 100,
-            preferredPeakBitRateForExpensiveNetworks: 200,
-            preferredMaximumResolution: .init(width: 100, height: 200),
-            preferredMaximumResolutionForExpensiveNetworks: .init(width: 300, height: 400)
+            allowsConstrainedNetworkAccess: false
         )
-        let player = Player(configuration: configuration)
-        expect(player.configuration.allowsExternalPlayback).to(beFalse())
-        expect(player.configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
-        expect(player.configuration.preventsDisplaySleepDuringVideoPlayback).to(beFalse())
-        expect(player.configuration.navigationMode).to(equal(.immediate))
-        expect(player.configuration.backwardSkipInterval).to(equal(42))
-        expect(player.configuration.forwardSkipInterval).to(equal(47))
-        expect(player.configuration.allowsConstrainedNetworkAccess).to(beFalse())
-        expect(player.configuration.preferredPeakBitRate).to(equal(100))
-        expect(player.configuration.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
-        expect(player.configuration.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
-        expect(player.configuration.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
+        expect(configuration.allowsExternalPlayback).to(beFalse())
+        expect(configuration.usesExternalPlaybackWhileMirroring).to(beTrue())
+        expect(configuration.preventsDisplaySleepDuringVideoPlayback).to(beFalse())
+        expect(configuration.navigationMode).to(equal(.immediate))
+        expect(configuration.backwardSkipInterval).to(equal(42))
+        expect(configuration.forwardSkipInterval).to(equal(47))
+        expect(configuration.allowsConstrainedNetworkAccess).to(beFalse())
     }
 }

--- a/Tests/PlayerTests/Types/PlayerLimitsTests.swift
+++ b/Tests/PlayerTests/Types/PlayerLimitsTests.swift
@@ -7,9 +7,17 @@
 @testable import PillarboxPlayer
 
 import Nimble
+import PillarboxStreams
 
 final class PlayerLimitsTests: TestCase {
-    func testPlayerLimitsDefaultValues() {
+    private static let limits = PlayerLimits(
+        preferredPeakBitRate: 100,
+        preferredPeakBitRateForExpensiveNetworks: 200,
+        preferredMaximumResolution: .init(width: 100, height: 200),
+        preferredMaximumResolutionForExpensiveNetworks: .init(width: 300, height: 400)
+    )
+
+    func testDefaultValues() {
         let limits = PlayerLimits()
         expect(limits.preferredPeakBitRate).to(equal(0))
         expect(limits.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
@@ -17,7 +25,7 @@ final class PlayerLimitsTests: TestCase {
         expect(limits.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
     }
 
-    func testPlayerLimitsCustomValues() {
+    func testCustomValues() {
         let limits = PlayerLimits(
             preferredPeakBitRate: 100,
             preferredPeakBitRateForExpensiveNetworks: 200,
@@ -28,5 +36,32 @@ final class PlayerLimitsTests: TestCase {
         expect(limits.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
         expect(limits.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
         expect(limits.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
+    }
+
+    func testAppliedDefaultValues() {
+        let player = Player(items: [
+            .simple(url: Stream.onDemand.url),
+            .simple(url: Stream.mediumOnDemand.url)
+        ])
+        player.queuePlayer.items().forEach { item in
+            expect(item.preferredPeakBitRate).to(equal(0))
+            expect(item.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+            expect(item.preferredMaximumResolution).to(equal(.zero))
+            expect(item.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+        }
+    }
+
+    func testAppliedInitialValues() {
+        let player = Player(items: [
+            .simple(url: Stream.onDemand.url),
+            .simple(url: Stream.mediumOnDemand.url)
+        ])
+        player.limits = Self.limits
+        player.queuePlayer.items().forEach { item in
+            expect(item.preferredPeakBitRate).to(equal(100))
+            expect(item.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+            expect(item.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+            expect(item.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
+        }
     }
 }

--- a/Tests/PlayerTests/Types/PlayerLimitsTests.swift
+++ b/Tests/PlayerTests/Types/PlayerLimitsTests.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import Nimble
+
+final class PlayerLimitsTests: TestCase {
+    func testPlayerLimitsDefaultValues() {
+        let limits = PlayerLimits()
+        expect(limits.preferredPeakBitRate).to(equal(0))
+        expect(limits.preferredPeakBitRateForExpensiveNetworks).to(equal(0))
+        expect(limits.preferredMaximumResolution).to(equal(.zero))
+        expect(limits.preferredMaximumResolutionForExpensiveNetworks).to(equal(.zero))
+    }
+
+    func testPlayerLimitsCustomValues() {
+        let limits = PlayerLimits(
+            preferredPeakBitRate: 100,
+            preferredPeakBitRateForExpensiveNetworks: 200,
+            preferredMaximumResolution: .init(width: 100, height: 200),
+            preferredMaximumResolutionForExpensiveNetworks: .init(width: 300, height: 400)
+        )
+        expect(limits.preferredPeakBitRate).to(equal(100))
+        expect(limits.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+        expect(limits.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+        expect(limits.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
+    }
+}

--- a/Tests/PlayerTests/Types/PlayerLimitsTests.swift
+++ b/Tests/PlayerTests/Types/PlayerLimitsTests.swift
@@ -64,4 +64,16 @@ final class PlayerLimitsTests: TestCase {
             expect(item.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
         }
     }
+
+    func testLoadedItem() {
+        let player = Player(item: .mock(url: Stream.onDemand.url, loadedAfter: 0.1))
+        player.limits = Self.limits
+        expect(player.playbackState).toEventually(equal(.paused))
+        player.queuePlayer.items().forEach { item in
+            expect(item.preferredPeakBitRate).to(equal(100))
+            expect(item.preferredPeakBitRateForExpensiveNetworks).to(equal(200))
+            expect(item.preferredMaximumResolution).to(equal(.init(width: 100, height: 200)))
+            expect(item.preferredMaximumResolutionForExpensiveNetworks).to(equal(.init(width: 300, height: 400)))
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR adds features making it possible to constrain the player behavior:

- [Low Data Mode](https://developer.apple.com/videos/play/wwdc2019/712/?time=492) support: Players can optionally always fail on constrained networks. Image sources also have been updated to support low-resolution variants if available.
- Limits: Bandwidth and / or resolution limits can be provided and updated at any time, making it possible to provide data-saving or environment-friendly options.

| Global quality setting | Player quality setting |
|--------|--------|
| <img width="567" alt="Settings" src="https://github.com/user-attachments/assets/5e0dc741-1748-44cf-83f7-588dae1a9312"> | <img width="567" alt="Player" src="https://github.com/user-attachments/assets/36c7ea39-4516-4de3-8261-1ea26959f09c"> | 

## Design considerations

- Having players fail on constrained networks seem rather useless at first, but this can be very helpful for secondary content (e.g. videos used for decorative purposes). For this reason constrained behavior is a player behavior and therefore a constant set at construction time, rather than an item configuration property (even though internal setup is actually made on `AVURLAsset`).
- The opposite behavior is implemented for limits, which users must be able to change at any time.

## Changes made

- Add `allowsConstrainedNetworkAccess` Boolean setting to `PlayerConfiguration`.
- Add standard and low resolution parameters to URL-based `ImageSource`s (breaking API change).
- Add `PlayerLimits` to setup peak bit rates and maximum resolution, also on expensive networks (mobile networks e.g.). 
- Add `limits` mutable property to `Player`. This property does not need to be published as it does not change by itself and is less relevant to observe than any kind of semantic quality definition built on top of it (see `QualitySetting` in the demo).
- Update Core Business items to deliver lower quality images when Low Data Mode is enabled (320px instead of 720px).
- Add _Quality_ setting to the demo global settings (with values high, medium and low). High is unlimited, while medium and low are limited to 2Mbps and 0.5Mbps respectively.
- Add _Quality_ selection menu to the demo custom player layout (modifying the same global setting).
- Implement limits for all relevant players view models in the demo. Other more standalone players have not been updated to keep their true purpose (e.g the simple example must remain simple).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
