### PR TITLE
Add hover support

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -352,6 +352,7 @@ private struct SkipBackwardButton: View {
         .opacity(player.canSkipBackward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipBackward())
         .keyboardShortcut("s", modifiers: [])
+        .circularHoverEffect()
     }
 
     private func skipBackward() {
@@ -375,6 +376,7 @@ private struct SkipForwardButton: View {
         .opacity(player.canSkipForward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipForward())
         .keyboardShortcut("d", modifiers: [])
+        .circularHoverEffect()
     }
 
     private func skipForward() {
@@ -394,6 +396,7 @@ private struct FullScreenButton: View {
                     .font(.system(size: 20))
             }
             .keyboardShortcut("f", modifiers: [])
+            .hoverEffect()
         }
     }
 
@@ -431,6 +434,7 @@ private struct VolumeButton: View {
                 .font(.system(size: 20))
         }
         .keyboardShortcut("m", modifiers: [])
+        .hoverEffect()
     }
 
     private var imageName: String {
@@ -457,6 +461,7 @@ private struct SettingsMenu: View {
                 .tint(.white)
         }
         .menuOrder(.fixed)
+        .hoverEffect()
     }
 
     @ViewBuilder
@@ -560,6 +565,7 @@ private struct LiveButton: View {
                         .fontWeight(.ultraLight)
                         .font(.system(size: 20))
                 }
+                .hoverEffect()
                 .accessibilityLabel("Jump to live")
             }
         }
@@ -829,12 +835,13 @@ private struct PlaybackButton: View {
                 .resizable()
                 .tint(.white)
         }
-#if os(iOS)
-        .keyboardShortcut(.space, modifiers: [])
-#endif
         .aspectRatio(contentMode: .fit)
         .frame(minWidth: 120, maxHeight: 90)
         .accessibilityLabel(accessibilityLabel)
+#if os(iOS)
+        .keyboardShortcut(.space, modifiers: [])
+        .circularHoverEffect()
+#endif
     }
 
     private func play() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -51,6 +51,14 @@ private struct MainView: View {
             MetricsView(metricsCollector: metricsCollector)
         }
         .statusBarHidden(isFullScreen ? isUserInterfaceHidden : false)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                visibilityTracker.reset()
+            case .ended:
+                break
+            }
+        }
         .bind(visibilityTracker, to: player)
         .bind(metricsCollector, to: player)
     }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -76,6 +76,7 @@ private struct Toolbar: View {
         Button(action: player.returnToPrevious) {
             Image(systemName: "arrow.left")
         }
+        .hoverEffect()
         .accessibilityLabel("Previous")
         .disabled(!player.canReturnToPrevious())
     }
@@ -86,22 +87,26 @@ private struct Toolbar: View {
             Button(action: toggleRepeatMode) {
                 Image(systemName: repeatModeImageName)
             }
+            .hoverEffect()
             .accessibilityLabel(repeatModeAccessibilityLabel)
 
             Button(action: model.shuffle) {
                 Image(systemName: "shuffle")
             }
+            .hoverEffect()
             .accessibilityLabel("Shuffle")
             .disabled(model.isEmpty)
 
             Button(action: add) {
                 Image(systemName: "plus")
             }
+            .hoverEffect()
             .accessibilityLabel("Add")
 
             Button(action: model.trash) {
                 Image(systemName: "trash")
             }
+            .hoverEffect()
             .accessibilityLabel("Delete all")
             .disabled(model.isEmpty)
         }
@@ -112,6 +117,7 @@ private struct Toolbar: View {
         Button(action: player.advanceToNext) {
             Image(systemName: "arrow.right")
         }
+        .hoverEffect()
         .accessibilityLabel("Next")
         .disabled(!player.canAdvanceToNext())
     }

--- a/Demo/Sources/Views/CloseButton.swift
+++ b/Demo/Sources/Views/CloseButton.swift
@@ -22,6 +22,7 @@ struct CloseButton: View {
 #if os(iOS)
         .keyboardShortcut(.escape, modifiers: [])
 #endif
+        .hoverEffect()
     }
 
     init(topBarStyle: Bool = false) {

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -116,3 +116,13 @@ extension View {
         }
     }
 }
+
+#if os(iOS)
+extension View {
+    func circularHoverEffect() -> some View {
+        padding()
+            .hoverEffect(.highlight)
+            .clipShape(Circle())
+    }
+}
+#endif

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -25,6 +25,7 @@ public struct PictureInPictureButton<Content>: View where Content: View {
                 Button(action: PictureInPicture.shared.custom.toggle) {
                     content(isActive)
                 }
+                .hoverEffect()
                 .onReceive(PictureInPicture.shared.custom.$isActive) { isActive = $0 }
             }
         }


### PR DESCRIPTION
## Description

This PR adds [hover support](https://developer.apple.com/videos/play/wwdc2020/10093/) to the most important demo players (custom player and playlist demo). This is useful when pairing a device via Continuity (and can be tested without a device by capturing the pointer in the iPadOS simulator).

## Changes made

- Add hover support to custom player layout (hover effect to buttons and UI visibility management while hovering).
- Add hover support to playlist demo.

Note that the `defaultHoverEffect(_:)` API was not used since it requires iPadOS 17.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
