### PR TITLE
Improve missing doc detection

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -182,16 +182,19 @@ file_header:
     \/\/  License information is available from the LICENSE file.
     \/\/
 
-function_parameter_count:
-  warning: 8
-
 file_length:
   warning: 1000
   error: 1500
 
+function_parameter_count:
+  warning: 8
+
 line_length:
   warning: 160
   error: 200
+
+missing_docs:
+  excludes_inherited_types: false
 
 nesting:
   type_level: 2

--- a/Demo/Sources/Extensions/URL.swift
+++ b/Demo/Sources/Extensions/URL.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 extension URL: @retroactive ExpressibleByStringLiteral {
+    // swiftlint:disable:next missing_docs
     public init(stringLiteral value: StringLiteralType) {
         self.init(string: value)!
     }

--- a/Sources/Analytics/AnalyticsDelegate.swift
+++ b/Sources/Analytics/AnalyticsDelegate.swift
@@ -6,6 +6,13 @@
 
 /// A delegate for analytics events.
 public protocol AnalyticsDelegate: AnyObject {
+    /// Called when a page view has been tracked.
+    ///
+    /// - Parameter commandersActPageView: The Commanders Act page view.
     func didTrackPageView(commandersAct commandersActPageView: CommandersActPageView)
+
+    /// Called when an event has been sent.
+    ///
+    /// - Parameter commandersActEvent: The Commanders Act event.
     func didSendEvent(commandersAct commandersActEvent: CommandersActEvent)
 }

--- a/Sources/Analytics/ComScore/Capture/ComScoreHit.swift
+++ b/Sources/Analytics/ComScore/Capture/ComScoreHit.swift
@@ -10,10 +10,19 @@
 public struct ComScoreHit {
     /// A name describing a comScore hit.
     public enum Name: String {
+        /// Play.
         case play
+
+        /// Rate change.
         case playrt
+
+        /// Pause.
         case pause
+
+        /// End.
         case end
+
+        /// View.
         case view
     }
 
@@ -31,6 +40,7 @@ public struct ComScoreHit {
 }
 
 extension ComScoreHit: CustomDebugStringConvertible {
+    // swiftlint:disable:next missing_docs
     public var debugDescription: String {
         name.rawValue
     }

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -17,17 +17,21 @@ public final class ComScoreTracker: PlayerItemTracker {
     private lazy var streamingAnalytics = ComScoreStreamingAnalytics()
     private var metadata: [String: String] = [:]
 
+    // swiftlint:disable:next missing_docs
     public init(configuration: Void) {}
 
+    // swiftlint:disable:next missing_docs
     public func enable(for player: AVPlayer) {
         createPlaybackSession()
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateMetadata(to metadata: [String: String]) {
         self.metadata = metadata
         setMetadata(metadata)
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateProperties(to properties: PlayerProperties) {
         guard !metadata.isEmpty else { return }
 
@@ -49,8 +53,10 @@ public final class ComScoreTracker: PlayerItemTracker {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateMetricEvents(to events: [MetricEvent]) {}
 
+    // swiftlint:disable:next missing_docs
     public func disable(with properties: PlayerProperties) {
         streamingAnalytics = ComScoreStreamingAnalytics()
     }

--- a/Sources/Analytics/CommandersAct/Capture/CommandersActHit.swift
+++ b/Sources/Analytics/CommandersAct/Capture/CommandersActHit.swift
@@ -10,14 +10,31 @@
 public struct CommandersActHit {
     /// A name describing a Commanders Act hit.
     public enum Name: Equatable {
+        /// Play.
         case play
+
+        /// Pause.
         case pause
+
+        /// Seek.
         case seek
+
+        /// Stop.
         case stop
+
+        /// End.
         case eof
+
+        /// Heartbeat.
         case pos
+
+        /// Live heartbeat.
         case uptime
+
+        /// Page view.
         case page_view
+
+        /// Custom.
         case custom(String)
 
         /// Returns the hit raw representation.
@@ -85,6 +102,7 @@ public struct CommandersActHit {
 }
 
 extension CommandersActHit: CustomDebugStringConvertible {
+    // swiftlint:disable:next missing_docs
     public var debugDescription: String {
         name.rawValue
     }

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -22,14 +22,18 @@ public final class CommandersActTracker: PlayerItemTracker {
     private let heartbeat = CommandersActHeartbeat()
     private var cancellable: AnyCancellable?
 
+    // swiftlint:disable:next missing_docs
     public init(configuration: Void) {}
 
+    // swiftlint:disable:next missing_docs
     public func enable(for player: AVPlayer) {}
 
+    // swiftlint:disable:next missing_docs
     public func updateMetadata(to metadata: [String: String]) {
         self.metadata = metadata
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateProperties(to properties: PlayerProperties) {
         if properties.isSeeking {
             notify(.seek, properties: properties)
@@ -48,8 +52,10 @@ public final class CommandersActTracker: PlayerItemTracker {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateMetricEvents(to events: [MetricEvent]) {}
 
+    // swiftlint:disable:next missing_docs
     public func disable(with properties: PlayerProperties) {
         notify(.stop, properties: properties)
         reset()

--- a/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
+++ b/Sources/Analytics/UserInterface/ContainerPageViewTracking.swift
@@ -18,6 +18,7 @@ public protocol ContainerPageViewTracking: UIViewController {
 }
 
 extension UINavigationController: ContainerPageViewTracking {
+    // swiftlint:disable:next missing_docs
     public var activeChildren: [UIViewController] {
         guard let topViewController else { return [] }
         return [topViewController]
@@ -25,6 +26,7 @@ extension UINavigationController: ContainerPageViewTracking {
 }
 
 extension UIPageViewController: ContainerPageViewTracking {
+    // swiftlint:disable:next missing_docs
     public var activeChildren: [UIViewController] {
         guard let viewController = viewControllers?.first else { return [] }
         return [viewController]
@@ -32,12 +34,14 @@ extension UIPageViewController: ContainerPageViewTracking {
 }
 
 extension UISplitViewController: ContainerPageViewTracking {
+    // swiftlint:disable:next missing_docs
     public var activeChildren: [UIViewController] {
         viewControllers
     }
 }
 
 extension UITabBarController: ContainerPageViewTracking {
+    // swiftlint:disable:next missing_docs
     public var activeChildren: [UIViewController] {
         guard let selectedViewController else { return [] }
         return [selectedViewController]

--- a/Sources/Circumspect/Similarity.swift
+++ b/Sources/Circumspect/Similarity.swift
@@ -28,6 +28,7 @@ public func beSimilarTo<T>(_ expectedValue: T?) -> Matcher<T> where T: Similar {
 }
 
 extension Array: Similar where Element: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: Self, rhs: Self) -> Bool {
         guard lhs.count == rhs.count else { return false }
         return zip(lhs, rhs).allSatisfy(~~)
@@ -35,6 +36,7 @@ extension Array: Similar where Element: Similar {
 }
 
 extension Optional: Similar where Wrapped: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: Wrapped?, rhs: Wrapped?) -> Bool {
         switch (lhs, rhs) {
         case (.none, .none):

--- a/Sources/Core/AsyncPublisher.swift
+++ b/Sources/Core/AsyncPublisher.swift
@@ -18,6 +18,7 @@ public struct AsyncPublisher<Output, Failure>: Publisher where Failure: Error {
         self.operation = operation
     }
 
+    // swiftlint:disable:next missing_docs
     public func receive<S>(subscriber: S) where S: Subscriber, S.Failure == Failure, S.Input == Output {
         let subscription = AsyncPublisherSubscription(subscriber: subscriber, operation: operation)
         subscriber.receive(subscription: subscription)

--- a/Sources/Core/ReplaySubject.swift
+++ b/Sources/Core/ReplaySubject.swift
@@ -24,6 +24,7 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
         buffer = .init(size: bufferSize)
     }
 
+    // swiftlint:disable:next missing_docs
     public func send(_ value: Output) {
         withLock(lock) {
             guard self.completion == nil else { return }
@@ -37,6 +38,7 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func send(completion: Subscribers.Completion<Failure>) {
         withLock(lock) {
             guard self.completion == nil else { return }
@@ -47,10 +49,12 @@ public final class ReplaySubject<Output, Failure>: Subject where Failure: Error 
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func send(subscription: Subscription) {
         subscription.request(.unlimited)
     }
 
+    // swiftlint:disable:next missing_docs
     public func receive<S>(subscriber: S) where S: Subscriber, S.Input == Output, S.Failure == Failure {
         withLock(lock) {
             let subscription = ReplaySubscription(subscriber: subscriber, values: buffer.values)

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -93,6 +93,7 @@ public struct MediaMetadata {
 }
 
 extension MediaMetadata: AssetMetadata {
+    // swiftlint:disable:next missing_docs
     public var playerMetadata: PlayerMetadata {
         .init(
             identifier: mediaComposition.chapterUrn,

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -24,26 +24,31 @@ public final class MetricsTracker: PlayerItemTracker {
 
     private var cancellables = Set<AnyCancellable>()
 
+    // swiftlint:disable:next missing_docs
     public var sessionIdentifier: String? {
         session.id
     }
 
+    // swiftlint:disable:next missing_docs
     public init(configuration: Configuration) {
         self.configuration = configuration
     }
 
+    // swiftlint:disable:next missing_docs
     public func enable(for player: AVPlayer) {}
 
+    // swiftlint:disable:next missing_docs
     public func updateMetadata(to metadata: Metadata) {
         self.metadata = metadata
     }
 
+    // swiftlint:disable:next missing_docs
     public func updateProperties(to properties: PlayerProperties) {
         self.properties = properties
         updateStopwatch(with: properties)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity missing_docs
     public func updateMetricEvents(to events: [MetricEvent]) {
         switch events.last?.kind {
         case .asset:
@@ -68,6 +73,7 @@ public final class MetricsTracker: PlayerItemTracker {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func disable(with properties: PlayerProperties) {
         reset(with: properties)
     }

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -55,16 +55,19 @@ public struct MetricEvent: Hashable {
         self.time = time
     }
 
+    // swiftlint:disable:next missing_docs
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
 
+    // swiftlint:disable:next missing_docs
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
 }
 
 extension MetricEvent.Kind: CustomStringConvertible {
+    // swiftlint:disable:next missing_docs
     public var description: String {
         switch self {
         case let .metadata(experience: experience, service: service):
@@ -106,6 +109,7 @@ extension MetricEvent: CustomStringConvertible {
         Self.dateFormatter.string(from: date)
     }
 
+    // swiftlint:disable:next missing_docs
     public var description: String {
         if let duration = Self.duration(from: time) {
             "[\(duration)] \(formattedDate) - \(kind.description)"

--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -46,6 +46,7 @@ public final class PictureInPicture {
 }
 
 extension PictureInPicture: PictureInPictureDelegate {
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureWillStart() {
         delegate?.pictureInPictureWillStart()
 
@@ -53,15 +54,18 @@ extension PictureInPicture: PictureInPictureDelegate {
         persisted?.pictureInPictureWillStart()
     }
 
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureDidStart() {
         delegate?.pictureInPictureDidStart()
         persisted?.pictureInPictureDidStart()
     }
 
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureControllerFailedToStart(with error: Error) {
         delegate?.pictureInPictureControllerFailedToStart(with: error)
     }
 
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureRestoreUserInterfaceForStop(with completion: @escaping (Bool) -> Void) {
         isRestored = true
         if let delegate {
@@ -79,11 +83,13 @@ extension PictureInPicture: PictureInPictureDelegate {
         }
     }
 
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureWillStop() {
         delegate?.pictureInPictureWillStop()
         persisted?.pictureInPictureWillStop()
     }
 
+    // swiftlint:disable:next missing_docs
     public func pictureInPictureDidStop() {
         delegate?.pictureInPictureDidStop()
         if !isRestored {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -245,6 +245,7 @@ public final class Player: ObservableObject, Equatable {
         self.init(items: [item], configuration: configuration)
     }
 
+    // swiftlint:disable:next missing_docs
     public static func == (lhs: Player, rhs: Player) -> Bool {
         lhs === rhs
     }

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -71,6 +71,7 @@ public final class PlayerItem: Equatable {
         .assign(to: &$content)
     }
 
+    // swiftlint:disable:next missing_docs
     public static func == (lhs: PlayerItem, rhs: PlayerItem) -> Bool {
         lhs === rhs
     }
@@ -324,6 +325,7 @@ extension PlayerItem {
 }
 
 extension PlayerItem: CustomDebugStringConvertible {
+    // swiftlint:disable:next missing_docs
     public var debugDescription: String {
         "\(id)"
     }

--- a/Sources/Player/Types/ImageSource.swift
+++ b/Sources/Player/Types/ImageSource.swift
@@ -43,6 +43,7 @@ public struct ImageSource: Equatable {
         Self(kind: .image(image))
     }
 
+    // swiftlint:disable:next missing_docs
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.kind == rhs.kind
     }

--- a/Sources/Player/UserInterface/LazyImage.swift
+++ b/Sources/Player/UserInterface/LazyImage.swift
@@ -13,6 +13,7 @@ public struct LazyImage<Content>: View where Content: View {
     private let source: ImageSource
     private let content: (Image) -> Content
 
+    // swiftlint:disable:next missing_docs
     public var body: some View {
         if let image = source.image {
             content(Image(uiImage: image))

--- a/Sources/Player/UserInterface/PictureInPictureButton.swift
+++ b/Sources/Player/UserInterface/PictureInPictureButton.swift
@@ -19,6 +19,7 @@ public struct PictureInPictureButton<Content>: View where Content: View {
     @State private var isPossible = false
     @State private var isActive = false
 
+    // swiftlint:disable:next missing_docs
     public var body: some View {
         Group {
             if isPossible && PictureInPicture.shared.persistable != nil {

--- a/Sources/Player/UserInterface/RoutePickerView.swift
+++ b/Sources/Player/UserInterface/RoutePickerView.swift
@@ -30,6 +30,7 @@ public struct RoutePickerView: View {
     private var prioritizesVideoDevices: Bool
     private var activeTintColor: Color?
 
+    // swiftlint:disable:next missing_docs
     public var body: some View {
         if !ProcessInfo.processInfo.isRunningOnMac {
             _RoutePickerView(prioritizesVideoDevices: prioritizesVideoDevices, activeTintColor: activeTintColor)

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -16,6 +16,7 @@ public struct SystemVideoView<VideoOverlay>: View where VideoOverlay: View {
     private var supportsPictureInPicture = false
     private var contextualActions: [UIAction] = []
 
+    // swiftlint:disable:next missing_docs
     public var body: some View {
         ZStack {
             if supportsPictureInPicture {

--- a/Sources/Player/UserInterface/VideoView.swift
+++ b/Sources/Player/UserInterface/VideoView.swift
@@ -18,6 +18,7 @@ public struct VideoView: View {
     private var supportsPictureInPicture = false
     private var orientation: SCNQuaternion = .monoscopicDefault
 
+    // swiftlint:disable:next missing_docs
     public var body: some View {
         ZStack {
             switch player.metadata.viewport {

--- a/Tests/MonitoringTests/MetricPayload.swift
+++ b/Tests/MonitoringTests/MetricPayload.swift
@@ -7,6 +7,7 @@
 @testable import PillarboxMonitoring
 
 extension MetricPayload: CustomDebugStringConvertible {
+    // swiftlint:disable:next missing_docs
     public var debugDescription: String {
         eventName.rawValue
     }

--- a/Tests/PlayerTests/Tools/Similarity.swift
+++ b/Tests/PlayerTests/Tools/Similarity.swift
@@ -11,6 +11,7 @@ import PillarboxCircumspect
 import UIKit
 
 extension ImageSource: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: ImageSource, rhs: ImageSource) -> Bool {
         switch (lhs.kind, rhs.kind) {
         case (.none, .none):
@@ -35,6 +36,7 @@ extension ImageSource: Similar {
 }
 
 extension Resource: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: PillarboxPlayer.Resource, rhs: PillarboxPlayer.Resource) -> Bool {
         switch (lhs, rhs) {
         case let (.simple(url: lhsUrl), .simple(url: rhsUrl)),
@@ -48,6 +50,7 @@ extension Resource: Similar {
 }
 
 extension NowPlaying.Info: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: Self, rhs: Self) -> Bool {
         // swiftlint:disable:next legacy_objc_type
         NSDictionary(dictionary: lhs).isEqual(to: rhs)
@@ -55,6 +58,7 @@ extension NowPlaying.Info: Similar {
 }
 
 extension MetricEvent: Similar {
+    // swiftlint:disable:next missing_docs
     public static func ~~ (lhs: MetricEvent, rhs: MetricEvent) -> Bool {
         switch (lhs.kind, rhs.kind) {
         case (.metadata, .metadata), (.asset, .asset), (.failure, .failure), (.warning, .warning):


### PR DESCRIPTION
## Description

This PR improves SwiftLint `missing_docs` detection by disabling `excludes_inherited_types`. This means public inherited methods or methods adopted through protocol conformance will be reported if missing documentation. This will make sure we don't miss any public documentation at all, which was previously possible.

For inherited methods we will mark methods with `swiftlint:disable:next missing_docs` to avoid duplicating documentation unnecessarily.

## Changes made

- Update SwiftLint configuration.
- Fix missing documentation.
- Inhibit issues where appropriate.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
