### PR TITLE
Fix slider background and animations

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -696,6 +696,7 @@ private struct TimeSlider: View {
             }
             .frame(height: progressTracker.isInteracting ? 16 : 8)
             .clipShape(.capsule)
+            .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
             .opacity(isVisible ? 1 : 0)
             .animation(.easeInOut(duration: 0.3), values: progressTracker.isInteracting, isVisible)
         }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -698,7 +698,7 @@ private struct TimeSlider: View {
             .clipShape(.capsule)
             .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
             .opacity(isVisible ? 1 : 0)
-            .animation(.easeInOut(duration: 0.3), values: progressTracker.isInteracting, isVisible)
+            .animation(.easeInOut(duration: 0.3), value: progressTracker.isInteracting)
         }
         .onEditingChanged { isEditing in
             progressTracker.isInteracting = isEditing


### PR DESCRIPTION
## Description

This PR fixes minor regressions introduced in #1118:

- A shadow has been restored for better readability on light content. 
- Animations have been tweaked to avoid initial animations when starting playback (e.g. DVR window or starting at a non-zero position).

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ed631918-21f5-40b8-868d-429a4fb9a425"> | <video src="https://github.com/user-attachments/assets/4863dd34-ce5a-434f-9c0c-d450edbdada1"> |

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
