### PR TITLE
Fix Pillarbox version in the demo app

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Add Apple certificate
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,6 +30,7 @@ jobs:
     name: 🧪 Tests
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [ios, tvos]
     steps:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Add Apple certificate
         run: |


### PR DESCRIPTION
## Description

This PR allows us to fix a version in our demo app. Indeed, the **Pillarbox** version is retrieved using `git describe`. However, `actions/checkout@v4` uses a shallow clone with a depth of one commit, this prevents tags to being retrieved.

## Changes made

- **Releases** and **Nightlies** workflows uses a deep clone to retrieve all tags.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
