### PR TITLE
Provide public API to stop Picture in Picture programmatically

### DIFF
--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -43,6 +43,12 @@ public final class PictureInPicture {
     public func startIfPossible() {
         custom.start()
     }
+
+    /// Stop Picture if Picture if running.
+    public func stop() {
+        custom.stop()
+        system.stop()
+    }
 }
 
 extension PictureInPicture: PictureInPictureDelegate {


### PR DESCRIPTION
## Description

This PR exposes a public API to stop Picture in Picture programmatically, as a companion to #1011. Unlike starting PiP, stopping works for both custom and system video views, and was never subject to App Store validation risks.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
