### PR TITLE
Fix system video view overlay issues

### DIFF
--- a/Sources/Player/Extensions/AVPlayerViewController.swift
+++ b/Sources/Player/Extensions/AVPlayerViewController.swift
@@ -43,6 +43,7 @@ extension AVPlayerViewController {
         else {
             let hostController = UIHostingController(rootView: videoOverlay)
             guard let hostView = hostController.view else { return }
+            hostView.backgroundColor = .clear
             addChild(hostController)
             contentOverlayView.addSubview(hostView)
             hostController.didMove(toParent: self)

--- a/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
@@ -60,9 +60,9 @@ final class SystemPictureInPicture: NSObject {
 
     func dismantleHostViewController(_ hostViewController: PictureInPictureHostViewController) {
         hostViewControllers.remove(hostViewController)
-        if !isActive && playerViewController == hostViewController.viewController {
+        if !isActive && playerViewController == hostViewController.playerViewController {
             if let lastHostView = hostViewControllers.last {
-                playerViewController = lastHostView.viewController
+                playerViewController = lastHostView.playerViewController
             }
             else {
                 playerViewController = nil
@@ -130,8 +130,8 @@ extension SystemPictureInPicture: AVPlayerViewControllerDelegate {
         }
         // Wire the PiP controller to a valid source if the restored state is not bound to the player involved in
         // the restoration.
-        else if !hostViewControllers.map(\.viewController).contains(self.playerViewController) {
-            self.playerViewController = hostViewControllers.last?.viewController
+        else if !hostViewControllers.map(\.playerViewController).contains(self.playerViewController) {
+            self.playerViewController = hostViewControllers.last?.playerViewController
         }
     }
 }

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -13,11 +13,9 @@ struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where V
     let contextualActions: [UIAction]
     let videoOverlay: VideoOverlay
 
-#if os(tvOS)
-    func makeCoordinator() -> AVPlayerViewControllerSpeedCoordinator {
+    func makeCoordinator() -> SystemVideoViewCoordinator {
         .init()
     }
-#endif
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let controller = AVPlayerViewController()
@@ -25,6 +23,7 @@ struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where V
 #if os(iOS)
         controller.updatesNowPlayingInfoCenter = false
 #endif
+        context.coordinator.controller = controller
         return controller
     }
 
@@ -34,8 +33,7 @@ struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where V
         uiViewController.setVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.contextualActions = contextualActions
-        context.coordinator.player = player
-        context.coordinator.controller = uiViewController
 #endif
+        context.coordinator.player = player
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureHostViewController.swift
+++ b/Sources/Player/UserInterface/PictureInPictureHostViewController.swift
@@ -8,22 +8,22 @@ import AVKit
 import UIKit
 
 final class PictureInPictureHostViewController: UIViewController {
-    weak var viewController: AVPlayerViewController?
+    weak var playerViewController: AVPlayerViewController?
 
-    func addViewController(_ viewController: AVPlayerViewController) {
-        addChild(viewController)
-        view.addSubview(viewController.view)
+    func addViewController(_ playerViewController: AVPlayerViewController) {
+        addChild(playerViewController)
+        view.addSubview(playerViewController.view)
 
-        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            viewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            viewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            viewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            viewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            playerViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            playerViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            playerViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            playerViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
-        viewController.didMove(toParent: self)
-        self.viewController = viewController
+        playerViewController.didMove(toParent: self)
+        self.playerViewController = playerViewController
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -24,16 +24,16 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
 
     func makeUIViewController(context: Context) -> PictureInPictureHostViewController {
         let controller = PictureInPicture.shared.system.makeHostViewController(for: player)
-        context.coordinator.controller = controller.viewController
+        context.coordinator.controller = controller.playerViewController
         return controller
     }
 
     func updateUIViewController(_ uiViewController: PictureInPictureHostViewController, context: Context) {
-        uiViewController.viewController?.player = player.systemPlayer
-        uiViewController.viewController?.videoGravity = gravity
-        uiViewController.viewController?.setVideoOverlay(videoOverlay)
+        uiViewController.playerViewController?.player = player.systemPlayer
+        uiViewController.playerViewController?.videoGravity = gravity
+        uiViewController.playerViewController?.setVideoOverlay(videoOverlay)
 #if os(tvOS)
-        uiViewController.viewController?.contextualActions = contextualActions
+        uiViewController.playerViewController?.contextualActions = contextualActions
 #endif
         context.coordinator.player = player
     }

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -14,18 +14,18 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
     let contextualActions: [UIAction]
     let videoOverlay: VideoOverlay
 
-    static func dismantleUIViewController(_ uiViewController: PictureInPictureHostViewController, coordinator: Coordinator) {
+    static func dismantleUIViewController(_ uiViewController: PictureInPictureHostViewController, coordinator: SystemVideoViewCoordinator) {
         PictureInPicture.shared.system.dismantleHostViewController(uiViewController)
     }
 
-#if os(tvOS)
-    func makeCoordinator() -> AVPlayerViewControllerSpeedCoordinator {
+    func makeCoordinator() -> SystemVideoViewCoordinator {
         .init()
     }
-#endif
 
     func makeUIViewController(context: Context) -> PictureInPictureHostViewController {
-        PictureInPicture.shared.system.makeHostViewController(for: player)
+        let controller = PictureInPicture.shared.system.makeHostViewController(for: player)
+        context.coordinator.controller = controller.viewController
+        return controller
     }
 
     func updateUIViewController(_ uiViewController: PictureInPictureHostViewController, context: Context) {
@@ -34,8 +34,7 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
         uiViewController.viewController?.setVideoOverlay(videoOverlay)
 #if os(tvOS)
         uiViewController.viewController?.contextualActions = contextualActions
-        context.coordinator.player = player
-        context.coordinator.controller = uiViewController.viewController
 #endif
+        context.coordinator.player = player
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -9,12 +9,6 @@ import SwiftUI
 
 // swiftlint:disable:next type_name
 struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where VideoOverlay: View {
-#if os(tvOS)
-    typealias Coordinator = AVPlayerViewControllerSpeedCoordinator
-#else
-    typealias Coordinator = Void
-#endif
-
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
@@ -25,7 +19,7 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
     }
 
 #if os(tvOS)
-    func makeCoordinator() -> Coordinator {
+    func makeCoordinator() -> AVPlayerViewControllerSpeedCoordinator {
         .init()
     }
 #endif

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -8,7 +8,7 @@ import AVKit
 import SwiftUI
 
 // swiftlint:disable:next type_name
-struct PictureInPictureSupportingSystemVideoView<VideoOvelay>: UIViewControllerRepresentable where VideoOvelay: View {
+struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where VideoOverlay: View {
 #if os(tvOS)
     typealias Coordinator = AVPlayerViewControllerSpeedCoordinator
 #else
@@ -18,7 +18,7 @@ struct PictureInPictureSupportingSystemVideoView<VideoOvelay>: UIViewControllerR
     let player: Player
     let gravity: AVLayerVideoGravity
     let contextualActions: [UIAction]
-    let videoOverlay: VideoOvelay
+    let videoOverlay: VideoOverlay
 
     static func dismantleUIViewController(_ uiViewController: PictureInPictureHostViewController, coordinator: Coordinator) {
         PictureInPicture.shared.system.dismantleHostViewController(uiViewController)

--- a/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
+++ b/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
@@ -30,20 +30,6 @@ final class SystemVideoViewCoordinator {
 
 @available(iOS, unavailable)
 private extension SystemVideoViewCoordinator {
-    func configurePlaybackSpeedPublisher(player: Player?, controller: AVPlayerViewController?) {
-        guard let player, let controller else {
-            cancellable = nil
-            return
-        }
-        cancellable = player.playbackSpeedPublisher()
-            .map { speed in
-                guard let range = speed.range, range != 1...1 else { return [] }
-                return Self.speedMenuItems(for: player, range: range, speed: speed.effectiveValue)
-            }
-            .receiveOnMainThread()
-            .assign(to: \.transportBarCustomMenuItems, on: controller)
-    }
-
     private static func allowedSpeeds(from range: ClosedRange<Float>) -> Set<Float> {
         Set(
             AVPlaybackSpeed.systemDefaultSpeeds
@@ -71,5 +57,19 @@ private extension SystemVideoViewCoordinator {
                 children: speedActions
             )
         ]
+    }
+
+    func configurePlaybackSpeedPublisher(player: Player?, controller: AVPlayerViewController?) {
+        guard let player, let controller else {
+            cancellable = nil
+            return
+        }
+        cancellable = player.playbackSpeedPublisher()
+            .map { speed in
+                guard let range = speed.range, range != 1...1 else { return [] }
+                return Self.speedMenuItems(for: player, range: range, speed: speed.effectiveValue)
+            }
+            .receiveOnMainThread()
+            .assign(to: \.transportBarCustomMenuItems, on: controller)
     }
 }

--- a/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
+++ b/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
@@ -8,23 +8,29 @@ import AVKit
 import Combine
 import UIKit
 
-@available(iOS, unavailable)
-final class AVPlayerViewControllerSpeedCoordinator {
+final class SystemVideoViewCoordinator {
     var player: Player? {
         didSet {
+#if os(tvOS)
             configurePlaybackSpeedPublisher(player: player, controller: controller)
+#endif
         }
     }
 
     var controller: AVPlayerViewController? {
         didSet {
+#if os(tvOS)
             configurePlaybackSpeedPublisher(player: player, controller: controller)
+#endif
         }
     }
 
     private var cancellable: AnyCancellable?
+}
 
-    private func configurePlaybackSpeedPublisher(player: Player?, controller: AVPlayerViewController?) {
+@available(iOS, unavailable)
+private extension SystemVideoViewCoordinator {
+    func configurePlaybackSpeedPublisher(player: Player?, controller: AVPlayerViewController?) {
         guard let player, let controller else {
             cancellable = nil
             return
@@ -37,11 +43,8 @@ final class AVPlayerViewControllerSpeedCoordinator {
             .receiveOnMainThread()
             .assign(to: \.transportBarCustomMenuItems, on: controller)
     }
-}
 
-@available(iOS, unavailable)
-private extension AVPlayerViewControllerSpeedCoordinator {
-    static func allowedSpeeds(from range: ClosedRange<Float>) -> Set<Float> {
+    private static func allowedSpeeds(from range: ClosedRange<Float>) -> Set<Float> {
         Set(
             AVPlaybackSpeed.systemDefaultSpeeds
                 .map(\.rate)
@@ -49,7 +52,7 @@ private extension AVPlayerViewControllerSpeedCoordinator {
         )
     }
 
-    static func speedMenuItems(
+    private static func speedMenuItems(
         for player: Player,
         range: ClosedRange<Float>,
         speed: Float


### PR DESCRIPTION
## Description

This PR fixes two issues introduced in #430:

- The overlay was opaque, always hiding the content behind it.
- The app was crashing when transitioning from an inline system video view to its full screen counterpart (due to parent / child relationship inconsistency).

## Changes made

- Remove parent / child relationship to avoid the crash.
- Make the overlay hosting controller view background trasnparent.
- Improve property naming.
- Make system video view coordinator available on all platforms (even if only doing meaningful work for tvOS at the moment).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
