### PR TITLE
Return Control Center to the system when not needed anymore

### DIFF
--- a/Sources/Player/ControlCenter/NowPlaying.swift
+++ b/Sources/Player/ControlCenter/NowPlaying.swift
@@ -4,20 +4,33 @@
 //  License information is available from the LICENSE file.
 //
 
+import MediaPlayer
+
 /// Metadata describing what is currently being played.
-struct NowPlaying {
+enum NowPlaying {
+    case empty
+    case filled(metadata: PlayerMetadata, playbackInfo: Info)
+
     typealias Info = [String: Any]
 
-    static let empty = Self(metadata: .empty, playbackInfo: [:])
-
-    let metadata: PlayerMetadata
-    let playbackInfo: Info
-
-    var isEmpty: Bool {
-        metadata == .empty && playbackInfo.isEmpty
+    var info: Info {
+        switch self {
+        case .empty:
+            [:]
+        case let .filled(metadata, playbackInfo):
+            metadata.nowPlayingInfo
+                .merging(playbackInfo) { _, new in new }
+                // For proper Control Center integration at least one metadata key must be filled.
+                .merging([MPMediaItemPropertyTitle: ""]) { old, _ in old }
+        }
     }
 
-    var info: Info {
-        metadata.nowPlayingInfo.merging(playbackInfo) { _, new in new }
+    var isEmpty: Bool {
+        switch self {
+        case .empty:
+            true
+        default:
+            false
+        }
     }
 }

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -134,14 +134,14 @@ extension Player {
     }
 
     func nowPlayingPublisher() -> AnyPublisher<NowPlaying, Never> {
-        $isActive
-            .map { [weak self] isActive in
-                guard let self, isActive else { return Just(NowPlaying.empty).eraseToAnyPublisher() }
+        Publishers.CombineLatest($isActive, queuePublisher)
+            .map { [weak self] isActive, queue in
+                guard let self, isActive, !queue.isActive else { return Just(NowPlaying.empty).eraseToAnyPublisher() }
                 return Publishers.CombineLatest(
                     metadataPublisher,
                     nowPlayingInfoPlaybackPublisher()
                 )
-                .map { NowPlaying(metadata: $0, playbackInfo: $1) }
+                .map { NowPlaying.filled(metadata: $0, playbackInfo: $1) }
                 .eraseToAnyPublisher()
             }
             .switchToLatest()

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -120,14 +120,13 @@ extension Player {
         propertiesPublisher
             .map { [weak queuePlayer] properties in
                 var nowPlayingInfo = NowPlaying.Info()
-                // Always fill a key so that the Control Center can be enabled for the item, even if it has no associated metadata.
-                nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = (properties.streamType == .live)
                 if properties.streamType != .unknown {
                     nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = properties.isBuffering ? 0 : properties.rate
                     if let time = properties.seekTime ?? queuePlayer?.currentTime(), time.isValid {
                         nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = (time - properties.seekableTimeRange.start).seconds
                     }
                     nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = properties.seekableTimeRange.duration.seconds
+                    nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = (properties.streamType == .live)
                 }
                 return nowPlayingInfo
             }

--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -46,15 +46,8 @@ private extension Player {
 
     func playRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.playCommand) { [weak self] _ in
-            guard let self else { return .commandFailed }
-            if canReplay() {
-                replay()
-                return .commandFailed
-            }
-            else {
-                play()
-                return .success
-            }
+            self?.play()
+            return .success
         }
     }
 

--- a/Sources/Player/Types/Queue.swift
+++ b/Sources/Player/Types/Queue.swift
@@ -30,6 +30,10 @@ struct Queue {
         itemState.error
     }
 
+    var isActive: Bool {
+        playerItem == nil
+    }
+
     private var playerItem: AVPlayerItem? {
         itemState.item
     }

--- a/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
@@ -30,7 +30,7 @@ final class NowPlayingInfoPublisherTests: TestCase {
     func testToggleActive() {
         let player = Player(item: .mock(url: Stream.onDemand.url, loadedAfter: 0, withMetadata: AssetMetadataMock(title: "title")))
         expectAtLeastSimilarPublished(
-            values: [[:], ["title": "title"]],
+            values: [[:], ["title": ""], ["title": "title"]],
             from: Self.nowPlayingInfoPublisher(for: player)
         ) {
             player.isActive = true

--- a/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/NowPlayingInfoPublisherTests.swift
@@ -15,6 +15,7 @@ final class NowPlayingInfoPublisherTests: TestCase {
     private static func nowPlayingInfoPublisher(for player: Player) -> AnyPublisher<NowPlaying.Info, Never> {
         player.nowPlayingPublisher()
             .map(\.info)
+            .removeDuplicates(by: ~~)
             .eraseToAnyPublisher()
     }
 
@@ -29,7 +30,7 @@ final class NowPlayingInfoPublisherTests: TestCase {
     func testToggleActive() {
         let player = Player(item: .mock(url: Stream.onDemand.url, loadedAfter: 0, withMetadata: AssetMetadataMock(title: "title")))
         expectAtLeastSimilarPublished(
-            values: [[:], [MPNowPlayingInfoPropertyIsLiveStream: false]],
+            values: [[:], ["title": "title"]],
             from: Self.nowPlayingInfoPublisher(for: player)
         ) {
             player.isActive = true


### PR DESCRIPTION
## Description

This PR improves Control Center integration by returning Control Center to the system once Pillarbox does not need it anymore. This allows any other app previously integrated with it to automatically claim ownership again.

Previously Control Center integration was preserved during item transitions. This ensured that Control Center was never returned to another app when in use, especially when navigating between playlist items from the Control Center itself. This approach was too greedy, though, and we never really properly relinquished ownership once the underlying queue player has consumed all its items.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/9a8db5e2-2231-4128-b66f-152ae7d6f528"/> | <video src="https://github.com/user-attachments/assets/377df483-0a75-4cc9-979e-731110e073ad"/> |

## Changes made

- Distinguish between item transitions (where Control Center should never be totally empty) and playback end (at which point the Control Center should be returned to the system) by observing queue updates. If there is no current `AVPlayerItem` this means playback is not currently active and Control Center must be returned to the system.
- Make this distinction obvious by replacing the `NowPlaying` struct with an enum (so that the totally empty state is now clearly identified).
- Remove replay support from the Control Center play button. When playback ends the Control Center is returned to the system, so replaying is not possible anyway.
- Avoid systematic insertion of `MPNowPlayingInfoPropertyIsLiveStream` in user info. This trick was used to preserve Control Center integration (which requires a non-empty dictionary). Instead, we now either use a totally empty dictionary (playback end) or a dictionary with at least an empty `MPMediaItemPropertyTitle` (when content is loaded in between items).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
