### PR TITLE
Remove superfluous Quality menu level on macOS

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -482,6 +482,7 @@ private struct QualityMenu: View {
                     Text(quality.name).tag(quality)
                 }
             }
+            .pickerStyle(.inline)
         } label: {
             Label {
                 Text("Quality")


### PR DESCRIPTION
## Description

This PR removes a superfluous Quality menu level when running the demo as iPad app on macOS, so that the menu appears as expected:

![Screenshot 2024-11-04 at 09 08 36](https://github.com/user-attachments/assets/35f821c6-917f-4320-953b-ad3af0ac48b4)

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
