### PR TITLE
Add VPN/proxy blocking reason

### DIFF
--- a/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
@@ -37,7 +37,7 @@ public extension MediaComposition {
         case unknown = "UNKNOWN"
 
         /// VPN or proxy detected.
-        case vpnProxy = "VPNPROXYDETECTED"
+        case vpnOrProxy = "VPNPROXYDETECTED"
 
         /// The standard description for the blocking reason.
         public var description: String {
@@ -96,7 +96,7 @@ public extension MediaComposition {
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
-            case .vpnProxy:
+            case .vpnOrProxy:
                 return String(
                     localized: "This content cannot be played while using a VPN or a proxy.",
                     bundle: .module,

--- a/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
@@ -37,7 +37,7 @@ public extension MediaComposition {
         case unknown = "UNKNOWN"
 
         /// VPN or proxy detected.
-        case vpnOrProxy = "VPNPROXYDETECTED"
+        case vpnOrProxyDetected = "VPNORPROXYDETECTED"
 
         /// The standard description for the blocking reason.
         public var description: String {
@@ -96,7 +96,7 @@ public extension MediaComposition {
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )
-            case .vpnOrProxy:
+            case .vpnOrProxyDetected:
                 return String(
                     localized: "This content cannot be played while using a VPN or a proxy.",
                     bundle: .module,

--- a/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition+BlockingReason.swift
@@ -36,6 +36,9 @@ public extension MediaComposition {
         /// Unknown reason.
         case unknown = "UNKNOWN"
 
+        /// VPN or proxy detected.
+        case vpnProxy = "VPNPROXYDETECTED"
+
         /// The standard description for the blocking reason.
         public var description: String {
             switch self {
@@ -90,6 +93,12 @@ public extension MediaComposition {
             case .unknown:
                 return String(
                     localized: "This content is not available.",
+                    bundle: .module,
+                    comment: "Blocking reason description message"
+                )
+            case .vpnProxy:
+                return String(
+                    localized: "This content cannot be played while using a VPN or a proxy.",
                     bundle: .module,
                     comment: "Blocking reason description message"
                 )

--- a/Sources/CoreBusiness/Resources/Localizable.xcstrings
+++ b/Sources/CoreBusiness/Resources/Localizable.xcstrings
@@ -71,6 +71,9 @@
         }
       }
     },
+    "This content cannot be played while using a VPN or a proxy." : {
+      "comment" : "Blocking reason description message"
+    },
     "This content is not available anymore." : {
       "comment" : "Blocking reason description message",
       "localizations" : {

--- a/Sources/CoreBusiness/Resources/Localizable.xcstrings
+++ b/Sources/CoreBusiness/Resources/Localizable.xcstrings
@@ -72,7 +72,39 @@
       }
     },
     "This content cannot be played while using a VPN or a proxy." : {
-      "comment" : "Blocking reason description message"
+      "comment" : "Blocking reason description message",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This content cannot be played while using a VPN or a proxy."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu ne peut pas être lu avec un VPN ou un proxy."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo contenuto non può essere riprodotto con VPN o proxy."
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà."
+          }
+        }
+      }
     },
     "This content is not available anymore." : {
       "comment" : "Blocking reason description message",

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -177,7 +177,7 @@
       }
     },
     "Playback Speed" : {
-      "comment" : "Playback setting menu title",
+      "comment" : "Playback speed menu title",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
## Description

This PR adds a new blocking reason which will be soon returned by Integration Layer services when the user is located behind a VPN or proxy.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
