### PR TITLE
Improve message view appearance

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -60,7 +60,6 @@ private struct Toolbar: View {
             nextButton()
         }
         .padding()
-        .frame(maxWidth: .infinity)
         .sheet(isPresented: $isSelectionPresented) {
             PlaylistSelectionView(model: model)
         }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -146,9 +146,7 @@ struct PlaylistView: View {
 #if os(iOS)
             if model.layout != .maximized {
                 Toolbar(model: model)
-                List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
-                    MediaCell(media: media)
-                }
+                list()
             }
 #endif
         }
@@ -159,6 +157,20 @@ struct PlaylistView: View {
         }
         .enabledForInAppPictureInPicture(persisting: model)
         .tracked(name: "playlist")
+    }
+
+    @ViewBuilder
+    private func list() -> some View {
+        ZStack {
+            if !model.medias.isEmpty {
+                List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
+                    MediaCell(media: media)
+                }
+            }
+            else {
+                MessageView(message: "No items", icon: .none)
+            }
+        }
     }
 }
 

--- a/Demo/Sources/Views/MessageViews.swift
+++ b/Demo/Sources/Views/MessageViews.swift
@@ -11,12 +11,15 @@ protocol Refreshable {
 }
 
 enum MessageIcon {
+    case none
     case error
     case empty
     case system(String)
 
-    var systemName: String {
+    var systemName: String? {
         switch self {
+        case .none:
+            return nil
         case .error:
             return "exclamationmark.bubble"
         case .empty:
@@ -32,15 +35,20 @@ struct MessageView: View {
     let icon: MessageIcon
 
     var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: icon.systemName)
-                .resizable()
-                .frame(width: 90, height: 90)
+        VStack(spacing: 16) {
+            if let systemName = icon.systemName {
+                Image(systemName: systemName)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundStyle(.secondary)
+                    .frame(height: 40)
+            }
             Text(message)
+                .font(.title2)
+                .fontWeight(.bold)
                 .multilineTextAlignment(.center)
-                .padding()
         }
-        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -61,4 +69,20 @@ struct RefreshableMessageView<Model>: View where Model: Refreshable {
         .focusable()
 #endif
     }
+}
+
+#Preview("None") {
+    MessageView(message: "No items", icon: .none)
+}
+
+#Preview("Error") {
+    MessageView(message: "No items", icon: .error)
+}
+
+#Preview("Empty") {
+    MessageView(message: "No items", icon: .empty)
+}
+
+#Preview("System") {
+    MessageView(message: "Not connected", icon: .system("wifi"))
 }

--- a/Demo/Sources/Views/MessageViews.swift
+++ b/Demo/Sources/Views/MessageViews.swift
@@ -30,6 +30,25 @@ enum MessageIcon {
     }
 }
 
+struct RefreshableMessageView<Model>: View where Model: Refreshable {
+    let model: Model
+    let message: String
+    let icon: MessageIcon
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                MessageView(message: message, icon: icon)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+            }
+            .refreshable { await model.refresh() }
+        }
+#if os(tvOS)
+        .focusable()
+#endif
+    }
+}
+
 struct MessageView: View {
     let message: String
     let icon: MessageIcon
@@ -49,25 +68,6 @@ struct MessageView: View {
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
-struct RefreshableMessageView<Model>: View where Model: Refreshable {
-    let model: Model
-    let message: String
-    let icon: MessageIcon
-
-    var body: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                MessageView(message: message, icon: icon)
-                    .frame(width: geometry.size.width, height: geometry.size.height)
-            }
-            .refreshable { await model.refresh() }
-        }
-#if os(tvOS)
-        .focusable()
-#endif
     }
 }
 


### PR DESCRIPTION
## Description

This PR enhances our custom message view appearance to more closely match `ContentUnavailableView`, which is available on iOS / tvOS 17 and above only.

## Changes made

- Update message view appearance.
- Add message-only support.
- Display message when there are no items in a playlist.
- Remove a superfluous frame added to the playlist demo toolbar.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
