### PR TITLE
Fix high speed capsule layout

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -105,13 +105,13 @@ private struct MainView: View {
             .gesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
             .simultaneousGesture(visibilityResetGesture())
             .gesture(toggleGesture(), isEnabled: !isInteracting)
-            .supportsHighSpeed(!isMonoscopic, for: player)
             .overlay(alignment: .center) {
                 skipOverlay(skipTracker: skipTracker, in: geometry)
             }
         }
         .animation(.defaultLinear, value: skipTracker.state)
         .ignoresSafeArea()
+        .supportsHighSpeed(!isMonoscopic, for: player)
         .readLayout(into: $layoutInfo)
         .bind(skipTracker, to: player)
     }

--- a/Demo/Sources/Views/HighSpeedView~ios.swift
+++ b/Demo/Sources/Views/HighSpeedView~ios.swift
@@ -85,16 +85,15 @@ private struct HighSpeedView<Content>: View where Content: View {
 }
 
 extension View {
+    @ViewBuilder
     func supportsHighSpeed(_ supported: Bool = true, for player: Player) -> some View {
-        Group {
-            if supported {
-                HighSpeedView(player: player) {
-                    self
-                }
-            }
-            else {
+        if supported {
+            HighSpeedView(player: player) {
                 self
             }
+        }
+        else {
+            self
         }
     }
 }


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- The `supportsHighSpeed` modifier has been moved under the `ignoreSafeArea` modifier.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
