### PR TITLE
Capture properties at the time tracking methods are called

### DIFF
--- a/Demo/Sources/Analytics/DemoTracker.swift
+++ b/Demo/Sources/Analytics/DemoTracker.swift
@@ -28,14 +28,14 @@ final class DemoTracker: PlayerItemTracker {
         Self.logger.debug("Update demo tracker metadata for \(self.id): \(metadata.title)")
     }
 
-    func updateProperties(to properties: PlayerProperties) {}
+    func updateProperties(to properties: TrackerProperties) {}
 
     func updateMetricEvents(to events: [MetricEvent]) {
         Self.logger.debug("Update demo tracker metric events for \(self.id): \(events)")
     }
 
-    func disable(with properties: PlayerProperties) {
-        Self.logger.debug("Disable demo tracker for \(self.id) - \(properties.time().seconds)")
+    func disable(with properties: TrackerProperties) {
+        Self.logger.debug("Disable demo tracker for \(self.id)) - \(properties.time.seconds)")
     }
 
     deinit {

--- a/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
+++ b/Sources/Analytics/ComScore/ComScoreStreamingAnalytics.swift
@@ -19,15 +19,15 @@ final class ComScoreStreamingAnalytics: SCORStreamingAnalytics {
 }
 
 extension ComScoreStreamingAnalytics {
-    private static func duration(from properties: PlayerProperties) -> Int {
+    private static func duration(from properties: TrackerProperties) -> Int {
         Int(properties.seekableTimeRange.duration.timeInterval().toMilliseconds)
     }
 
-    private static func position(from properties: PlayerProperties) -> Int {
-        Int(properties.time().timeInterval().toMilliseconds)
+    private static func position(from properties: TrackerProperties) -> Int {
+        Int(properties.time.timeInterval().toMilliseconds)
     }
 
-    private static func offset(from properties: PlayerProperties) -> Int {
+    private static func offset(from properties: TrackerProperties) -> Int {
         Int(properties.endOffset().timeInterval().toMilliseconds)
     }
 
@@ -45,7 +45,7 @@ extension ComScoreStreamingAnalytics {
         }
     }
 
-    func setPlaybackPosition(from properties: PlayerProperties) {
+    func setPlaybackPosition(from properties: TrackerProperties) {
         if properties.streamType == .dvr {
             start(fromDvrWindowOffset: Self.offset(from: properties))
             setDVRWindowLength(Self.duration(from: properties))

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -32,7 +32,7 @@ public final class ComScoreTracker: PlayerItemTracker {
     }
 
     // swiftlint:disable:next missing_docs
-    public func updateProperties(to properties: PlayerProperties) {
+    public func updateProperties(to properties: TrackerProperties) {
         guard !metadata.isEmpty else { return }
 
         AnalyticsListener.capture(streamingAnalytics.configuration())
@@ -57,7 +57,7 @@ public final class ComScoreTracker: PlayerItemTracker {
     public func updateMetricEvents(to events: [MetricEvent]) {}
 
     // swiftlint:disable:next missing_docs
-    public func disable(with properties: PlayerProperties) {
+    public func disable(with properties: TrackerProperties) {
         streamingAnalytics = ComScoreStreamingAnalytics()
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActHeartbeat.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActHeartbeat.swift
@@ -13,7 +13,7 @@ final class CommandersActHeartbeat {
     private let posInterval: TimeInterval
     private let uptimeInterval: TimeInterval
 
-    private var properties: PlayerProperties?
+    private var properties: TrackerProperties?
     private var cancellable: AnyCancellable?
 
     init(delay: TimeInterval = 30, posInterval: TimeInterval = 30, uptimeInterval: TimeInterval = 60) {
@@ -22,7 +22,7 @@ final class CommandersActHeartbeat {
         self.uptimeInterval = uptimeInterval
     }
 
-    func update(with properties: PlayerProperties, labels: @escaping (PlayerProperties) -> [String: String]) {
+    func update(with properties: TrackerProperties, labels: @escaping (TrackerProperties) -> [String: String]) {
         self.properties = properties
 
         if properties.playbackState == .playing {
@@ -41,7 +41,7 @@ final class CommandersActHeartbeat {
         cancellable = nil
     }
 
-    private func sendEvent(_ event: Event, labels: @escaping (PlayerProperties) -> [String: String]) {
+    private func sendEvent(_ event: Event, labels: @escaping (TrackerProperties) -> [String: String]) {
         guard let properties else { return }
         Analytics.shared.sendEvent(commandersAct: .init(
             name: event.rawValue,
@@ -67,7 +67,7 @@ private extension CommandersActHeartbeat {
     }
 
     static func eventPublisher(
-        for properties: PlayerProperties,
+        for properties: TrackerProperties,
         delay: TimeInterval,
         posInterval: TimeInterval,
         uptimeInterval: TimeInterval

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -34,7 +34,7 @@ public final class CommandersActTracker: PlayerItemTracker {
     }
 
     // swiftlint:disable:next missing_docs
-    public func updateProperties(to properties: PlayerProperties) {
+    public func updateProperties(to properties: TrackerProperties) {
         if properties.isSeeking {
             notify(.seek, properties: properties)
         }
@@ -56,20 +56,20 @@ public final class CommandersActTracker: PlayerItemTracker {
     public func updateMetricEvents(to events: [MetricEvent]) {}
 
     // swiftlint:disable:next missing_docs
-    public func disable(with properties: PlayerProperties) {
+    public func disable(with properties: TrackerProperties) {
         notify(.stop, properties: properties)
         reset()
     }
 }
 
 private extension CommandersActTracker {
-    func notify(_ event: Event, properties: PlayerProperties) {
+    func notify(_ event: Event, properties: TrackerProperties) {
         updateStopwatch(event: event, properties: properties)
         sendEventIfNeeded(event: event, properties: properties)
         heartbeat.update(with: properties, labels: labels)
     }
 
-    func updateStopwatch(event: Event, properties: PlayerProperties) {
+    func updateStopwatch(event: Event, properties: TrackerProperties) {
         if event == .play && !properties.isBuffering {
             stopwatch.start()
         }
@@ -78,7 +78,7 @@ private extension CommandersActTracker {
         }
     }
 
-    func sendEventIfNeeded(event: Event, properties: PlayerProperties) {
+    func sendEventIfNeeded(event: Event, properties: TrackerProperties) {
         guard event != lastEvent else { return }
 
         switch (lastEvent, event) {
@@ -103,7 +103,7 @@ private extension CommandersActTracker {
 }
 
 private extension CommandersActTracker {
-    func labels(from properties: PlayerProperties) -> [String: String] {
+    func labels(from properties: TrackerProperties) -> [String: String] {
         var labels = metadata
 
         labels["media_player_display"] = "Pillarbox"
@@ -131,12 +131,12 @@ private extension CommandersActTracker {
         return labels
     }
 
-    func volume(from properties: PlayerProperties) -> String {
+    func volume(from properties: TrackerProperties) -> String {
         guard !properties.isMuted else { return "0" }
         return String(Int(AVAudioSession.sharedInstance().outputVolume * 100))
     }
 
-    func audioTrack(from properties: PlayerProperties) -> String {
+    func audioTrack(from properties: TrackerProperties) -> String {
         if case let .on(option) = properties.currentMediaOption(for: .audible) {
             return languageCode(from: option)
         }
@@ -145,7 +145,7 @@ private extension CommandersActTracker {
         }
     }
 
-    func audioDescription(from properties: PlayerProperties) -> String {
+    func audioDescription(from properties: TrackerProperties) -> String {
         if case let .on(option) = properties.currentMediaOption(for: .audible), option.hasMediaCharacteristic(.describesVideoForAccessibility) {
             return "true"
         }
@@ -154,7 +154,7 @@ private extension CommandersActTracker {
         }
     }
 
-    func subtitleOn(from properties: PlayerProperties) -> String {
+    func subtitleOn(from properties: TrackerProperties) -> String {
         if case let .on(option) = properties.currentMediaOption(for: .legible), !option.hasMediaCharacteristic(.containsOnlyForcedSubtitles) {
             return "true"
         }
@@ -163,7 +163,7 @@ private extension CommandersActTracker {
         }
     }
 
-    func subtitleSelection(from properties: PlayerProperties) -> String? {
+    func subtitleSelection(from properties: TrackerProperties) -> String? {
         if case let .on(option) = properties.currentMediaOption(for: .legible), !option.hasMediaCharacteristic(.containsOnlyForcedSubtitles) {
             return languageCode(from: option)
         }
@@ -172,15 +172,15 @@ private extension CommandersActTracker {
         }
     }
 
-    func mediaPosition(from properties: PlayerProperties) -> Int {
-        Int(properties.time().timeInterval())
+    func mediaPosition(from properties: TrackerProperties) -> Int {
+        Int(properties.time.timeInterval())
     }
 
     func playbackDuration() -> Int {
         Int(stopwatch.time())
     }
 
-    func timeshiftOffset(from properties: PlayerProperties) -> Int {
+    func timeshiftOffset(from properties: TrackerProperties) -> Int {
         Int(properties.endOffset().timeInterval())
     }
 

--- a/Sources/Analytics/Extensions/TrackerProperties.swift
+++ b/Sources/Analytics/Extensions/TrackerProperties.swift
@@ -7,8 +7,8 @@
 import CoreMedia
 import PillarboxPlayer
 
-extension PlayerProperties {
+extension TrackerProperties {
     func endOffset() -> CMTime {
-        max(seekableTimeRange.end - time(), .zero)
+        max(seekableTimeRange.end - time, .zero)
     }
 }

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -16,7 +16,7 @@ public final class MetricsTracker: PlayerItemTracker {
     private let stopwatch = Stopwatch()
 
     private var metadata: Metadata?
-    private var properties: PlayerProperties?
+    private var properties: TrackerProperties?
 
     private var session = TrackingSession()
     private var stallDate: Date?
@@ -43,7 +43,7 @@ public final class MetricsTracker: PlayerItemTracker {
     }
 
     // swiftlint:disable:next missing_docs
-    public func updateProperties(to properties: PlayerProperties) {
+    public func updateProperties(to properties: TrackerProperties) {
         self.properties = properties
         updateStopwatch(with: properties)
     }
@@ -74,7 +74,7 @@ public final class MetricsTracker: PlayerItemTracker {
     }
 
     // swiftlint:disable:next missing_docs
-    public func disable(with properties: PlayerProperties) {
+    public func disable(with properties: TrackerProperties) {
         reset(with: properties)
     }
 }
@@ -149,13 +149,13 @@ private extension MetricsTracker {
             name: "\(error.domain)(\(error.code))",
             position: Self.position(from: properties),
             positionTimestamp: Self.positionTimestamp(from: properties),
-            url: URL(string: properties?.metrics()?.uri),
+            url: URL(string: properties?.metrics?.uri),
             vpn: Self.isUsingVirtualPrivateNetwork()
         )
     }
 
-    func statusData(from properties: PlayerProperties) -> MetricStatusData {
-        let metrics = properties.metrics()
+    func statusData(from properties: TrackerProperties) -> MetricStatusData {
+        let metrics = properties.metrics
         return MetricStatusData(
             airplay: properties.isExternalPlaybackActive,
             bandwidth: metrics?.observedBitrate,
@@ -175,7 +175,7 @@ private extension MetricsTracker {
         )
     }
 
-    func updateStopwatch(with properties: PlayerProperties) {
+    func updateStopwatch(with properties: TrackerProperties) {
         if properties.playbackState == .playing && !properties.isBuffering {
             stopwatch.start()
         }
@@ -184,7 +184,7 @@ private extension MetricsTracker {
         }
     }
 
-    func reset(with properties: PlayerProperties?) {
+    func reset(with properties: TrackerProperties?) {
         defer {
             stallDuration = 0
             session.reset()
@@ -269,7 +269,7 @@ private extension MetricsTracker {
 }
 
 private extension MetricsTracker {
-    static func streamType(from properties: PlayerProperties) -> String? {
+    static func streamType(from properties: TrackerProperties) -> String? {
         switch properties.streamType {
         case .unknown:
             return nil
@@ -280,30 +280,30 @@ private extension MetricsTracker {
         }
     }
 
-    static func position(from properties: PlayerProperties?) -> Int? {
+    static func position(from properties: TrackerProperties?) -> Int? {
         guard let properties else { return nil }
         switch properties.streamType {
         case .unknown:
             return nil
         case .onDemand:
-            return properties.time().toMilliseconds
+            return properties.time.toMilliseconds
         case .live:
             return 0
         case .dvr:
-            return (properties.time() - properties.seekableTimeRange.start).toMilliseconds
+            return (properties.time - properties.seekableTimeRange.start).toMilliseconds
         }
     }
 
-    static func positionTimestamp(from properties: PlayerProperties?) -> Int? {
-        guard let date = properties?.date() else { return nil }
+    static func positionTimestamp(from properties: TrackerProperties?) -> Int? {
+        guard let date = properties?.date else { return nil }
         return date.timestamp
     }
 
-    static func bufferedDuration(from properties: PlayerProperties?) -> Int? {
+    static func bufferedDuration(from properties: TrackerProperties?) -> Int? {
         properties?.loadedTimeRange.duration.toMilliseconds
     }
 
-    static func duration(from properties: PlayerProperties) -> Int? {
+    static func duration(from properties: TrackerProperties) -> Int? {
         properties.seekableTimeRange.duration.toMilliseconds
     }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -291,7 +291,12 @@ extension PlayerItem {
 
     func updateTrackersProperties(matchingBehavior behavior: TrackingBehavior, to properties: PlayerProperties) {
         trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.updateProperties(to: properties)
+            adapter.updateProperties(to: .init(
+                playerProperties: properties,
+                time: properties.time(),
+                date: properties.date(),
+                metrics: properties.metrics()
+            ))
         }
     }
 
@@ -303,7 +308,12 @@ extension PlayerItem {
 
     func disableTrackers(matchingBehavior behavior: TrackingBehavior, with properties: PlayerProperties) {
         trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.disable(with: properties)
+            adapter.disable(with: .init(
+                playerProperties: properties,
+                time: properties.time(),
+                date: properties.date(),
+                metrics: properties.metrics()
+            ))
         }
     }
 

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -56,7 +56,7 @@ public protocol PlayerItemTracker: AnyObject {
     ///
     /// This method can be called quite often, but only when the tracker is active. Implementations should avoid
     /// performing significant work unnecessarily.
-    func updateProperties(to properties: PlayerProperties)
+    func updateProperties(to properties: TrackerProperties)
 
     /// A method called when metric events are updated.
     ///
@@ -68,7 +68,7 @@ public protocol PlayerItemTracker: AnyObject {
     /// A method called when the tracker is disabled.
     ///
     /// - Parameter properties: The updated properties.
-    func disable(with properties: PlayerProperties)
+    func disable(with properties: TrackerProperties)
 }
 
 public extension PlayerItemTracker {

--- a/Sources/Player/Tracking/PlayerItemTracking.swift
+++ b/Sources/Player/Tracking/PlayerItemTracking.swift
@@ -11,7 +11,7 @@ protocol PlayerItemTracking {
     var registration: TrackingRegistration? { get }
 
     func enable(for player: AVPlayer)
-    func updateProperties(to properties: PlayerProperties)
+    func updateProperties(to properties: TrackerProperties)
     func updateMetricEvents(to events: [MetricEvent])
-    func disable(with properties: PlayerProperties)
+    func disable(with properties: TrackerProperties)
 }

--- a/Sources/Player/Tracking/TrackerAdapter.swift
+++ b/Sources/Player/Tracking/TrackerAdapter.swift
@@ -46,7 +46,7 @@ extension TrackerAdapter: PlayerItemTracking {
         tracker.enable(for: player)
     }
 
-    func updateProperties(to properties: PlayerProperties) {
+    func updateProperties(to properties: TrackerProperties) {
         tracker.updateProperties(to: properties)
     }
 
@@ -54,7 +54,7 @@ extension TrackerAdapter: PlayerItemTracking {
         tracker.updateMetricEvents(to: events)
     }
 
-    func disable(with properties: PlayerProperties) {
+    func disable(with properties: TrackerProperties) {
         tracker.disable(with: properties)
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActHeartbeatTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActHeartbeatTests.swift
@@ -8,7 +8,7 @@
 
 import Combine
 import Nimble
-import PillarboxPlayer
+@testable import PillarboxPlayer
 import PillarboxStreams
 
 final class CommandersActHeartbeatTests: CommandersActTestCase {
@@ -19,7 +19,7 @@ final class CommandersActHeartbeatTests: CommandersActTestCase {
         let player = Player(item: .simple(url: stream.url))
         player.propertiesPublisher
             .sink { properties in
-                heartbeat.update(with: properties) { properties in
+                heartbeat.update(with: .init(playerProperties: properties, time: .zero, date: nil, metrics: nil)) { properties in
                     ["media_volume": properties.isMuted ? "0" : "100"]
                 }
             }

--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -70,6 +70,6 @@ final class PlayerTests: TestCase {
 
     func testNoMetricsWhenFailed() {
         let player = Player(item: .failing(loadedAfter: 0.1))
-        expect(player.properties.metrics()).toAlways(beNil(), until: .seconds(1))
+        expect(player.metrics()).toAlways(beNil(), until: .seconds(1))
     }
 }

--- a/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
+++ b/Tests/PlayerTests/Tools/PlayerItemTrackerMock.swift
@@ -43,7 +43,7 @@ final class PlayerItemTrackerMock: PlayerItemTracker {
 
     func updateMetadata(to metadata: Void) {}
 
-    func updateProperties(to properties: PlayerProperties) {}
+    func updateProperties(to properties: TrackerProperties) {}
 
     func updateMetricEvents(to events: [MetricEvent]) {
         guard !events.isEmpty else { return }
@@ -54,7 +54,7 @@ final class PlayerItemTrackerMock: PlayerItemTracker {
         configuration.statePublisher.send(.enabled)
     }
 
-    func disable(with properties: PlayerProperties) {
+    func disable(with properties: TrackerProperties) {
         configuration.statePublisher.send(.disabled)
     }
 

--- a/Tests/PlayerTests/Tools/TrackerUpdateMock.swift
+++ b/Tests/PlayerTests/Tools/TrackerUpdateMock.swift
@@ -37,13 +37,13 @@ final class TrackerUpdateMock<Metadata>: PlayerItemTracker where Metadata: Equat
         configuration.statePublisher.send(.updatedMetadata(metadata))
     }
 
-    func updateProperties(to properties: PlayerProperties) {
+    func updateProperties(to properties: TrackerProperties) {
         configuration.statePublisher.send(.updatedProperties)
     }
 
     func updateMetricEvents(to events: [MetricEvent]) {}
 
-    func disable(with properties: PlayerProperties) {
+    func disable(with properties: TrackerProperties) {
         configuration.statePublisher.send(.disabled)
     }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with property information publicly accessible but whose values depend on the time at which the corresponding methods are called:

- `time()`
- `date()`
- `metrics()`

This is risky since tracker implementations (which are the primary beneficiaries of such information) might use values that do not match the time at which an event should have been triggered.

To enforce correct usage this PR hides the functions listed above from `PlayerProperties` public interface and introduces a `TrackerProperties` which captures the values at the time a tracker update is triggered. To make `TrackerProperties` as convenient to use as `PlayerProperties` most of its API simply forwards calls to the underlying `PlayerProperties`.

## Changes made

- Hide functions from `PlayerProperties` public interface to avoid incorrect usage.
- Add `TrackerProperties`.
- Update tracker-related code to use `TrackerProperties` instead of `PlayerProperties`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
