### PR TITLE
Replace `navigation_bu_distributer` with `content_bu_owner`

### DIFF
--- a/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
@@ -42,8 +42,8 @@ public struct CommandersActLabels: Decodable {
     /// The value of `navigation_property_type`.
     public let navigation_property_type: String?
 
-    /// The value of `navigation_bu_distributer`.
-    public let navigation_bu_distributer: String?
+    /// The value of `content_bu_owner`.
+    public let content_bu_owner: String?
 
     /// The value of `navigation_level_0`.
     public let navigation_level_0: String?
@@ -137,7 +137,7 @@ private extension CommandersActLabels {
         case navigation_device
         case consent_services
         case navigation_property_type
-        case navigation_bu_distributer
+        case content_bu_owner
         case navigation_level_0
         case navigation_level_1
         case navigation_level_2

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -34,7 +34,7 @@ final class CommandersActService {
         }
         event.pageName = pageView.name
         event.addNonBlankAdditionalProperty("navigation_property_type", withStringValue: "app")
-        event.addNonBlankAdditionalProperty("navigation_bu_distributer", withStringValue: vendor?.rawValue)
+        event.addNonBlankAdditionalProperty("content_bu_owner", withStringValue: vendor?.rawValue)
         pageView.levels.enumerated().forEach { index, level in
             guard index < 8 else { return }
             event.addNonBlankAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -54,7 +54,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(labels.app_library_version).to(equal(Analytics.version))
                 expect(labels.navigation_app_site_name).to(equal("site"))
                 expect(labels.navigation_property_type).to(equal("app"))
-                expect(labels.navigation_bu_distributer).to(equal("SRG"))
+                expect(labels.content_bu_owner).to(equal("SRG"))
                 expect(labels.consent_services).to(equal("service1,service2,service3"))
             }
         ) {


### PR DESCRIPTION
## Description

This PR renames field `navigation_bu_distributer` to `content_bu_owner` for **CommandersAct** page view tracking.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
