### PR TITLE
Document limit restrictions when casting to AirPlay receivers

### DIFF
--- a/Sources/Player/Types/PlayerLimits.swift
+++ b/Sources/Player/Types/PlayerLimits.swift
@@ -32,6 +32,8 @@ public struct PlayerLimits {
     /// [expensive networks](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/3235752-allowsexpensivenetworkaccess).
     ///
     /// Disabled when set to `.zero`.
+    ///
+    /// > Note: Limits are ignored when casting to an AirPlay receiver.
     public let preferredMaximumResolutionForExpensiveNetworks: CGSize
 
     /// Creates a set of limits.


### PR DESCRIPTION
## Description

This PR documents the fact that limits are not applied when casting to AirPlay receivers.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
