### PR TITLE
Dependency update

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "8db40c4bd24b3d1a7499a9962e02b88f97e80908880b5ae3fdf0bc35e9a93e26",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "24ffbad1da8467b615958be9d0dd1e92c4396699",
-        "version" : "5.4.12"
+        "revision" : "62e3c97f4e38a3f61bd85608ba9d4d4af3abacfd",
+        "version" : "5.4.14"
       }
     },
     {
@@ -95,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "9ea26675cdfa11571b52f772f68d62e52a004e2c",
-        "version" : "19.0.7"
+        "revision" : "7e8243cd50a87b6c57666f617155e2e9cd26a847",
+        "version" : "19.0.9"
       }
     },
     {
@@ -127,5 +128,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "ebf1c67ba73a9cbd9227deda54b8c80412594646e2210cbe7388e9597cec6815",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
       "state" : {
-        "revision" : "adeebce59de7017eb0abe2b6a74346ca8371ffcc",
-        "version" : "6.14.0"
+        "revision" : "56d8a44c387fee1f7ef1786f13f8960b85109d31",
+        "version" : "6.14.1"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "24ffbad1da8467b615958be9d0dd1e92c4396699",
-        "version" : "5.4.12"
+        "revision" : "62e3c97f4e38a3f61bd85608ba9d4d4af3abacfd",
+        "version" : "5.4.14"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "f3bedd7c2a858f4513e7d004def200a69238db2f",
-        "version" : "13.6.2"
+        "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
+        "version" : "13.7.1"
       }
     },
     {
@@ -64,5 +65,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
## Description

This PR updates a few Pillarbox and demo dependencies.

## Changes made

- Update comScore to version 6.14.1 (previously 6.14.0).
- Update Commanders Act to version 5.4.14 (previously 5.4.12).
- Update SRG Data Providet to version 19.0.0 (previously 19.0.7).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
