### PR TITLE
Avoid code signing when checking that the demo compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           check_name: 📋 Unit test report (${{ matrix.platform }})
           fail_on_failure: true
 
-  archive-demos:
-    name: 📦 Archives
+  build-demos:
+    name: 🔨 Builds
     runs-on: macos-latest
     strategy:
       matrix:
@@ -49,23 +49,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Add Apple certificate
-        run: |
-          Scripts/private/add-apple-certificate.sh \
-          $RUNNER_TEMP \
-          ${{ secrets.KEYCHAIN_PASSWORD }} \
-          ${{ secrets.APPLE_DEV_CERTIFICATE }} \
-          ${{ secrets.APPLE_DEV_CERTIFICATE_PASSWORD }}
-
-      - name: Configure environment
-        run: |
-          Scripts/private/configure-environment.sh \
-          ${{ secrets.APP_STORE_CONNECT_API_KEY }}
-
-      - name: Archive the demo
-        run: Scripts/private/archive-demo.sh -p ${{ matrix.platform }}
-        env:
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ISSUER_ID }}
-          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_GROUPS }}
+      - name: Build the demo
+        run: make build-${{ matrix.platform }}

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ test-streams-start:
 test-streams-stop:
 	@Scripts/public/test-streams.sh -k
 
+.PHONY: build-ios
+build-ios:
+	@Scripts/public/build-demo.sh -p ios
+
+.PHONY: build-tvos
+build-tvos:
+	@Scripts/public/build-demo.sh -p tvos
+
 .PHONY: test-ios
 test-ios:
 	@Scripts/public/test-streams.sh -s
@@ -54,11 +62,15 @@ help:
 	@echo "Default:"
 	@echo "  all                            Default target"
 	@echo
-	@echo "Test:"
+	@echo "Builds:"
+	@echo "  build-ios                      Build iOS demo app"
+	@echo "  build-tvos                     Build tvOS demo app"
+	@echo
+	@echo "Tests:"
 	@echo "  test-streams-start             Start test streams"
 	@echo "  test-streams-stop              Stop test streams"
-	@echo "  test-ios                       Build & run iOS unit tests"
-	@echo "  test-tvos                      Build & run tvOS unit tests"
+	@echo "  test-ios                       Build and run iOS unit tests"
+	@echo "  test-tvos                      Build and run tvOS unit tests"
 	@echo
 	@echo "Quality:"
 	@echo "  check-quality                  Run quality checks"

--- a/Scripts/public/build-demo.sh
+++ b/Scripts/public/build-demo.sh
@@ -37,8 +37,8 @@ fi
 
 install_tools
 
-echo -e "Archiving $PLATFORM demo..."
+echo -e "Building $PLATFORM demo..."
 bundle config set path '.bundle'
 bundle install
-bundle exec fastlane "archive_demo_$PLATFORM"
+bundle exec fastlane "build_demo_$PLATFORM"
 echo "... done."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,7 +92,8 @@ def build_demo_app(platform_id, configuration_id)
     scheme: 'Pillarbox-demo',
     destination: "generic/platform=#{PLATFORMS[platform_id]}",
     output_directory: 'Binaries',
-    skip_archive: true
+    skip_archive: true,
+    skip_codesigning: true
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,7 +85,18 @@ def bump_testflight_build_number(platform_id, configuration_id)
   build_number
 end
 
-def build_and_sign_app(platform_id, configuration_id)
+def build_demo_app(platform_id, configuration_id)
+  build_app(
+    project: 'Demo/Pillarbox-demo.xcodeproj',
+    configuration: CONFIGURATIONS[configuration_id],
+    scheme: 'Pillarbox-demo',
+    destination: "generic/platform=#{PLATFORMS[platform_id]}",
+    output_directory: 'Binaries',
+    skip_archive: true
+  )
+end
+
+def build_and_sign_demo_app(platform_id, configuration_id)
   build_app(
     project: 'Demo/Pillarbox-demo.xcodeproj',
     configuration: CONFIGURATIONS[configuration_id],
@@ -141,17 +152,16 @@ rescue StandardError => e
   UI.important('TestFlight external delivery was skipped because a build is already in review')
 end
 
-def archive_demo(platform_id)
-  ensure_configuration_availability
-  build_and_sign_app(platform_id, :nightly)
-  build_and_sign_app(platform_id, :release)
+def build_demo(platform_id)
+  build_demo_app(platform_id, :nightly)
+  build_demo_app(platform_id, :release)
 end
 
 def deliver_demo_nightly(platform_id)
   ensure_configuration_availability
   build_number = bump_testflight_build_number(platform_id, :nightly)
   add_version_badge(platform_id, last_git_tag, build_number, 'orange')
-  build_and_sign_app(platform_id, :nightly)
+  build_and_sign_demo_app(platform_id, :nightly)
   reset_git_repo(skip_clean: true)
   upload_app_to_testflight
   distribute_app_to_testers(platform_id, :nightly, build_number)
@@ -161,7 +171,7 @@ def deliver_demo_release(platform_id)
   ensure_configuration_availability
   build_number = bump_testflight_build_number(platform_id, :release)
   add_version_badge(platform_id, 'v.', last_git_tag, 'blue')
-  build_and_sign_app(platform_id, :release)
+  build_and_sign_demo_app(platform_id, :release)
   reset_git_repo(skip_clean: true)
   upload_app_to_testflight
   distribute_app_to_testers(platform_id, :release, build_number)
@@ -203,14 +213,14 @@ platform :ios do
     reset_git_repo(skip_clean: true)
   end
 
-  desc 'Archive the iOS demo app'
-  lane :archive_demo_ios do
-    archive_demo(:ios)
+  desc 'Build the iOS demo app'
+  lane :build_demo_ios do
+    build_demo(:ios)
   end
 
-  desc 'Archive the tvOS demo app'
-  lane :archive_demo_tvos do
-    archive_demo(:tvos)
+  desc 'Build the tvOS demo app'
+  lane :build_demo_tvos do
+    build_demo(:tvos)
   end
 
   desc 'Deliver an iOS demo app nightly build'


### PR DESCRIPTION
## Description

This PR improves our CI workflow to make it possible to validate external PRs. GitHub namely [avoids exposing secrets](https://github.com/orgs/community/discussions/26242) when running workflows for external PRs, for security reasons.

To solve this issue we improved our workflows to avoid secrets in CI steps used mostly to check that the code compiles on all supported platforms.

## Changes made

- Provide targets that build the demo without requiring secrets (no archiving).
- Rename _archiving_ to _build_ in associated targets.
- Update CI workflow to remove the need for secrets entirely.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
