### PR TITLE
Support Enhance Dialogue on tvOS demo app

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -18,7 +18,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     // swiftlint:disable:next discouraged_optional_collection
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        try? AVAudioSession.sharedInstance().setCategory(.playback)
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
         UserDefaults.registerDefaults()
         configureShowTime()
         configureDataProvider()


### PR DESCRIPTION
## Description

This PR allows us to activate **Enhance Dialogue** option in the audio menu for video playback on tvOS.

## Changes made

- `moviePlayback` has been added as `AVAudioSession` mode to be eligible to the **Enhance Dialogue**.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
