### PR TITLE
Avoid using SwiftLint via Mint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,9 @@ clean-imports:
 	@echo "Cleaning imports..."
 	@mkdir -p .build
 	@xcodebuild -scheme Pillarbox -destination generic/platform=ios > ./.build/xcodebuild.log
-	@mint run swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
+	@swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
 	@xcodebuild -scheme Pillarbox-demo -project ./Demo/Pillarbox-demo.xcodeproj -destination generic/platform=iOS > ./.build/xcodebuild.log
-	@mint run swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
+	@swiftlint analyze --fix --compiler-log-path ./.build/xcodebuild.log
 	@echo "... done.\n"
 
 .PHONY: find-dead-code

--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,0 @@
-realm/SwiftLint@0.56.2

--- a/Scripts/check-quality.sh
+++ b/Scripts/check-quality.sh
@@ -4,9 +4,9 @@ set -e
 
 echo "... checking Swift code..."
 if [ $# -eq 0 ]; then
-  mint run swiftlint --quiet --strict
+  swiftlint --quiet --strict
 elif [[ "$1" == "only-changes" ]]; then
-  git diff --staged --name-only | grep ".swift$" | xargs mint run swiftlint --quiet --strict
+  git diff --staged --name-only | grep ".swift$" | xargs swiftlint lint --quiet --strict
 fi
 echo "... checking Ruby scripts..."
 bundle exec rubocop --format quiet

--- a/Scripts/fix-quality.sh
+++ b/Scripts/fix-quality.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-mint run swiftlint --fix && mint run swiftlint
+swiftlint --fix && swiftlint

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -27,8 +27,8 @@ The continuous integration agents must have the following tools installed:
 - [bundler](https://bundler.io)
 - [ffmpeg](https://ffmpeg.org)
 - [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
-- [mint](https://github.com/yonaskolb/Mint)
 - [shellcheck](https://www.shellcheck.net)
+- [swiftlint](https://github.com/realm/SwiftLint)
 - [xcodes](https://github.com/RobotsAndPencils/xcodes)
 - [yamllint](https://github.com/adrienverge/yamllint)
 

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -13,10 +13,10 @@ The following tools are required for the best possible development experience:
 - [ffmpeg](https://ffmpeg.org)
 - [gem](https://rubygems.org)
 - [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
-- [mint](https://github.com/yonaskolb/Mint)
 - [Periphery](https://github.com/peripheryapp/periphery)
 - [Python](https://www.python.org)
 - [shellcheck](https://www.shellcheck.net)
+- [swiftlint](https://github.com/realm/SwiftLint)
 - [xcodes](https://github.com/RobotsAndPencils/xcodes)
 - [yamllint](https://github.com/adrienverge/yamllint)
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,7 +4,7 @@
 # Quality check
 #================================================================
 
-PATH="$(which mint):$(which ruby):$PATH"
+PATH="$(which swiftlint):$(which ruby):$PATH"
 
 if Scripts/check-quality.sh only-changes; then
 	echo "✅ Quality checked"


### PR DESCRIPTION
## Description

This PR removes [Mint](https://github.com/yonaskolb/Mint) which was introduced to enable using [SwiftLint 0.54.0](https://github.com/SRGSSR/pillarbox-apple/issues/736).

> [!NOTE]  
> The advantage of using `Mint` is that it allows for a specific version of SwiftLint. However, the downside is that it takes a long time to build the first time. Moreover, if we consider that we have a CI system that uses virtual machines in a near future, which create a new environment for each workflow, we cannot afford to spend that much time.

## Changes made

- `Mint` has been removed.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
