### PR TITLE
Remove custom server initializer

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -379,22 +379,13 @@
     "URN" : {
 
     },
-    "URN (IL Production)" : {
+    "URN (Production)" : {
 
     },
-    "URN (IL Stage)" : {
+    "URN (Stage)" : {
 
     },
-    "URN (IL Test)" : {
-
-    },
-    "URN (SAM Production)" : {
-
-    },
-    "URN (SAM Stage)" : {
-
-    },
-    "URN (SAM Test)" : {
+    "URN (Test)" : {
 
     },
     "Use a proxy tool to observe events." : {

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -15,7 +15,7 @@ private struct LoadedView: View {
     @EnvironmentObject private var router: Router
 
     @AppStorage(UserDefaults.DemoSettingKey.serverSetting.rawValue)
-    private var serverSetting: ServerSetting = .ilProduction
+    private var serverSetting: ServerSetting = .production
 
     var body: some View {
         CustomList(data: contents) { content in
@@ -65,7 +65,7 @@ private struct ContentCell: View {
     let content: ContentListViewModel.Content
 
     @AppStorage(UserDefaults.DemoSettingKey.serverSetting.rawValue)
-    private var serverSetting: ServerSetting = .ilProduction
+    private var serverSetting: ServerSetting = .production
 
     @EnvironmentObject private var router: Router
 

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 // Behavior: h-exp, v-exp
 struct ContentListsView: View {
     @AppStorage(UserDefaults.DemoSettingKey.serverSetting.rawValue)
-    private var selectedServerSetting: ServerSetting = .ilProduction
+    private var selectedServerSetting: ServerSetting = .production
 
     var body: some View {
         CustomList {

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -50,12 +50,9 @@ private struct MediaEntryView: View {
         case url
         case tokenProtected
         case encrypted
-        case ilProductionUrn
-        case ilStageUrn
-        case ilTestUrn
-        case samProductionUrn
-        case samStageUrn
-        case samTestUrn
+        case productionUrn
+        case stageUrn
+        case testUrn
     }
 
     @State private var kind: Kind = .url
@@ -74,18 +71,12 @@ private struct MediaEntryView: View {
         case .encrypted:
             guard let url, let certificateUrl else { return URLMedia.unknown }
             return .init(title: "Encrypted", type: .encryptedUrl(url, certificateUrl: certificateUrl))
-        case .ilProductionUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .ilProduction))
-        case .ilStageUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .ilStage))
-        case .ilTestUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .ilTest))
-        case .samProductionUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .samProduction))
-        case .samStageUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .samStage))
-        case .samTestUrn:
-            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .samTest))
+        case .productionUrn:
+            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .production))
+        case .stageUrn:
+            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .stage))
+        case .testUrn:
+            return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .test))
         }
     }
 
@@ -103,7 +94,7 @@ private struct MediaEntryView: View {
 
     private var textPlaceholder: String {
         switch kind {
-        case .ilProductionUrn, .ilStageUrn, .ilTestUrn, .samProductionUrn, .samStageUrn, .samTestUrn:
+        case .productionUrn, .stageUrn, .testUrn:
             return "URN"
         default:
             return "URL"
@@ -112,7 +103,7 @@ private struct MediaEntryView: View {
 
     private var isValid: Bool {
         switch kind {
-        case .ilProductionUrn, .ilStageUrn, .ilTestUrn, .samProductionUrn, .samStageUrn, .samTestUrn:
+        case .productionUrn, .stageUrn, .testUrn:
             return !text.isEmpty
         case .encrypted:
             return url != nil && certificateUrl != nil
@@ -146,13 +137,9 @@ private struct MediaEntryView: View {
             Text("URL with SRG SSR token protection").tag(Kind.tokenProtected)
             Text("URL with SRG SSR DRM encryption").tag(Kind.encrypted)
             Divider()
-            Text("URN (IL Production)").tag(Kind.ilProductionUrn)
-            Text("URN (IL Stage)").tag(Kind.ilStageUrn)
-            Text("URN (IL Test)").tag(Kind.ilTestUrn)
-            Divider()
-            Text("URN (SAM Production)").tag(Kind.samProductionUrn)
-            Text("URN (SAM Stage)").tag(Kind.samStageUrn)
-            Text("URN (SAM Test)").tag(Kind.samTestUrn)
+            Text("URN (Production)").tag(Kind.productionUrn)
+            Text("URN (Stage)").tag(Kind.stageUrn)
+            Text("URN (Test)").tag(Kind.testUrn)
         }
 #if os(tvOS)
         .pickerStyle(.navigationLink)

--- a/Demo/Sources/Model/Media.swift
+++ b/Demo/Sources/Model/Media.swift
@@ -22,7 +22,7 @@ struct Media: Hashable {
         case urn(String, serverSetting: ServerSetting)
 
         static func urn(_ urn: String) -> Self {
-            .urn(urn, serverSetting: .ilProduction)
+            .urn(urn, serverSetting: .production)
         }
     }
 

--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -9,95 +9,44 @@ import SRGDataProvider
 
 @objc
 enum ServerSetting: Int, CaseIterable {
-    case ilProduction
-    case ilStage
-    case ilTest
-
-    case ilProductionCH
-    case ilStageCH
-    case ilTestCH
-
-    case ilProductionWW
-    case ilStageWW
-    case ilTestWW
-
-    case samProduction
-    case samStage
-    case samTest
+    case production
+    case stage
+    case test
 
     var title: String {
         switch self {
-        case .ilProduction:
-            return "IL Production"
-        case .ilStage:
-            return "IL Stage"
-        case .ilTest:
-            return "IL Test"
-        case .ilProductionCH:
-            return "IL Production - CH"
-        case .ilStageCH:
-            return "IL Stage - CH"
-        case .ilTestCH:
-            return "IL Test - CH"
-        case .ilProductionWW:
-            return "IL Production - WW"
-        case .ilStageWW:
-            return "IL Stage - WW"
-        case .ilTestWW:
-            return "IL Test - WW"
-        case .samProduction:
-            return "SAM Production"
-        case .samStage:
-            return "SAM Stage"
-        case .samTest:
-            return "SAM Test"
+        case .production:
+            return "Production"
+        case .stage:
+            return "Stage"
+        case .test:
+            return "Test"
         }
     }
 
     var dataProvider: SRGDataProvider {
-        let dataProvider = SRGDataProvider(serviceURL: baseUrl)
-        dataProvider.globalParameters = globalParameters
-        return dataProvider
+        .init(serviceURL: baseUrl)
     }
 
     private var baseUrl: URL {
         switch self {
-        case .ilProduction, .ilProductionCH, .ilProductionWW:
+        case .production:
             return SRGIntegrationLayerProductionServiceURL()
-        case .ilStage, .ilStageCH, .ilStageWW:
+        case .stage:
             return SRGIntegrationLayerStagingServiceURL()
-        case .ilTest, .ilTestCH, .ilTestWW:
+        case .test:
             return SRGIntegrationLayerTestServiceURL()
-        case .samProduction:
-            return SRGIntegrationLayerProductionServiceURL().appending(component: "sam")
-        case .samStage:
-            return SRGIntegrationLayerStagingServiceURL().appending(component: "sam")
-        case .samTest:
-            return SRGIntegrationLayerTestServiceURL().appending(component: "sam")
-        }
-    }
-
-    private var globalParameters: [String: String] {
-        .init(uniqueKeysWithValues: queryItems.compactMap { item in
-            guard let value = item.value else { return nil }
-            return (item.name, value)
-        })
-    }
-
-    private var queryItems: [URLQueryItem] {
-        switch self {
-        case .ilProductionCH, .ilStageCH, .ilTestCH:
-            return [URLQueryItem(name: "forceLocation", value: "CH")]
-        case .ilProductionWW, .ilStageWW, .ilTestWW:
-            return [URLQueryItem(name: "forceLocation", value: "WW")]
-        case .samProduction, .samStage, .samTest:
-            return [URLQueryItem(name: "forceSAM", value: "true")]
-        default:
-            return []
         }
     }
 
     var server: Server {
-        .init(baseUrl: baseUrl, queryItems: queryItems)
+        switch self {
+        case .production:
+            return .production
+        case .stage:
+            return .stage
+        case .test:
+            return .test
+        }
     }
 }

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -43,7 +43,7 @@ extension UserDefaults {
     }
 
     @objc dynamic var serverSetting: ServerSetting {
-        .init(rawValue: integer(forKey: DemoSettingKey.serverSetting.rawValue)) ?? .ilProduction
+        .init(rawValue: integer(forKey: DemoSettingKey.serverSetting.rawValue)) ?? .production
     }
 
     @objc dynamic var qualitySetting: QualitySetting {
@@ -55,7 +55,7 @@ extension UserDefaults {
             DemoSettingKey.presenterModeEnabled.rawValue: false,
             DemoSettingKey.seekBehaviorSetting.rawValue: SeekBehaviorSetting.immediate.rawValue,
             DemoSettingKey.smartNavigationEnabled.rawValue: true,
-            DemoSettingKey.serverSetting.rawValue: ServerSetting.ilProduction.rawValue,
+            DemoSettingKey.serverSetting.rawValue: ServerSetting.production.rawValue,
             DemoSettingKey.qualitySetting.rawValue: QualitySetting.high.rawValue
         ])
     }

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -24,25 +24,13 @@ public struct Server {
     public static let test = Self(baseUrl: URL(string: "https://il-test.srgssr.ch")!)
 
     private let baseUrl: URL
-    private let queryItems: [URLQueryItem]
-
-    /// This API will be removed in a future Pillarbox release. Do not use.
-    ///
-    /// > Warning: This API will be removed in a future Pillarbox release. Do not use.
-    public init(baseUrl: URL, queryItems: [URLQueryItem] = []) {
-        // FIXME: This initializer must be made private after SAM replaces the IL. The assertion must be removed at
-        //        the same time.
-        assert(Bundle.main.allowsReservedInitializer, "This API will be removed in a future Pillarbox release. Do not use.")
-        self.baseUrl = baseUrl
-        self.queryItems = queryItems
-    }
 
     func mediaCompositionRequest(forUrn urn: String) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .init(url: url)
         }
-        components.queryItems = queryItems + [
+        components.queryItems = [
             URLQueryItem(name: "onlyChapters", value: "true"),
             URLQueryItem(name: "vector", value: Self.vector)
         ]
@@ -56,7 +44,7 @@ public struct Server {
         ) else {
             return url
         }
-        components.queryItems = queryItems + [
+        components.queryItems = [
             URLQueryItem(name: "imageUrl", value: url.absoluteString),
             URLQueryItem(name: "format", value: "jpg"),
             URLQueryItem(name: "width", value: String(width.rawValue))
@@ -67,12 +55,5 @@ public struct Server {
         else {
             return url
         }
-    }
-}
-
-private extension Bundle {
-    var allowsReservedInitializer: Bool {
-        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return false }
-        return bundleIdentifier.hasPrefix("ch.srgssr.Pillarbox-demo") || bundleIdentifier.hasPrefix("com.apple.dt.xctest.tool")
     }
 }


### PR DESCRIPTION
## Description

This PR removes the custom server initializer, fixing a regression introduced in version 7.0.0 which intended to keep it for a while (but as a result would not play any URN in debug builds).

Note that we could have kept the API [somehow private](https://github.com/SRGSSR/pillarbox-apple/issues/1100#issuecomment-2636083022) but we still agreed that alternative server configurations currently offered by the demo (SAM, geoblocking) are not really useful. If really needed we can test such configurations in a debug build, tweaking URLs and request headers before.

## Changes made

- Remove custom `Server` initializer.
- Remove all non-standard server configurations from the demo.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
