### PR TITLE
Improve playlist demo item insertion

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -42,6 +42,9 @@
     "Android" : {
 
     },
+    "Append" : {
+
+    },
     "Application" : {
 
     },
@@ -159,6 +162,15 @@
     "Information" : {
 
     },
+    "Insert after" : {
+
+    },
+    "Insert before" : {
+
+    },
+    "Insertion options" : {
+
+    },
     "Jump to live" : {
 
     },
@@ -202,6 +214,9 @@
 
     },
     "Mode" : {
+
+    },
+    "Multiplier" : {
 
     },
     "Next" : {
@@ -256,6 +271,9 @@
 
     },
     "Playlists" : {
+
+    },
+    "Prepend" : {
 
     },
     "Presenter mode" : {

--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -28,7 +28,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     private func configureShowTime() {
         UserDefaults.standard.publisher(for: \.presenterModeEnabled)
-            .receiveOnMainThread()
             .sink { isEnabled in
                 ShowTime.enabled = isEnabled ? .always : .never
             }
@@ -37,7 +36,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     private func configureDataProvider() {
         UserDefaults.standard.publisher(for: \.serverSetting)
-            .receiveOnMainThread()
             .sink { serverSetting in
                 SRGDataProvider.current = serverSetting.dataProvider
             }

--- a/Demo/Sources/Showcase/Playlist/PlaylistEntry.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistEntry.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import PillarboxPlayer
+
+struct PlaylistEntry: Hashable {
+    let media: Media
+    let item: PlayerItem
+
+    init(media: Media) {
+        self.media = media
+        self.item = media.item()
+    }
+}

--- a/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
@@ -6,6 +6,7 @@
 
 import SwiftUI
 
+@available(tvOS, unavailable)
 struct PlaylistSelectionView: View {
     static let medias = [
         URLMedia.onDemandVideoHLS,
@@ -57,9 +58,7 @@ struct PlaylistSelectionView: View {
         }
         .environment(\.editMode, .constant(.active))
         .navigationBarTitle("Add content")
-#if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
-#endif
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel", action: cancel)
@@ -117,6 +116,7 @@ struct PlaylistSelectionView: View {
     }
 }
 
+@available(tvOS, unavailable)
 private extension PlaylistSelectionView {
     enum InsertionOption: CaseIterable {
         case prepend

--- a/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
@@ -44,11 +44,16 @@ struct PlaylistSelectionView: View {
     let model: PlaylistViewModel
 
     @State private var selectedMedias: Set<Media> = []
+    @State private var selectedInsertionOption: InsertionOption = .append
+    @State private var multiplier = 1
+
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        List(Self.medias, id: \.self, selection: $selectedMedias) { media in
-            Text(media.title)
+        VStack {
+            picker()
+            list()
+            stepper()
         }
         .environment(\.editMode, .constant(.active))
         .navigationBarTitle("Add content")
@@ -67,12 +72,69 @@ struct PlaylistSelectionView: View {
         .tracked(name: "selection", levels: ["playlist"])
     }
 
+    private func picker() -> some View {
+        Picker("Insertion options", selection: $selectedInsertionOption) {
+            ForEach(InsertionOption.allCases, id: \.self) { option in
+                Text(option.name)
+                    .tag(option)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .padding(.bottom)
+    }
+
+    private func list() -> some View {
+        List(Self.medias, id: \.self, selection: $selectedMedias) { media in
+            Text(media.title)
+        }
+    }
+
+    private func stepper() -> some View {
+        Stepper(value: $multiplier, in: 1...100) {
+            LabeledContent("Multiplier", value: "×\(multiplier)")
+        }
+        .padding()
+    }
+
     private func cancel() {
         dismiss()
     }
 
     private func add() {
-        model.add(Array(selectedMedias))
+        let medias = Array(repeating: selectedMedias, count: multiplier).flatMap(\.self)
+        switch selectedInsertionOption {
+        case .prepend:
+            model.prepend(medias)
+        case .insertBefore:
+            model.insert(medias, before: model.currentMedia)
+        case .insertAfter:
+            model.insert(medias, after: model.currentMedia)
+        case .append:
+            model.append(medias)
+        }
         dismiss()
+    }
+}
+
+private extension PlaylistSelectionView {
+    enum InsertionOption: CaseIterable {
+        case prepend
+        case insertBefore
+        case insertAfter
+        case append
+
+        var name: LocalizedStringKey {
+            switch self {
+            case .prepend:
+                "Prepend"
+            case .insertBefore:
+                "Insert before"
+            case .insertAfter:
+                "Insert after"
+            case .append:
+                "Append"
+            }
+        }
     }
 }

--- a/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
@@ -101,7 +101,7 @@ struct PlaylistSelectionView: View {
     }
 
     private func add() {
-        let entries = Array(repeating: selectedMedias, count: multiplier).flatMap(\.self).map { PlaylistEntry(media: $0) }
+        let entries = Array(repeating: selectedMedias, count: multiplier).flatMap(\.self).map(PlaylistEntry.init)
         switch selectedInsertionOption {
         case .prepend:
             model.prepend(entries)

--- a/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
@@ -102,16 +102,16 @@ struct PlaylistSelectionView: View {
     }
 
     private func add() {
-        let medias = Array(repeating: selectedMedias, count: multiplier).flatMap(\.self)
+        let entries = Array(repeating: selectedMedias, count: multiplier).flatMap(\.self).map { PlaylistEntry(media: $0) }
         switch selectedInsertionOption {
         case .prepend:
-            model.prepend(medias)
+            model.prepend(entries)
         case .insertBefore:
-            model.insert(medias, before: model.currentMedia)
+            model.insertBeforeCurrent(entries)
         case .insertAfter:
-            model.insert(medias, after: model.currentMedia)
+            model.insertAfterCurrent(entries)
         case .append:
-            model.append(medias)
+            model.append(entries)
         }
         dismiss()
     }

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -71,69 +71,6 @@ private struct Toolbar: View {
         self.player = model.player
         self.model = model
     }
-
-    private func previousButton() -> some View {
-        Button(action: player.returnToPrevious) {
-            Image(systemName: "arrow.left")
-        }
-        .hoverEffect()
-        .accessibilityLabel("Previous")
-        .disabled(!player.canReturnToPrevious())
-    }
-
-    private func managementButtons() -> some View {
-        HStack(spacing: 30) {
-            Button(action: toggleRepeatMode) {
-                Image(systemName: repeatModeImageName)
-            }
-            .hoverEffect()
-            .accessibilityLabel(repeatModeAccessibilityLabel)
-
-            Button(action: model.shuffle) {
-                Image(systemName: "shuffle")
-            }
-            .hoverEffect()
-            .accessibilityLabel("Shuffle")
-            .disabled(model.isEmpty)
-
-            Button(action: add) {
-                Image(systemName: "plus")
-            }
-            .hoverEffect()
-            .accessibilityLabel("Add")
-
-            Button(action: model.trash) {
-                Image(systemName: "trash")
-            }
-            .hoverEffect()
-            .accessibilityLabel("Delete all")
-            .disabled(model.isEmpty)
-        }
-    }
-
-    private func nextButton() -> some View {
-        Button(action: player.advanceToNext) {
-            Image(systemName: "arrow.right")
-        }
-        .hoverEffect()
-        .accessibilityLabel("Next")
-        .disabled(!player.canAdvanceToNext())
-    }
-
-    private func toggleRepeatMode() {
-        switch player.repeatMode {
-        case .off:
-            player.repeatMode = .all
-        case .one:
-            player.repeatMode = .off
-        case .all:
-            player.repeatMode = .one
-        }
-    }
-
-    private func add() {
-        isSelectionPresented.toggle()
-    }
 }
 
 struct PlaylistView: View {
@@ -173,6 +110,86 @@ struct PlaylistView: View {
                 MessageView(message: "No items", icon: .none)
             }
         }
+    }
+}
+
+private extension Toolbar {
+    func previousButton() -> some View {
+        Button(action: player.returnToPrevious) {
+            Image(systemName: "arrow.left")
+        }
+        .hoverEffect()
+        .accessibilityLabel("Previous")
+        .disabled(!player.canReturnToPrevious())
+    }
+
+    func managementButtons() -> some View {
+        HStack(spacing: 30) {
+            repeatModeButton()
+            shuffleButton()
+            addButton()
+            trashButton()
+        }
+    }
+
+    func nextButton() -> some View {
+        Button(action: player.advanceToNext) {
+            Image(systemName: "arrow.right")
+        }
+        .hoverEffect()
+        .accessibilityLabel("Next")
+        .disabled(!player.canAdvanceToNext())
+    }
+}
+
+private extension Toolbar {
+    func repeatModeButton() -> some View {
+        Button(action: toggleRepeatMode) {
+            Image(systemName: repeatModeImageName)
+        }
+        .hoverEffect()
+        .accessibilityLabel(repeatModeAccessibilityLabel)
+    }
+
+    func shuffleButton() -> some View {
+        Button(action: model.shuffle) {
+            Image(systemName: "shuffle")
+        }
+        .hoverEffect()
+        .accessibilityLabel("Shuffle")
+        .disabled(model.isEmpty)
+    }
+
+    func addButton() -> some View {
+        Button(action: add) {
+            Image(systemName: "plus")
+        }
+        .hoverEffect()
+        .accessibilityLabel("Add")
+    }
+
+    func trashButton() -> some View {
+        Button(action: model.trash) {
+            Image(systemName: "trash")
+        }
+        .hoverEffect()
+        .accessibilityLabel("Delete all")
+        .disabled(model.isEmpty)
+    }
+
+    private func toggleRepeatMode() {
+        switch player.repeatMode {
+        case .off:
+            player.repeatMode = .all
+        case .one:
+            player.repeatMode = .off
+        case .all:
+            player.repeatMode = .one
+        }
+    }
+
+    private func add() {
+        isSelectionPresented.toggle()
     }
 }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -91,7 +91,7 @@ struct PlaylistView: View {
         }
         .animation(.defaultLinear, value: model.layout)
         .onAppear {
-            model.medias = medias
+            model.entries = medias.map { .init(media: $0) }
             model.play()
         }
         .enabledForInAppPictureInPicture(persisting: model)
@@ -101,16 +101,16 @@ struct PlaylistView: View {
     @ViewBuilder
     private func list() -> some View {
         ZStack {
-            if !model.medias.isEmpty {
-                List($model.medias, id: \.self, editActions: .all, selection: $model.currentMedia) { $media in
-                    MediaCell(media: media)
+            if !model.isEmpty {
+                List($model.entries, id: \.self, editActions: .all, selection: $model.currentEntry) { $entry in
+                    MediaCell(media: entry.media)
                 }
             }
             else {
                 MessageView(message: "No items", icon: .none)
             }
         }
-        .animation(.linear, value: model.medias)
+        .animation(.linear, value: model.entries)
     }
 }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -110,6 +110,7 @@ struct PlaylistView: View {
                 MessageView(message: "No items", icon: .none)
             }
         }
+        .animation(.linear, value: model.medias)
     }
 }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView.swift
@@ -24,6 +24,7 @@ private struct MediaCell: View {
     }
 }
 
+@available(tvOS, unavailable)
 private struct Toolbar: View {
     @ObservedObject private var player: Player
     @ObservedObject private var model: PlaylistViewModel
@@ -114,6 +115,7 @@ struct PlaylistView: View {
     }
 }
 
+@available(tvOS, unavailable)
 private extension Toolbar {
     func previousButton() -> some View {
         Button(action: player.returnToPrevious) {
@@ -143,6 +145,7 @@ private extension Toolbar {
     }
 }
 
+@available(tvOS, unavailable)
 private extension Toolbar {
     func repeatModeButton() -> some View {
         Button(action: toggleRepeatMode) {

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -22,7 +22,12 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
 
     @Published var currentEntry: PlaylistEntry? {
         didSet {
-            player.currentItem = currentEntry?.item
+            // TODO: Workaround for 'Publishing changes from within view updates' warnings triggered when a published
+            //       property is used as `List` selection. Remove when fixed by Apple or after migration to Observation.
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                player.currentItem = currentEntry?.item
+            }
         }
     }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -22,12 +22,7 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
 
     @Published var currentEntry: PlaylistEntry? {
         didSet {
-            // TODO: Workaround for 'Publishing changes from within view updates' warnings triggered when a published
-            //       property is used as `List` selection. Remove when fixed by Apple or after migration to Observation.
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                player.currentItem = currentEntry?.item
-            }
+            player.currentItem = currentEntry?.item
         }
     }
 

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -69,8 +69,32 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
         return items
     }
 
-    func add(_ medias: [Media]) {
-        self.medias.append(contentsOf: medias)
+    func prepend(_ medias: [Media]) {
+        insert(medias, before: nil)
+    }
+
+    func insert(_ medias: [Media], before: Media?) {
+        if let before {
+            guard let beforeIndex = self.medias.firstIndex(of: before) else { return }
+            self.medias.insert(contentsOf: medias, at: beforeIndex)
+        }
+        else {
+            self.medias.insert(contentsOf: medias, at: 0)
+        }
+    }
+
+    func insert(_ medias: [Media], after: Media?) {
+        if let after {
+            guard let index = self.medias.firstIndex(of: after) else { return }
+            self.medias.insert(contentsOf: medias, at: self.medias.index(after: index))
+        }
+        else {
+            self.medias.append(contentsOf: medias)
+        }
+    }
+
+    func append(_ medias: [Media]) {
+        insert(medias, after: nil)
     }
 
     func play() {

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -6,7 +6,6 @@
 
 import Combine
 import Foundation
-import OrderedCollections
 import PillarboxPlayer
 
 final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
@@ -15,30 +14,20 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
 
     @Published var layout: PlaybackView.Layout = .minimized
 
-    @Published private var items = OrderedDictionary<Media, PlayerItem>() {
+    @Published var entries: [PlaylistEntry] = [] {
         didSet {
-            player.items = items.values.elements
+            player.items = entries.map(\.item)
         }
     }
 
-    @Published var currentMedia: Media? {
+    @Published var currentEntry: PlaylistEntry? {
         didSet {
-            guard let currentMedia, let currentItem = items[currentMedia] else { return }
-            player.currentItem = currentItem
-        }
-    }
-
-    var medias: [Media] {
-        get {
-            Array(items.keys)
-        }
-        set {
-            items = Self.updated(initialItems: items, with: newValue)
+            player.currentItem = currentEntry?.item
         }
     }
 
     var isEmpty: Bool {
-        player.items.isEmpty
+        entries.isEmpty
     }
 
     init() {
@@ -46,55 +35,22 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
         configureLimitsPublisher()
     }
 
-    private static func updated(
-        initialItems: OrderedDictionary<Media, PlayerItem>,
-        with medias: [Media]
-    ) -> OrderedDictionary<Media, PlayerItem> {
-        var items = initialItems
-        let changes = medias.difference(from: initialItems.keys).inferringMoves()
-        changes.forEach { change in
-            switch change {
-            case let .insert(offset: offset, element: element, associatedWith: associatedWith):
-                if let associatedWith {
-                    let previousPlayerItem = initialItems.elements[associatedWith].value
-                    items.updateValue(previousPlayerItem, forKey: element, insertingAt: offset)
-                }
-                else {
-                    items.updateValue(element.item(), forKey: element, insertingAt: offset)
-                }
-            case let .remove(offset: offset, element: _, associatedWith: _):
-                items.remove(at: offset)
-            }
-        }
-        return items
+    func prepend(_ entries: [PlaylistEntry]) {
+        self.entries.insert(contentsOf: entries, at: 0)
     }
 
-    func prepend(_ medias: [Media]) {
-        insert(medias, before: nil)
+    func insertBeforeCurrent(_ entries: [PlaylistEntry]) {
+        guard let currentEntry, let index = self.entries.firstIndex(of: currentEntry) else { return }
+        self.entries.insert(contentsOf: entries, at: index)
     }
 
-    func insert(_ medias: [Media], before: Media?) {
-        if let before {
-            guard let beforeIndex = self.medias.firstIndex(of: before) else { return }
-            self.medias.insert(contentsOf: medias, at: beforeIndex)
-        }
-        else {
-            self.medias.insert(contentsOf: medias, at: 0)
-        }
+    func insertAfterCurrent(_ entries: [PlaylistEntry]) {
+        guard let currentEntry, let index = self.entries.firstIndex(of: currentEntry) else { return }
+        self.entries.insert(contentsOf: entries, at: self.entries.index(after: index))
     }
 
-    func insert(_ medias: [Media], after: Media?) {
-        if let after {
-            guard let index = self.medias.firstIndex(of: after) else { return }
-            self.medias.insert(contentsOf: medias, at: self.medias.index(after: index))
-        }
-        else {
-            self.medias.append(contentsOf: medias)
-        }
-    }
-
-    func append(_ medias: [Media]) {
-        insert(medias, after: nil)
+    func append(_ entries: [PlaylistEntry]) {
+        self.entries.append(contentsOf: entries)
     }
 
     func play() {
@@ -103,20 +59,20 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
     }
 
     func shuffle() {
-        items.shuffle()
+        entries.shuffle()
     }
 
     func trash() {
-        medias = []
+        entries = []
     }
 
     private func configureCurrentMediaPublisher() {
         player.$currentItem
             .map { [weak self] item in
                 guard let self, let item else { return nil }
-                return media(for: item)
+                return entry(for: item)
             }
-            .assign(to: &$currentMedia)
+            .assign(to: &$currentEntry)
     }
 
     private func configureLimitsPublisher() {
@@ -125,7 +81,7 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
             .store(in: &cancellables)
     }
 
-    private func media(for item: PlayerItem) -> Media? {
-        items.first { $0.value == item }?.key
+    private func entry(for item: PlayerItem) -> PlaylistEntry? {
+        entries.first { $0.item == item }
     }
 }

--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -31,7 +31,7 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
     }
 
     init() {
-        configureCurrentMediaPublisher()
+        configureCurrentEntryPublisher()
         configureLimitsPublisher()
     }
 
@@ -66,11 +66,10 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
         entries = []
     }
 
-    private func configureCurrentMediaPublisher() {
-        player.$currentItem
-            .map { [weak self] item in
-                guard let self, let item else { return nil }
-                return entry(for: item)
+    private func configureCurrentEntryPublisher() {
+        Publishers.CombineLatest(player.$currentItem, $entries)
+            .map { item, entries in
+                entries.first { $0.item == item }
             }
             .assign(to: &$currentEntry)
     }

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -20,7 +20,7 @@ private enum TriggerId: Hashable {
 /// - Simple assets which can be played from a simple URL.
 /// - Custom assets which require custom resource loading.
 /// - Encrypted assets which require a FairPlay content key session.
-public final class PlayerItem: Equatable {
+public final class PlayerItem: Hashable {
     private static let trigger = Trigger()
 
     @Published private(set) var content: AssetContent
@@ -83,6 +83,11 @@ public final class PlayerItem: Equatable {
     static func reload(for id: UUID) {
         trigger.activate(for: TriggerId.reset(id))
         trigger.activate(for: TriggerId.load(id))
+    }
+
+    // swiftlint:disable:next missing_docs
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 
     func matches(_ playerItem: AVPlayerItem?) -> Bool {


### PR DESCRIPTION
## Description

This PR improves playlist demo item insertion support with inspiration from our recent [Castor demo implementation](https://github.com/SRGSSR/castor/pull/61).

## Changes made

- Update model to support insertion of the same media several times.
- Conform `PlayerItem` hashable to make it more suitable for wrapping into structs which themselves need to be hashable. Instead of approaches we previously used (generic source attached to the item (#1041), sync between media and player item lists we had until this PR), this makes it possible to use composition as a simple way of implementing playlist items that bundle a business object and its associated item.
- Add insertion location options (prepend, before current item, after current item, append).
- Add multiplier to insert the same group of items several times.
- Better organize playlist implementation and mark iOS-specific list management as unavailable on tvOS.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
