### PR TITLE
Prevent item creation from non-official service endpoints

### DIFF
--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -32,7 +32,7 @@ public struct Server {
     public init(baseUrl: URL, queryItems: [URLQueryItem] = []) {
         // FIXME: This initializer must be made private after SAM replaces the IL. The assertion must be removed at
         //        the same time.
-        assert(Bundle.main.bundleIdentifier!.hasPrefix("ch.srgssr.Pillarbox-demo"), "This API will be removed in a future Pillarbox release. Do not use.")
+        assert(Bundle.main.allowsReservedInitializer, "This API will be removed in a future Pillarbox release. Do not use.")
         self.baseUrl = baseUrl
         self.queryItems = queryItems
     }
@@ -67,5 +67,12 @@ public struct Server {
         else {
             return url
         }
+    }
+}
+
+private extension Bundle {
+    var allowsReservedInitializer: Bool {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return false }
+        return bundleIdentifier.hasPrefix("ch.srgssr.Pillarbox-demo") || bundleIdentifier.hasPrefix("com.apple.dt.xctest.tool")
     }
 }

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -26,15 +26,13 @@ public struct Server {
     private let baseUrl: URL
     private let queryItems: [URLQueryItem]
 
-    /// Creates a server with custom settings.
+    /// This API will be removed in a future Pillarbox release. Do not use.
     ///
-    /// - Parameters:
-    ///   - baseUrl: The base URL of the server.
-    ///   - queryItems: Additional query items to associate with each request.
-    ///
-    /// Useful for servers which can exactly pose as SRG SSR servers and deliver the same playback metadata format and
-    /// image scaling capabilities.
+    /// > Warning: This API will be removed in a future Pillarbox release. Do not use.
     public init(baseUrl: URL, queryItems: [URLQueryItem] = []) {
+        // FIXME: This initializer must be made private after SAM replaces the IL. The assertion must be removed at
+        //        the same time.
+        assert(Bundle.main.bundleIdentifier!.hasPrefix("ch.srgssr.Pillarbox-demo"), "This API will be removed in a future Pillarbox release. Do not use.")
         self.baseUrl = baseUrl
         self.queryItems = queryItems
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,9 +25,8 @@ DEVICES = {
 
 ICON_GLOBS = {
   ios: '/Demo/Resources/Assets.xcassets/AppIcon.appiconset/*.png',
-  tvos: \
-    '/Demo/Resources/Assets.xcassets/App Icon & Top Shelf Image.brandassets/*/Back.imagestacklayer' \
-    '/Content.imageset/*.png'
+  tvos: '/Demo/Resources/Assets.xcassets/App Icon & Top Shelf Image.brandassets/*/Back.imagestacklayer' \
+        '/Content.imageset/*.png'
 }.freeze
 
 SHIELD_SCALES = {


### PR DESCRIPTION
## Description

This PR prevents item creation from non-official SRG SSR service endpoints.

## Changes made

- Add assertion preventing creation of custom `Server`s outside our demo.
- Document the (still public) `Server` initializer as not available.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
