### PR TITLE
Improve demo accessibility via VoiceOver

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -76,6 +76,9 @@
     "Clear URL cache" : {
 
     },
+    "Close" : {
+
+    },
     "Color" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -205,6 +205,9 @@
     "Observed bitrate min" : {
 
     },
+    "Open as playlist" : {
+
+    },
     "Open modal" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -7,6 +7,16 @@
     "-" : {
 
     },
+    "%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
     "%g× %@" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -280,6 +290,12 @@
 
     },
     "Startup times (QoS)" : {
+
+    },
+    "Startup times (Quality of experience)" : {
+
+    },
+    "Startup times (Quality of service)" : {
 
     },
     "Stop" : {

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -172,6 +172,9 @@
     "Made with " : {
 
     },
+    "Made with love in Switzerland" : {
+
+    },
     "Max. %.02f Mbps" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -331,9 +331,6 @@
     "Stop" : {
 
     },
-    "Supports Picture in Picture" : {
-
-    },
     "Swap" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -226,6 +226,9 @@
     "Open as playlist" : {
 
     },
+    "Open full-screen player" : {
+
+    },
     "Open modal" : {
 
     },
@@ -328,7 +331,7 @@
     "Stop" : {
 
     },
-    "Supports PiP" : {
+    "Supports Picture in Picture" : {
 
     },
     "Swap" : {

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -160,6 +160,9 @@
     "Information" : {
 
     },
+    "Jump to live" : {
+
+    },
     "Kind" : {
 
     },

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -103,6 +103,9 @@
     "Deferred" : {
 
     },
+    "Delete all" : {
+
+    },
     "Displays touches for presentation purposes." : {
 
     },
@@ -199,6 +202,9 @@
     "Mode" : {
 
     },
+    "Next" : {
+
+    },
     "None" : {
 
     },
@@ -250,6 +256,9 @@
     "Presenter mode" : {
 
     },
+    "Previous" : {
+
+    },
     "Progress" : {
 
     },
@@ -281,6 +290,9 @@
 
     },
     "Shows a video overlay displaying various playback-related statistics." : {
+
+    },
+    "Shuffle" : {
 
     },
     "Simulate memory warning" : {

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -109,6 +109,9 @@
     "Documentation" : {
 
     },
+    "Double tap to toggle controls" : {
+
+    },
     "Embeddings" : {
 
     },
@@ -386,6 +389,9 @@
 
     },
     "Version information" : {
+
+    },
+    "Video" : {
 
     },
     "Web" : {

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -135,6 +135,7 @@ struct ContentListView: View {
             case .loading:
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityHidden(true)
             case let .loaded(contents: contents) where contents.isEmpty:
                 RefreshableMessageView(model: model, message: "No content.", icon: .empty)
             case let .loaded(contents: contents):

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -56,6 +56,7 @@ private struct LoadedView: View {
         Button(action: openPlaylist) {
             Image(systemName: "rectangle.stack.badge.play")
         }
+        .accessibilityLabel("Open as playlist")
         .opacity(medias().isEmpty ? 0 : 1)
     }
 }

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -69,6 +69,8 @@ struct ContentListsView: View {
                 Text(title)
             }
             .headerStyle()
+            .accessibilityElement()
+            .accessibilityLabel(title)
         }
     }
 

--- a/Demo/Sources/Metrics/MetricEventCell.swift
+++ b/Demo/Sources/Metrics/MetricEventCell.swift
@@ -52,6 +52,8 @@ struct MetricEventCell: View {
                 .lineLimit(3)
                 .multilineTextAlignment(.leading)
         }
+        .accessibilityElement()
+        .accessibilityLabel(description)
     }
 
     private static func duration(from time: CMTime) -> String? {

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -56,6 +56,8 @@ private struct InformationSectionContent: View {
                 .lineLimit(1)
                 .foregroundColor(.secondary)
         }
+        .accessibilityElement()
+        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 
@@ -115,6 +117,8 @@ private struct ExperienceStartupTimesSectionContent: View {
                 .lineLimit(1)
                 .foregroundColor(.secondary)
         }
+        .accessibilityElement()
+        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 
@@ -150,6 +154,8 @@ private struct ServiceStartupTimesSectionContent: View {
                 .lineLimit(1)
                 .foregroundColor(.secondary)
         }
+        .accessibilityElement()
+        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 
@@ -201,6 +207,7 @@ struct MetricsView: View {
             ExperienceStartupTimesSectionContent(metricEvents: metricsCollector.metricEvents)
         } header: {
             Text("Startup times (QoE)")
+                .accessibilityLabel("Startup times (Quality of experience)")
         }
     }
 
@@ -210,6 +217,7 @@ struct MetricsView: View {
             ServiceStartupTimesSectionContent(metricEvents: metricsCollector.metricEvents)
         } header: {
             Text("Startup times (QoS)")
+                .accessibilityLabel("Startup times (Quality of service)")
         }
     }
 

--- a/Demo/Sources/Players/BasicPlaybackView.swift
+++ b/Demo/Sources/Players/BasicPlaybackView.swift
@@ -41,6 +41,7 @@ struct BasicPlaybackView: View {
 #endif
             ProgressView()
                 .opacity(isBusy ? 1 : 0)
+                .accessibilityHidden(true)
         }
         .onReceive(player: player, assign: \.isBusy, to: $isBusy)
     }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -508,6 +508,7 @@ private struct LoadingIndicator: View {
             .tint(.white)
             .opacity(isBuffering ? 1 : 0)
             .animation(.linear(duration: 0.1), value: isBuffering)
+            .accessibilityHidden(true)
             .onReceive(player: player, assign: \.isBuffering, to: $isBuffering)
     }
 }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -559,6 +559,7 @@ private struct LiveButton: View {
                         .fontWeight(.ultraLight)
                         .font(.system(size: 20))
                 }
+                .accessibilityLabel("Jump to live")
             }
         }
         .onReceive(player: player, assign: \.streamType, to: $streamType)
@@ -797,7 +798,7 @@ private struct PlaybackMessageView: View {
 private struct PlaybackButton: View {
     @ObservedObject var player: Player
 
-    private var imageName: String? {
+    private var imageName: String {
         if player.canReplay() {
             return "arrow.counterclockwise.circle.fill"
         }
@@ -809,22 +810,30 @@ private struct PlaybackButton: View {
         }
     }
 
+    private var accessibilityLabel: String {
+        if player.canReplay() {
+            return "Restart"
+        }
+        else if player.shouldPlay {
+            return "Pause"
+        }
+        else {
+            return "Play"
+        }
+    }
+
     var body: some View {
         Button(action: play) {
-            if let imageName {
-                Image(systemName: imageName)
-                    .resizable()
-                    .tint(.white)
-            }
-            else {
-                Color.clear
-            }
+            Image(systemName: imageName)
+                .resizable()
+                .tint(.white)
         }
 #if os(iOS)
         .keyboardShortcut(.space, modifiers: [])
 #endif
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
+        .accessibilityLabel(accessibilityLabel)
     }
 
     private func play() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -108,12 +108,16 @@ private struct MainView: View {
     private func main() -> some View {
         ZStack {
             video()
+                .accessibilityElement()
+                .accessibilityLabel("Video")
+                .accessibilityHint("Double tap to toggle controls")
+                .accessibilityAction(.default, visibilityTracker.toggle)
+                .accessibilityHidden(shouldKeepControlsAlwaysVisible)
             controls()
         }
         .ignoresSafeArea()
         .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
         .readLayout(into: $layoutInfo)
-        .accessibilityAddTraits(.isButton)
         .gesture(toggleGesture(), including: toggleGestureMask)
         .gesture(magnificationGesture(), including: magnificationGestureMask)
         .simultaneousGesture(visibilityResetGesture())

--- a/Demo/Sources/Players/SimplePlayerView.swift
+++ b/Demo/Sources/Players/SimplePlayerView.swift
@@ -39,6 +39,7 @@ struct SimplePlayerView: View {
     private func progressView() -> some View {
         ProgressView()
             .opacity(isBusy ? 1 : 0)
+            .accessibilityHidden(true)
     }
 
     @ViewBuilder

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -19,6 +19,7 @@ struct SearchView: View {
                 MessageView(message: "Enter something to search.", icon: .system("magnifyingglass"))
             case .loading:
                 ProgressView()
+                    .accessibilityHidden(true)
             case let .loaded(medias: medias):
                 loadedView(medias)
             case let .failed(error):

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -60,6 +60,8 @@ private struct InfoCell: View {
                 .multilineTextAlignment(.trailing)
                 .lineLimit(2)
         }
+        .accessibilityElement()
+        .accessibilityLabel("\(title), \(value)")
     }
 }
 
@@ -306,6 +308,8 @@ struct SettingsView: View {
             Text(" in Switzerland")
         }
         .frame(maxWidth: .infinity)
+        .accessibilityElement()
+        .accessibilityLabel("Made with love in Switzerland")
     }
 
 #if os(iOS)

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -61,7 +61,7 @@ private struct InfoCell: View {
                 .lineLimit(2)
         }
         .accessibilityElement()
-        .accessibilityLabel("\(title), \(value)")
+        .accessibilityLabel("\(Text(title)), \(value)")
     }
 }
 

--- a/Demo/Sources/Showcase/BlurredView.swift
+++ b/Demo/Sources/Showcase/BlurredView.swift
@@ -24,6 +24,7 @@ struct BlurredView: View {
             ProgressView()
                 .opacity(isBusy ? 1 : 0)
         }
+        .accessibilityHidden(true)
         .background(.black)
         .overlay(alignment: .topLeading) {
             CloseButton(topBarStyle: true)

--- a/Demo/Sources/Showcase/LinkView.swift
+++ b/Demo/Sources/Showcase/LinkView.swift
@@ -21,6 +21,7 @@ struct LinkView: View {
                 BasicPlaybackView(player: isDisplayed ? player : Player())
                 ProgressView()
                     .opacity(isBusy ? 1 : 0)
+                    .accessibilityHidden(true)
             }
             Toggle("Content displayed", isOn: $isDisplayed)
                 .padding()

--- a/Demo/Sources/Showcase/Multi/SingleView.swift
+++ b/Demo/Sources/Showcase/Multi/SingleView.swift
@@ -21,6 +21,7 @@ struct SingleView: View {
             playbackButton(player: player)
             ProgressView()
                 .opacity(isBusy ? 1 : 0)
+                .accessibilityHidden(true)
         }
         .onReceive(player: player, assign: \.isBusy, to: $isBusy)
     }

--- a/Demo/Sources/Showcase/PiP/MultiPiPView.swift
+++ b/Demo/Sources/Showcase/PiP/MultiPiPView.swift
@@ -33,7 +33,7 @@ struct MultiPiPView: View {
     private func playbackView(player: Player, supportsPictureInPicture: Binding<Bool>) -> some View {
         VStack {
             playbackView(player: player, supportsPictureInPicture: supportsPictureInPicture.wrappedValue)
-            Toggle("Supports PiP", isOn: supportsPictureInPicture)
+            Toggle("Picture in Picture", isOn: supportsPictureInPicture)
                 .padding(.horizontal)
         }
     }

--- a/Demo/Sources/Showcase/PiP/TransitionPiPView.swift
+++ b/Demo/Sources/Showcase/PiP/TransitionPiPView.swift
@@ -18,7 +18,7 @@ private struct PresentedView: View {
         VStack {
             PlaybackView(player: player)
                 .supportsPictureInPicture(supportsPictureInPicture)
-            Toggle("Supports PiP", isOn: $supportsPictureInPicture)
+            Toggle("Picture in Picture", isOn: $supportsPictureInPicture)
                 .padding(.horizontal)
         }
     }
@@ -38,7 +38,7 @@ struct TransitionPiPView: View {
                 .supportsPictureInPicture(supportsPictureInPicture && !isPresented)
 
             VStack(spacing: 20) {
-                Toggle("Supports PiP", isOn: $supportsPictureInPicture)
+                Toggle("Picture in Picture", isOn: $supportsPictureInPicture)
                 Button(action: openModal) {
                     Text("Open modal")
                 }

--- a/Demo/Sources/Showcase/PiP/TwinsPiPView.swift
+++ b/Demo/Sources/Showcase/PiP/TwinsPiPView.swift
@@ -35,7 +35,7 @@ struct TwinsPiPView: View {
             PlaybackView(player: model.player)
                 .supportsPictureInPicture(supportsPictureInPicture.wrappedValue)
 
-            Toggle("Supports PiP", isOn: supportsPictureInPicture)
+            Toggle("Picture in Picture", isOn: supportsPictureInPicture)
                 .padding(.horizontal)
         }
     }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -19,6 +19,8 @@ private struct MediaCell: View {
                     .foregroundColor(.secondary)
             }
         }
+        .accessibilityElement()
+        .accessibilityLabel(media.title)
     }
 }
 
@@ -35,6 +37,17 @@ private struct Toolbar: View {
             "repeat.1.circle.fill"
         case .all:
             "repeat.circle.fill"
+        }
+    }
+
+    private var repeatModeAccessibilityLabel: String {
+        switch player.repeatMode {
+        case .off:
+            "Repeat none"
+        case .one:
+            "Repeat current"
+        case .all:
+            "Repeat all"
         }
     }
 
@@ -63,6 +76,7 @@ private struct Toolbar: View {
         Button(action: player.returnToPrevious) {
             Image(systemName: "arrow.left")
         }
+        .accessibilityLabel("Previous")
         .disabled(!player.canReturnToPrevious())
     }
 
@@ -72,19 +86,23 @@ private struct Toolbar: View {
             Button(action: toggleRepeatMode) {
                 Image(systemName: repeatModeImageName)
             }
+            .accessibilityLabel(repeatModeAccessibilityLabel)
 
             Button(action: model.shuffle) {
                 Image(systemName: "shuffle")
             }
+            .accessibilityLabel("Shuffle")
             .disabled(model.isEmpty)
 
             Button(action: add) {
                 Image(systemName: "plus")
             }
+            .accessibilityLabel("Add")
 
             Button(action: model.trash) {
                 Image(systemName: "trash")
             }
+            .accessibilityLabel("Delete all")
             .disabled(model.isEmpty)
         }
     }
@@ -94,6 +112,7 @@ private struct Toolbar: View {
         Button(action: player.advanceToNext) {
             Image(systemName: "arrow.right")
         }
+        .accessibilityLabel("Next")
         .disabled(!player.canAdvanceToNext())
     }
 

--- a/Demo/Sources/Showcase/Stories/StoriesView.swift
+++ b/Demo/Sources/Showcase/Stories/StoriesView.swift
@@ -24,6 +24,8 @@ private struct StoryView: View {
         }
         .tint(.white)
         .animation(.defaultLinear, value: isBusy)
+        .accessibilityElement()
+        .accessibilityLabel("Video")
         .onReceive(player: player, assign: \.isBusy, to: $isBusy)
     }
 }

--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -30,8 +30,13 @@ struct TransitionView: View {
 
     var body: some View {
         VideoView(player: player)
-            .accessibilityAddTraits(.isButton)
             .onTapGesture {
+                isPresented.toggle()
+            }
+            .accessibilityElement()
+            .accessibilityLabel("Open full-screen player")
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction(.default) {
                 isPresented.toggle()
             }
             .onAppear(perform: play)

--- a/Demo/Sources/Views/Cell.swift
+++ b/Demo/Sources/Views/Cell.swift
@@ -32,8 +32,9 @@ struct Cell: View {
                         .foregroundColor(.secondary)
                 }
             }
-
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement()
+            .accessibilityLabel(title ?? "")
 #else
             MediaCardView(
                 size: size,

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -18,6 +18,7 @@ struct CloseButton: View {
                 .topBarStyle(topBarStyle)
         }
         .shadow(color: .black, radius: 1)
+        .accessibilityLabel("Close")
 #if os(iOS)
         .keyboardShortcut(.escape, modifiers: [])
 #endif

--- a/Demo/Sources/Views/Modal.swift
+++ b/Demo/Sources/Views/Modal.swift
@@ -36,6 +36,9 @@ private struct PresentedModifier: ViewModifier {
                         dismiss()
                     }
             )
+            .accessibilityAction(.escape) {
+                dismiss()
+            }
     }
 }
 

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -9,11 +9,10 @@ import Foundation
 
 final class DataProvider {
     private let server: Server
-    private let session: URLSession
+    private let session = URLSession(configuration: .default)
 
     init(server: Server = .production) {
         self.server = server
-        session = URLSession(configuration: .default)
     }
 
     static func decoder() -> JSONDecoder {


### PR DESCRIPTION
## Description

This PR makes various improvements to VoiceOver support in the demo.

## Changes made

- Improve custom player accessibility.
- Improve specific player accessibility.
- Implement Z-escape gesture for modals.
- Make metrics debugging view accessible.
- Make all lists accessible.
- Make settings accessible.

It is likely that all accessibility strings can be properly localized but this should be a pretty good start already. The tvOS implementation might not be perfect as well but could likely be enhanced in a second PR.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
