### PR TITLE
Use built-in labeled content view instead of horizontal stacks where appropriate

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -7,16 +7,6 @@
     "-" : {
 
     },
-    "%@, %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@, %2$@"
-          }
-        }
-      }
-    },
     "%g× %@" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Demo/Sources/Metrics/MetricsView.swift
+++ b/Demo/Sources/Metrics/MetricsView.swift
@@ -48,16 +48,10 @@ private struct InformationSectionContent: View {
     }
 
     private func cell(_ name: LocalizedStringKey, value: String) -> some View {
-        HStack {
-            Text(name)
-            Spacer()
+        LabeledContent(name) {
             Text(value)
                 .monospacedDigit()
-                .lineLimit(1)
-                .foregroundColor(.secondary)
         }
-        .accessibilityElement()
-        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 
@@ -109,16 +103,10 @@ private struct ExperienceStartupTimesSectionContent: View {
     }
 
     private func cell(_ name: LocalizedStringKey, value: String) -> some View {
-        HStack {
-            Text(name)
-            Spacer()
+        LabeledContent(name) {
             Text(value)
                 .monospacedDigit()
-                .lineLimit(1)
-                .foregroundColor(.secondary)
         }
-        .accessibilityElement()
-        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 
@@ -146,16 +134,10 @@ private struct ServiceStartupTimesSectionContent: View {
     }
 
     private func cell(_ name: LocalizedStringKey, value: String) -> some View {
-        HStack {
-            Text(name)
-            Spacer()
+        LabeledContent(name) {
             Text(value)
                 .monospacedDigit()
-                .lineLimit(1)
-                .foregroundColor(.secondary)
         }
-        .accessibilityElement()
-        .accessibilityLabel("\(Text(name)), \(value)")
     }
 }
 

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -13,11 +13,8 @@ private struct UrlCacheView: View {
     var body: some View {
         HStack {
             Button(action: clearUrlCache) {
-                HStack {
-                    Text("Clear URL cache")
-                    Spacer()
+                LabeledContent("Clear URL cache") {
                     Text(urlCacheSize)
-                        .font(.footnote)
                         .foregroundColor(.red)
                 }
             }
@@ -52,16 +49,7 @@ private struct InfoCell: View {
     }
 
     private func content() -> some View {
-        HStack {
-            Text(title)
-            Spacer()
-            Text(value)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.trailing)
-                .lineLimit(2)
-        }
-        .accessibilityElement()
-        .accessibilityLabel("\(Text(title)), \(value)")
+        LabeledContent(title, value: value)
     }
 }
 
@@ -257,9 +245,7 @@ struct SettingsView: View {
             }
         }
 #else
-        HStack {
-            Text(key)
-            Spacer()
+        LabeledContent(key) {
             numberTextField(value: value)
         }
 #endif


### PR DESCRIPTION
## Description

This PR replaces manual label layout using `HStack`, two labels and a spacer, with the native `LabeledContent` view. This not only ensures correct appearance on all devices but also makes the view itself correctly accessible via VoiceOver for free.

## Changes made

Self-explanatory. Note that the line limit of 1 has been removed in the metrics view (URLs now appear in full).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
