### PR TITLE
Fix layout glitches during rotation

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -360,7 +360,7 @@ private struct SkipBackwardButton: View {
         .opacity(player.canSkipBackward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipBackward())
         .keyboardShortcut("s", modifiers: [])
-        .circularHoverEffect()
+        .hoverEffect()
     }
 
     private func skipBackward() {
@@ -384,7 +384,7 @@ private struct SkipForwardButton: View {
         .opacity(player.canSkipForward() ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipForward())
         .keyboardShortcut("d", modifiers: [])
-        .circularHoverEffect()
+        .hoverEffect()
     }
 
     private func skipForward() {
@@ -848,7 +848,7 @@ private struct PlaybackButton: View {
         .accessibilityLabel(accessibilityLabel)
 #if os(iOS)
         .keyboardShortcut(.space, modifiers: [])
-        .circularHoverEffect()
+        .hoverEffect()
 #endif
     }
 

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -116,13 +116,3 @@ extension View {
         }
     }
 }
-
-#if os(iOS)
-extension View {
-    func circularHoverEffect() -> some View {
-        padding()
-            .hoverEffect(.highlight)
-            .clipShape(Circle())
-    }
-}
-#endif


### PR DESCRIPTION
## Description

This PR fixes layout glitches visible during rotation of our custom player, with skip buttons moving in and out in a non-natural way:

https://github.com/user-attachments/assets/0eb7beb8-252c-47b9-9542-8d18f6e0c948

## Implementation considerations

This issue was introduced with addition of hover support (#1073). To have a look & feel similar to the system UI custom player playback and skip buttons were clipped to a circle and padded a bit.

Sadly this introduces two issues:

- The aforementioned animation glitches.
- A button size reduction on some compact layouts (e.g. narrow split view on iPad).

To solve animation issues we can wrap the button hierarchy into a `geometryGroup()`, but this API is only available since iOS 17. Alternatives on iOS 16, like those mentioned in this [article](https://fatbobman.com/en/posts/mastring-geometrygroup/), do not work in our case.

If we remove the padding, the clipped buttons also look ugly.

For these reasons I simply propose not to perform circular clipping at all. The pointer frame will turn into the exact button frame when hovering, which is acceptable and does not require padding. Having a layout that works is better IMHO, and maybe we can do better in the future.

## Changes made

- Remove circular view clipping.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
