### PR TITLE
Increase job timeouts to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     name: 🧪 Tests
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -9,7 +9,7 @@ jobs:
   deliver-demo-nightlies:
     name: 🌙 Nightlies
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         platform: [ios, tvos]

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -9,7 +9,7 @@ jobs:
   deliver-demo-releases:
     name: 🚀 Releases
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         platform: [ios, tvos]


### PR DESCRIPTION
## Description

We recently had a CI job which succeeded in 20 minutes but was killed during the cleanup phase. To avoid such issues while ensuring long-running jobs are still properly killed the timeout has been increased to 30 minutes.

In general the longest jobs should need less than 15 minutes.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
