### PR TITLE
Require an identifier to be provided when creating a metrics tracker

### DIFF
--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -34,12 +34,12 @@ public extension PlayerItem {
                 CommandersActTracker.adapter { $0.analyticsMetadata },
                 MetricsTracker.adapter(
                     configuration: .init(
+                        identifier: urn,
                         serviceUrl: URL(string: "https://monitoring.pillarbox.ch/api/events")!
                     ),
                     behavior: .mandatory
                 ) { metadata in
                     MetricsTracker.Metadata(
-                        identifier: metadata.mainChapter.urn,
                         metadataUrl: metadata.mediaCompositionUrl,
                         assetUrl: metadata.resource?.url
                     )

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -76,16 +76,19 @@ public final class MetricsTracker: PlayerItemTracker {
 public extension MetricsTracker {
     /// Configuration associated with the tracker.
     struct Configuration {
+        let identifier: String
         let serviceUrl: URL
         let heartbeatInterval: TimeInterval
 
         /// Creates the configuration.
         ///
         /// - Parameters:
+        ///   - identifier: An identifier for the content.
         ///   - serviceUrl: The URL service endpoint where data must be sent.
         ///   - heartbeatInterval: The interval between heartbeats, in seconds.
-        public init(serviceUrl: URL, heartbeatInterval: TimeInterval = 30) {
+        public init(identifier: String, serviceUrl: URL, heartbeatInterval: TimeInterval = 30) {
             assert(heartbeatInterval >= 1)
+            self.identifier = identifier
             self.serviceUrl = serviceUrl
             self.heartbeatInterval = heartbeatInterval
         }
@@ -93,18 +96,15 @@ public extension MetricsTracker {
 
     /// Metadata associated with the tracker.
     struct Metadata {
-        let identifier: String?
         let metadataUrl: URL?
         let assetUrl: URL?
 
         /// Creates metadata.
         ///
         /// - Parameters:
-        ///   - identifier: An identifier for the content.
         ///   - metadataUrl: The URL where metadata has been fetched.
         ///   - assetUrl: The URL of the asset being played.
-        public init(identifier: String? = nil, metadataUrl: URL? = nil, assetUrl: URL? = nil) {
-            self.identifier = identifier
+        public init(metadataUrl: URL? = nil, assetUrl: URL? = nil) {
             self.metadataUrl = metadataUrl
             self.assetUrl = assetUrl
         }
@@ -127,7 +127,7 @@ private extension MetricsTracker {
             player: .init(name: "Pillarbox", platform: "Apple", version: Player.version),
             media: .init(
                 assetUrl: metadata?.assetUrl,
-                id: metadata?.identifier,
+                id: configuration.identifier,
                 metadataUrl: metadata?.metadataUrl,
                 origin: Bundle.main.bundleIdentifier
             ),

--- a/Sources/Monitoring/Monitoring.docc/PillarboxMonitoring.md
+++ b/Sources/Monitoring/Monitoring.docc/PillarboxMonitoring.md
@@ -24,9 +24,9 @@ To monitor playback, attach a ``MetricsTracker`` to a `PlayerItem`, configured w
 ```swift
 let item = PlayerItem.simple(url: URL(string: "https://your.domain.com/content.m3u8")!, trackerAdapters: [
     MetricsTracker.adapter(
-        configuration: .init(serviceUrl: URL(string: "https://your.domain.com/monitoring")!)
+        configuration: .init(identifier: "your-content-identifier", serviceUrl: URL(string: "https://your.domain.com/monitoring")!)
     ) { metadata in
-        .init(identifier: "your-content-identifier")
+        .init(assetUrl: URL(string: "https://your.domain.com/content.m3u8")!)
     }
 ])
 ```

--- a/Tests/MonitoringTests/MetricsTracker.swift
+++ b/Tests/MonitoringTests/MetricsTracker.swift
@@ -9,10 +9,12 @@ import PillarboxMonitoring
 
 extension MetricsTracker.Configuration {
     static let test = MetricsTracker.Configuration(
+        identifier: "identifier",
         serviceUrl: URL(string: "https://localhost/ingest")!
     )
 
     static let heartbeatTest = MetricsTracker.Configuration(
+        identifier: "identifier",
         serviceUrl: URL(string: "https://localhost/ingest")!,
         heartbeatInterval: 1
     )
@@ -20,7 +22,6 @@ extension MetricsTracker.Configuration {
 
 extension MetricsTracker.Metadata {
     static let test = MetricsTracker.Metadata(
-        identifier: "identifier",
         metadataUrl: URL(string: "https://localhost/metadata.json"),
         assetUrl: URL(string: "https://localhost/asset.m3u8")
     )


### PR DESCRIPTION
## Description

This PR improves monitoring of a session by ensuring a unique identifier is provided for the content being monitored.

## Changes made

- Move identifier from metrics tracker metadata to configuration, making it mandatory in the process.
- Update the documentation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
