### PR TITLE
Reorganize gestures for a better user experience

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -93,7 +93,8 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 video()
-                    .gesture(skipGesture(in: geometry))
+                    .gesture(toggleGesture(), isEnabled: !isInteracting)
+                    .simultaneousGesture(skipGesture(in: geometry))
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -104,7 +105,6 @@ private struct MainView: View {
             .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
             .gesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
             .simultaneousGesture(visibilityResetGesture())
-            .simultaneousGesture(toggleGesture(), isEnabled: !isInteracting)
             .overlay(alignment: .center) {
                 skipOverlay(skipTracker: skipTracker, in: geometry)
             }
@@ -251,6 +251,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 Color(white: 0, opacity: 0.5)
+                    .gesture(toggleGesture(), isEnabled: !isInteracting)
                     .simultaneousGesture(skipGesture(in: geometry))
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -94,7 +94,7 @@ private struct MainView: View {
             ZStack {
                 video()
                     .gesture(toggleGesture(), isEnabled: !isInteracting)
-                    .simultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(skipGesture(in: geometry), isEnabled: !isInteracting)
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -252,7 +252,7 @@ private struct MainView: View {
             ZStack {
                 Color(white: 0, opacity: 0.5)
                     .gesture(toggleGesture(), isEnabled: !isInteracting)
-                    .simultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(skipGesture(in: geometry), isEnabled: !isInteracting)
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
             }


### PR DESCRIPTION
## Description

This PR improves gestures for a better experience.

## Changes made

- The tap gesture was triggering UI toggle when tapping on buttons, which is not the desired experience. This has been fixed by reordering/duplicating gestures. Gesture duplication would not have been required as of iOS 18 but ensures the behavior implemented in #1192 still works correctly on iOS 17.
- Avoid triggering skip gestures while interacting with the slider.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
