### PR TITLE
Clamp the player buffer

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -707,8 +707,7 @@ private struct TimeSlider: View {
     }
 
     private func sliderBackground() -> some View {
-        Rectangle()
-            .foregroundColor(.white)
+        Color.white
             .opacity(0.1)
             .background(.ultraThinMaterial)
     }
@@ -718,8 +717,7 @@ private struct TimeSlider: View {
         if progressTracker.timeRange.isValid {
             let duration = progressTracker.timeRange.duration.seconds
             ForEach(player.metadata.timeRanges, id: \.self) { timeRange in
-                Rectangle()
-                    .foregroundColor(Self.color(for: timeRange))
+                Self.color(for: timeRange)
                     .opacity(0.7)
                     .frame(width: width * CGFloat(timeRange.duration.seconds / duration))
                     .offset(x: width * CGFloat(timeRange.start.seconds / duration))
@@ -728,16 +726,14 @@ private struct TimeSlider: View {
     }
 
     private func sliderBuffer(width: CGFloat) -> some View {
-        Rectangle()
-            .foregroundColor(.white)
+        Color.white
             .opacity(0.3)
             .frame(width: CGFloat(buffer) * width)
             .animation(.linear(duration: 0.5), value: buffer)
     }
 
     private func sliderTrack(progress: CGFloat, width: CGFloat) -> some View {
-        Rectangle()
-            .foregroundColor(.white)
+        Color.white
             .frame(width: progress * width)
     }
 

--- a/Sources/Player/Types/TimeProperties.swift
+++ b/Sources/Player/Types/TimeProperties.swift
@@ -26,7 +26,7 @@ extension TimeProperties {
     var buffer: Float {
         let duration = seekableTimeRange.duration
         guard loadedTimeRange.end.isNumeric, duration.isNumeric, duration != .zero else { return 0 }
-        return Float(loadedTimeRange.end.seconds / duration.seconds)
+        return Float(loadedTimeRange.end.seconds / duration.seconds).clamped(to: 0...1)
     }
 
     static func timeRange(from timeRanges: [NSValue]) -> CMTimeRange? {

--- a/Tests/PlayerTests/Types/TimePropertiesTests.swift
+++ b/Tests/PlayerTests/Types/TimePropertiesTests.swift
@@ -15,7 +15,7 @@ final class TimePropertiesTests: TestCase {
     }
 
     func testTimeRange() {
-        expect(TimeProperties.timeRange(from: [NSValue(timeRange: .finite)])).to(equal(.finite))
+        expect(TimeProperties.timeRange(from: [NSValue(timeRange: .oneSecond)])).to(equal(.oneSecond))
     }
 
     func testTimeRanges() {
@@ -34,7 +34,7 @@ final class TimePropertiesTests: TestCase {
     func testSeekableTimeRangeFallback() {
         expect(
             TimeProperties.timeRange(
-                loadedTimeRanges: [NSValue(timeRange: .finite)],
+                loadedTimeRanges: [NSValue(timeRange: .oneSecond)],
                 seekableTimeRanges: []
             )
         )
@@ -45,7 +45,7 @@ final class TimePropertiesTests: TestCase {
         expect(
             TimeProperties(
                 loadedTimeRanges: [],
-                seekableTimeRanges: [NSValue(timeRange: .finite)],
+                seekableTimeRanges: [NSValue(timeRange: .oneSecond)],
                 isPlaybackLikelyToKeepUp: true
             ).buffer
         )
@@ -55,8 +55,19 @@ final class TimePropertiesTests: TestCase {
     func testBuffer() {
         expect(
             TimeProperties(
-                loadedTimeRanges: [NSValue(timeRange: .finite)],
-                seekableTimeRanges: [NSValue(timeRange: .finite)],
+                loadedTimeRanges: [NSValue(timeRange: .oneSecond)],
+                seekableTimeRanges: [NSValue(timeRange: .oneSecond)],
+                isPlaybackLikelyToKeepUp: true
+            ).buffer
+        )
+        .to(equal(1))
+    }
+
+    func testBufferClamped() {
+        expect(
+            TimeProperties(
+                loadedTimeRanges: [NSValue(timeRange: .twoSeconds)],
+                seekableTimeRanges: [NSValue(timeRange: .oneSecond)],
                 isPlaybackLikelyToKeepUp: true
             ).buffer
         )
@@ -65,5 +76,6 @@ final class TimePropertiesTests: TestCase {
 }
 
 private extension CMTimeRange {
-    static let finite = Self(start: .zero, duration: .init(value: 1, timescale: 1))
+    static let oneSecond = Self(start: .zero, duration: .init(value: 1, timescale: 1))
+    static let twoSeconds = Self(start: .zero, duration: .init(value: 2, timescale: 1))
 }


### PR DESCRIPTION
## Description

This PR allows us to clamp the player buffer to prevent potential overflows.

## Changes made

- Clamped the player buffer.
- Use colors instead of shapes for the playback slider.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
