### PR TITLE
Use enum to restrict source keys to valid values

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -47,7 +47,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     private func configureAnalytics() {
         let configuration = Analytics.Configuration(
             vendor: .SRG,
-            sourceKey: .developmentSourceKey,
+            sourceKey: .development,
             appSiteName: "pillarbox-demo-apple"
         )
         try? Analytics.shared.start(with: configuration, dataSource: self, delegate: self)

--- a/Sources/Analytics/Analytics.docc/setup-article.md
+++ b/Sources/Analytics/Analytics.docc/setup-article.md
@@ -33,30 +33,30 @@ To enable measurements, you need to start the ``Analytics`` singleton. First, cr
 ```swift
 let configuration = Analytics.Configuration(
     vendor: .SRF,
-    sourceKey: .productionSourceKey,
+    sourceKey: .production,
     appSiteName: "app-site-name"
 )
 ```
 
 Provide the **vendor** publishing the app, the appropriate **source key**, and the **site name** for your app.
 
-> Note: Use `.productionSourceKey` for production apps. For development, set it to `.developmentSourceKey` to avoid contaminating production data.
+> Note: Use `.production` for production apps. For development, set it to `.development` to avoid contaminating production data.
 
 Next, initialize the tracker singleton in your `application(_:didFinishLaunchingWithOptions:)` method, located in your [application delegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate):
 
 ```swift
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
-        _ application: UIApplication, 
+        _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         let configuration = Analytics.Configuration(
             vendor: .SRF,
-            sourceKey: .productionSourceKey,
+            sourceKey: .production,
             appSiteName: "app-site-name"
         )
         try? Analytics.shared.start(with: configuration)
-        
+
         // ...
     }
 }

--- a/Sources/Analytics/Analytics.docc/user-consent-article.md
+++ b/Sources/Analytics/Analytics.docc/user-consent-article.md
@@ -21,16 +21,16 @@ To send user consent choices you must therefore register an ``AnalyticsDataSourc
 ```swift
 final class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
-        _ application: UIApplication, 
+        _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         let configuration = Analytics.Configuration(
             vendor: .SRF,
-            sourceKey: .productionSourceKey,
+            sourceKey: .production,
             appSiteName: "app-site-name"
         )
         try? Analytics.shared.start(with: configuration, dataSource: self)
-        
+
         // ...
     }
 }

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -22,7 +22,7 @@ public class Analytics {
     /// application.
     public struct Configuration {
         let vendor: Vendor
-        let sourceKey: String
+        let sourceKey: SourceKey
         let appSiteName: String
 
         /// Creates an analytics configuration.
@@ -31,10 +31,9 @@ public class Analytics {
         ///
         /// - Parameters:
         ///   - vendor: The vendor which the application belongs to.
-        ///   - sourceKey: The source key. Production apps should use `.productionSourceKey` while apps in development
-        ///     should use `.developmentSourceKey`.
+        ///   - sourceKey: The source key.
         ///   - appSiteName: The app/site name.
-        public init(vendor: Vendor, sourceKey: String, appSiteName: String) {
+        public init(vendor: Vendor, sourceKey: SourceKey, appSiteName: String) {
             self.vendor = vendor
             self.sourceKey = sourceKey
             self.appSiteName = appSiteName

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -13,7 +13,7 @@ final class CommandersActService {
     func start(with configuration: Analytics.Configuration) {
         vendor = configuration.vendor
 
-        if let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey) {
+        if let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey.rawValue) {
             serverSide.addPermanentData("app_library_version", withValue: Analytics.version)
             serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
             serverSide.addPermanentData("navigation_device", withValue: Self.device)

--- a/Sources/Analytics/Extensions/String.swift
+++ b/Sources/Analytics/Extensions/String.swift
@@ -6,14 +6,6 @@
 
 import Foundation
 
-public extension String {
-    /// The source key for apps in production.
-    static let productionSourceKey = "1b30366c-9e8d-4720-8b12-4165f468f9ae"
-
-    /// The source key for apps in development.
-    static let developmentSourceKey = "39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
-}
-
 extension String {
     var isBlank: Bool {
         trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/Sources/Analytics/SourceKey.swift
+++ b/Sources/Analytics/SourceKey.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+/// Source keys.
+public enum SourceKey: String {
+    /// The source key for apps in production.
+    case production = "1b30366c-9e8d-4720-8b12-4165f468f9ae"
+
+    /// The source key for apps in development.
+    case development = "39ae8f94-595c-4ca4-81f7-fb7748bd3f04"
+}

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -27,7 +27,7 @@ class TestCase: XCTestCase {
         PollingDefaults.timeout = .seconds(20)
         PollingDefaults.pollInterval = .milliseconds(100)
         try? Analytics.shared.start(
-            with: .init(vendor: .SRG, sourceKey: .developmentSourceKey, appSiteName: "site"),
+            with: .init(vendor: .SRG, sourceKey: .development, appSiteName: "site"),
             dataSource: dataSource
         )
     }


### PR DESCRIPTION
## Description

This PR restrict source keys to valid values supported for the Commanders Act GD site id (3666).

## Changes made

- Make source key an enum instead of a string with recommended values.
- Update documentation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
