### PR TITLE
Add system video view overlay support

### DIFF
--- a/Sources/Player/Extensions/AVPlayerViewController.swift
+++ b/Sources/Player/Extensions/AVPlayerViewController.swift
@@ -35,29 +35,25 @@ extension AVPlayerViewController {
         return duplicate
     }
 
-    func addVideoOverlay<VideoOverlay>(_ videoOverlay: VideoOverlay) where VideoOverlay: View {
-        removeOverlayViewControllers()
+    func setVideoOverlay<VideoOverlay>(_ videoOverlay: VideoOverlay) where VideoOverlay: View {
+        if let hostController = children.compactMap({ $0 as? UIHostingController<VideoOverlay> }).first {
+            hostController.rootView = videoOverlay
+        }
+        else if let contentOverlayView {
+            let hostController = UIHostingController(rootView: videoOverlay)
+            if let hostView = hostController.view {
+                addChild(hostController)
+                contentOverlayView.addSubview(hostView)
+                hostController.didMove(toParent: self)
 
-        let overlayViewController = UIHostingController(rootView: videoOverlay)
-        guard let contentOverlayView, let overlayView = overlayViewController.view else { return }
-        addChild(overlayViewController)
-        contentOverlayView.addSubview(overlayView)
-        overlayViewController.didMove(toParent: self)
-
-        overlayView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            overlayView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
-            overlayView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
-            overlayView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
-            overlayView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor)
-        ])
-    }
-
-    private func removeOverlayViewControllers() {
-        children.forEach { viewController in
-            viewController.willMove(toParent: nil)
-            viewController.view.removeFromSuperview()
-            viewController.removeFromParent()
+                hostView.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    hostView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
+                    hostView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
+                    hostView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
+                    hostView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor)
+                ])
+            }
         }
     }
 }

--- a/Sources/Player/Extensions/AVPlayerViewController.swift
+++ b/Sources/Player/Extensions/AVPlayerViewController.swift
@@ -36,24 +36,24 @@ extension AVPlayerViewController {
     }
 
     func setVideoOverlay<VideoOverlay>(_ videoOverlay: VideoOverlay) where VideoOverlay: View {
+        guard let contentOverlayView else { return }
         if let hostController = children.compactMap({ $0 as? UIHostingController<VideoOverlay> }).first {
             hostController.rootView = videoOverlay
         }
-        else if let contentOverlayView {
+        else {
             let hostController = UIHostingController(rootView: videoOverlay)
-            if let hostView = hostController.view {
-                addChild(hostController)
-                contentOverlayView.addSubview(hostView)
-                hostController.didMove(toParent: self)
+            guard let hostView = hostController.view else { return }
+            addChild(hostController)
+            contentOverlayView.addSubview(hostView)
+            hostController.didMove(toParent: self)
 
-                hostView.translatesAutoresizingMaskIntoConstraints = false
-                NSLayoutConstraint.activate([
-                    hostView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
-                    hostView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
-                    hostView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
-                    hostView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor)
-                ])
-            }
+            hostView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                hostView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
+                hostView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
+                hostView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
+                hostView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor)
+            ])
         }
     }
 }

--- a/Sources/Player/Extensions/AVPlayerViewController.swift
+++ b/Sources/Player/Extensions/AVPlayerViewController.swift
@@ -33,4 +33,28 @@ extension AVPlayerViewController {
 #endif
         return duplicate
     }
+
+    func addOverlayViewController(_ overlayViewController: UIViewController) {
+        removeOverlayViewControllers()
+        guard let contentOverlayView, let overlayView = overlayViewController.view else { return }
+        addChild(overlayViewController)
+        contentOverlayView.addSubview(overlayView)
+        overlayViewController.didMove(toParent: self)
+
+        overlayView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            overlayView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor),
+            overlayView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor),
+            overlayView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor),
+            overlayView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor)
+        ])
+    }
+
+    private func removeOverlayViewControllers() {
+        children.forEach { viewController in
+            viewController.willMove(toParent: nil)
+            viewController.view.removeFromSuperview()
+            viewController.removeFromParent()
+        }
+    }
 }

--- a/Sources/Player/Extensions/AVPlayerViewController.swift
+++ b/Sources/Player/Extensions/AVPlayerViewController.swift
@@ -5,6 +5,7 @@
 //
 
 import AVKit
+import SwiftUI
 
 extension AVPlayerViewController {
     func stopPictureInPicture() {
@@ -34,8 +35,10 @@ extension AVPlayerViewController {
         return duplicate
     }
 
-    func addOverlayViewController(_ overlayViewController: UIViewController) {
+    func addVideoOverlay<VideoOverlay>(_ videoOverlay: VideoOverlay) where VideoOverlay: View {
         removeOverlayViewControllers()
+
+        let overlayViewController = UIHostingController(rootView: videoOverlay)
         guard let contentOverlayView, let overlayView = overlayViewController.view else { return }
         addChild(overlayViewController)
         contentOverlayView.addSubview(overlayView)

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -7,11 +7,11 @@
 import AVKit
 import SwiftUI
 
-struct BasicSystemVideoView: UIViewControllerRepresentable {
+struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where VideoOverlay: View {
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
-    let overlayViewController: UIViewController
+    let videoOverlay: VideoOverlay
 
 #if os(tvOS)
     func makeCoordinator() -> AVPlayerViewControllerSpeedCoordinator {
@@ -31,7 +31,7 @@ struct BasicSystemVideoView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
         uiViewController.player = player.systemPlayer
         uiViewController.videoGravity = gravity
-        uiViewController.addOverlayViewController(overlayViewController)
+        uiViewController.addVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -31,7 +31,7 @@ struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where V
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
         uiViewController.player = player.systemPlayer
         uiViewController.videoGravity = gravity
-        uiViewController.addVideoOverlay(videoOverlay)
+        uiViewController.setVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -11,6 +11,7 @@ struct BasicSystemVideoView: UIViewControllerRepresentable {
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
+    let overlayViewController: UIViewController
 
 #if os(tvOS)
     func makeCoordinator() -> AVPlayerViewControllerSpeedCoordinator {
@@ -30,6 +31,7 @@ struct BasicSystemVideoView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
         uiViewController.player = player.systemPlayer
         uiViewController.videoGravity = gravity
+        uiViewController.addOverlayViewController(overlayViewController)
 #if os(tvOS)
         uiViewController.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -37,7 +37,7 @@ struct PictureInPictureSupportingSystemVideoView<VideoOvelay>: UIViewControllerR
     func updateUIViewController(_ uiViewController: PictureInPictureHostViewController, context: Context) {
         uiViewController.viewController?.player = player.systemPlayer
         uiViewController.viewController?.videoGravity = gravity
-        uiViewController.viewController?.addVideoOverlay(videoOverlay)
+        uiViewController.viewController?.setVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.viewController?.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -8,7 +8,7 @@ import AVKit
 import SwiftUI
 
 // swiftlint:disable:next type_name
-struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable {
+struct PictureInPictureSupportingSystemVideoView<VideoOvelay>: UIViewControllerRepresentable where VideoOvelay: View {
 #if os(tvOS)
     typealias Coordinator = AVPlayerViewControllerSpeedCoordinator
 #else
@@ -18,7 +18,7 @@ struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable 
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
-    let overlayViewController: UIViewController
+    let videoOverlay: VideoOvelay
 
     static func dismantleUIViewController(_ uiViewController: PictureInPictureHostViewController, coordinator: Coordinator) {
         PictureInPicture.shared.system.dismantleHostViewController(uiViewController)
@@ -37,7 +37,7 @@ struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable 
     func updateUIViewController(_ uiViewController: PictureInPictureHostViewController, context: Context) {
         uiViewController.viewController?.player = player.systemPlayer
         uiViewController.viewController?.videoGravity = gravity
-        uiViewController.viewController?.addOverlayViewController(overlayViewController)
+        uiViewController.viewController?.addVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.viewController?.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -18,6 +18,7 @@ struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable 
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
+    let overlayViewController: UIViewController
 
     static func dismantleUIViewController(_ uiViewController: PictureInPictureHostViewController, coordinator: Coordinator) {
         PictureInPicture.shared.system.dismantleHostViewController(uiViewController)
@@ -36,6 +37,7 @@ struct PictureInPictureSupportingSystemVideoView: UIViewControllerRepresentable 
     func updateUIViewController(_ uiViewController: PictureInPictureHostViewController, context: Context) {
         uiViewController.viewController?.player = player.systemPlayer
         uiViewController.viewController?.videoGravity = gravity
+        uiViewController.viewController?.addOverlayViewController(overlayViewController)
 #if os(tvOS)
         uiViewController.viewController?.contextualActions = contextualActions
         context.coordinator.player = player

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -23,7 +23,7 @@ public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
                     player: player,
                     gravity: gravity,
                     contextualActions: contextualActions,
-                    overlayViewController: UIHostingController(rootView: videoOverlay)
+                    videoOverlay: videoOverlay
                 )
             }
             else {
@@ -31,7 +31,7 @@ public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
                     player: player,
                     gravity: gravity,
                     contextualActions: contextualActions,
-                    overlayViewController: UIHostingController(rootView: videoOverlay)
+                    videoOverlay: videoOverlay
                 )
             }
         }

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -19,10 +19,20 @@ public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
     public var body: some View {
         ZStack {
             if supportsPictureInPicture {
-                PictureInPictureSupportingSystemVideoView(player: player, gravity: gravity, contextualActions: contextualActions)
+                PictureInPictureSupportingSystemVideoView(
+                    player: player,
+                    gravity: gravity,
+                    contextualActions: contextualActions,
+                    overlayViewController: UIHostingController(rootView: videoOverlay)
+                )
             }
             else {
-                BasicSystemVideoView(player: player, gravity: gravity, contextualActions: contextualActions)
+                BasicSystemVideoView(
+                    player: player,
+                    gravity: gravity,
+                    contextualActions: contextualActions,
+                    overlayViewController: UIHostingController(rootView: videoOverlay)
+                )
             }
         }
         .onAppear {

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -8,8 +8,9 @@ import AVFoundation
 import SwiftUI
 
 /// A view providing the standard system playback user experience.
-public struct SystemVideoView: View {
+public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
     private let player: Player
+    private let videoOverlay: VideoOverlay
 
     private var gravity: AVLayerVideoGravity = .resizeAspect
     private var supportsPictureInPicture = false
@@ -35,9 +36,25 @@ public struct SystemVideoView: View {
 
     /// Creates a view displaying video content.
     ///
-    /// - Parameter player: The player whose content is displayed.
-    public init(player: Player) {
+    /// - Parameters:
+    ///    - player: The player whose content is displayed.
+    ///    - videoOverlay: A closure returning an overlay view to be placed atop the player's content. This view is
+    ///      fully interactive, but is placed below the system-provided playback controls and will only receive unhandled
+    ///      events.
+    public init(player: Player, @ViewBuilder videoOverlay: () -> VideoOverlay) {
         self.player = player
+        self.videoOverlay = videoOverlay()
+    }
+}
+
+public extension SystemVideoView where VideoOverlay == EmptyView {
+    /// Creates a view displaying video content.
+    ///
+    /// - Parameter player: The player whose content is displayed.
+    init(player: Player) {
+        self.init(player: player) {
+            EmptyView()
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds overlay support to `SystemVideoView` with an API identical to `VideoPlayer`. This can be useful to customize the system video view when playing audio content, e.g. by displaying an associated image.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
