### PR TITLE
Add method to respond to state changes at the user interface level

### DIFF
--- a/Sources/Core/View.swift
+++ b/Sources/Core/View.swift
@@ -14,16 +14,30 @@ public extension View {
     ///   - publisher: The publisher to subscribe to.
     ///   - keyPath: The key path to extract.
     ///   - binding: The binding to which values must be assigned.
-    /// - Returns: A view that fills the given binding when the `publisher` emits an event.
     func onReceive<P, T>(
         _ publisher: P,
         assign keyPath: KeyPath<P.Output, T>,
         to binding: Binding<T>
     ) -> some View where P: Publisher, P.Failure == Never, T: Equatable {
-            onReceive(publisher.slice(at: keyPath).receiveOnMainThread()) { output in
-                if binding.wrappedValue != output {
-                    binding.wrappedValue = output
-                }
+        onReceive(publisher.slice(at: keyPath).receiveOnMainThread()) { output in
+            if binding.wrappedValue != output {
+                binding.wrappedValue = output
             }
+        }
+    }
+
+    /// Observes values emitted by the given publisher at the specified key path.
+    ///
+    /// - Parameters:
+    ///   - publisher: The publisher to subscribe to.
+    ///   - keyPath: The key path to extract.
+    ///   - action: A closure to run when the value changes, executed on the main thread. The action is not called for
+    ///     the first value that the publisher might provide upon subscription.
+    func onReceive<P, T>(
+        _ publisher: P,
+        at keyPath: KeyPath<P.Output, T>,
+        perform action: @escaping (T) -> Void
+    ) -> some View where P: Publisher, P.Failure == Never, T: Equatable {
+        onReceive(publisher.slice(at: keyPath).dropFirst().receiveOnMainThread(), perform: action)
     }
 }

--- a/Sources/Player/Player.docc/Articles/state-observation/state-observation-article.md
+++ b/Sources/Player/Player.docc/Articles/state-observation/state-observation-article.md
@@ -47,7 +47,7 @@ For this reason ``Player`` does not publish time updates automatically. Explicit
 - Use ``Player/periodicTimePublisher(forInterval:queue:)`` for periodic time updates.
 - Use ``Player/boundaryTimePublisher(for:queue:)`` to detect time traversal.
 
-When implementing a user interface, you should rather use ``ProgressTracker`` to observe progress changes without the need for explicit time update subscription.
+When implementing a user interface you should rather use ``ProgressTracker`` to observe progress changes without the need for explicit time update subscription.
 
 ### Explicitly subscribe to frequent updates
 
@@ -75,6 +75,28 @@ struct PlaybackView: View {
 ```
 
 Check ``PlayerProperties`` for the list of all properties that are available for explicit observation.
+
+### Respond to state updates
+
+You can respond to state updates at the view level using the ``SwiftUICore/View/onReceive(player:at:perform:)`` modifier. This can be useful to trigger actions when some specific state is reached, for example when ending playback of an item:
+
+```swift
+struct PlaybackView: View {
+    @StateObject private var player = Player(
+        item: .simple(url: URL(string: "https://www.server.com/master.m3u8")!)
+    )
+
+    var body: some View {
+        ZStack {
+            VideoView(player: player)
+        }
+        .onReceive(player: player, at: \.playbackState) { playbackState in
+            guard playbackState == .ended else { return }
+            // ...
+        }
+    }
+}
+```
 
 ### Use SwiftUI property wrappers wisely
 

--- a/Sources/Player/UserInterface/View.swift
+++ b/Sources/Player/UserInterface/View.swift
@@ -13,8 +13,6 @@ public extension View {
     ///   - player: The player.
     ///   - keyPath: The key path to extract.
     ///   - binding: The binding to which the value must be assigned.
-    /// - Returns: A view that fills the given binding when the player's publisher emits an
-    ///   event.
     ///
     /// > Warning: Be careful to associate often updated state to local view scopes to avoid unnecessary view body refreshes. Please
     /// refer to <doc:state-observation-article> for more information.
@@ -28,6 +26,24 @@ public extension View {
         }
     }
 
+    /// Observes values emitted by the given player's publisher.
+    ///
+    /// - Parameters:
+    ///   - player: The player.
+    ///   - keyPath: The key path to extract.
+    ///   - action: A closure to run when the value changes.
+    @ViewBuilder
+    func onReceive<T>(player: Player?, at keyPath: KeyPath<PlayerProperties, T>, perform action: @escaping (T) -> Void) -> some View where T: Equatable {
+        if let player {
+            onReceive(player.propertiesPublisher, at: keyPath, perform: action)
+        }
+        else {
+            self
+        }
+    }
+}
+
+public extension View {
     /// Enable in-app Picture in Picture support.
     ///
     /// - Parameter persistable: The object to persist during Picture in Picture.


### PR DESCRIPTION
## Description

This PR adds a `View.onReceive(player:at:perform:)` modifier that makes it possible to respond to player state changes at the user interface level, triggering transient states (e.g. an animation).

It is tempting to use `onChange` or built-in `onReceive` modifiers in such cases but those do not work (or require to be careful) for reasons explained in the associated issue. For this reason a more explicit modifier might make sense.

## Changes made

- Add `View.onReceive(player:at:perform:)` modifier.
- Update state observation article.
- Make some existing modifier documentation less verbose.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
