### PR TITLE
Support actions associated with menu interactions

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -452,7 +452,7 @@ private struct SettingsMenu: View {
 
     var body: some View {
         Menu {
-            player.standardSettingMenu()
+            player.standardSettingsMenu()
             QualityMenu(player: player)
             metricsMenu()
         } label: {

--- a/Sources/Player/Player.docc/Articles/playback-speed-article.md
+++ b/Sources/Player/Player.docc/Articles/playback-speed-article.md
@@ -22,7 +22,7 @@ To adjust the playback speed programmatically, use the ``Player/setDesiredPlayba
 
 When building a playback user interface, one of the most common requirements is to provide users with the ability to change the playback speed.
 
-For a quick implementation, you can use the standard system player experience by calling ``Player/standardSettingMenu()``. Wrap the returned view in a [Menu](https://developer.apple.com/documentation/swiftui/menu) to that offers not only playback speed selection but also media options for audible and legible characteristics.
+For a quick implementation, you can use the standard system player experience by calling ``Player/standardSettingsMenu()``. Wrap the returned view in a [Menu](https://developer.apple.com/documentation/swiftui/menu) to that offers not only playback speed selection but also media options for audible and legible characteristics.
 
 If you want more customization, you can create your own menu using ``Player/playbackSpeedMenu(speeds:)``. This allows you to tailor the list of speed options to your app’s needs.
 

--- a/Sources/Player/Player.docc/Articles/subtitles-and-alternative-audio-tracks-article.md
+++ b/Sources/Player/Player.docc/Articles/subtitles-and-alternative-audio-tracks-article.md
@@ -41,7 +41,7 @@ To override default preferences, call ``Player/setMediaSelection(preferredLangua
 
 For most playback user interfaces, all you need is a way to let users switch subtitles or audio tracks:
 
-- To replicate the standard system player experience, use ``Player/standardSettingMenu()`` and embed its result in a [Menu](https://developer.apple.com/documentation/swiftui/menu). This menu includes options for media selection and playback speed.
+- To replicate the standard system player experience, use ``Player/standardSettingsMenu()`` and embed its result in a [Menu](https://developer.apple.com/documentation/swiftui/menu). This menu includes options for media selection and playback speed.
 - To customize menus further, use ``Player/mediaSelectionMenu(characteristic:)`` to retrieve a submenu for a specific characteristic.
 - For complete control, use the media selection APIs to build a fully custom interface.
 

--- a/Sources/Player/Player.docc/Extensions/player-extension.md
+++ b/Sources/Player/Player.docc/Extensions/player-extension.md
@@ -139,4 +139,4 @@
 
 - ``mediaSelectionMenu(characteristic:)``
 - ``playbackSpeedMenu(speeds:)``
-- ``standardSettingMenu()``
+- ``standardSettingsMenu()``

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -149,7 +149,7 @@ public extension Player {
     /// behavior.
     func playbackSpeedMenu(
         speeds: Set<Float> = [0.5, 1, 1.25, 1.5, 2],
-        action: @escaping (_ playbackSpeed: Float) -> Void = { _ in }
+        action: @escaping (_ speed: Float) -> Void = { _ in }
     ) -> some View {
         PlaybackSpeedMenuContent(speeds: speeds, action: action, player: self)
     }

--- a/Sources/Player/UserInterface/SettingsMenu.swift
+++ b/Sources/Player/UserInterface/SettingsMenu.swift
@@ -112,7 +112,7 @@ public extension Player {
     ///
     /// The returned view is meant to be used as content of a `Menu`. Using it for any other purpose has undefined
     /// behavior.
-    func standardSettingMenu() -> some View {
+    func standardSettingsMenu() -> some View {
         SettingsMenuContent(player: self)
     }
 


### PR DESCRIPTION
## Description

This PR improves our settings menu APIs to better support user choice persistence associated with item selection.

Only the playback speed and media selection submenu APIs have been updated to support custom actions. The top-level standard menu API is meant to offer a vanilla experience (standard playback speeds, no actions) and has not been updated, especially since building such a menu with the other available APIs is straightforward.

## Changes made

- Add `action` closures to menu creation methods.
- Rename `standardSettingMenu()` as `standardSettingsMenu()`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
