### PR TITLE
Avoid running the release workflow when it is not appropriate

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 ---
 name: Pull Request
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   merge_group:
   pull_request:
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,7 +3,6 @@ name: Releases
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: main
     tags: '*'
 
 jobs:


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- Push on `main` branch does not trigger the **release** workflow.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
