### PR TITLE
Disable skip gestures on iOS 17

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -93,8 +93,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 video()
-                    .gesture(toggleGesture(), isEnabled: !isInteracting)
-                    .simultaneousGesture(skipGesture(in: geometry), isEnabled: !isInteracting)
+                    .simultaneousGesture(skipGesture(in: geometry))
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -103,8 +102,9 @@ private struct MainView: View {
                 controls()
             }
             .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
-            .gesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
+            .simultaneousGesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
             .simultaneousGesture(visibilityResetGesture())
+            .gesture(toggleGesture(), isEnabled: !isInteracting)
             .overlay(alignment: .center) {
                 skipOverlay(skipTracker: skipTracker, in: geometry)
             }
@@ -251,8 +251,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 Color(white: 0, opacity: 0.5)
-                    .gesture(toggleGesture(), isEnabled: !isInteracting)
-                    .simultaneousGesture(skipGesture(in: geometry), isEnabled: !isInteracting)
+                    .simultaneousGesture(skipGesture(in: geometry))
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
             }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -93,7 +93,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 video()
-                    .simultaneousGesture(skipGesture(in: geometry))
+                    .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -251,7 +251,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 Color(white: 0, opacity: 0.5)
-                    .simultaneousGesture(skipGesture(in: geometry))
+                    .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
             }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -102,9 +102,9 @@ private struct MainView: View {
                 controls()
             }
             .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
+            .gesture(toggleGesture(), isEnabled: !isInteracting)
             .simultaneousGesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
             .simultaneousGesture(visibilityResetGesture())
-            .gesture(toggleGesture(), isEnabled: !isInteracting)
             .overlay(alignment: .center) {
                 skipOverlay(skipTracker: skipTracker, in: geometry)
             }

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -86,6 +86,21 @@ extension View {
     }
 }
 
+@available(tvOS, unavailable)
+extension View {
+    /// Support for simultaneous gestures applied on nested hierarchies has been improved in iOS 18 so that all gestures
+    /// are correctly triggered.
+    @ViewBuilder
+    func optionalNestedSimultaneousGesture<T>(_ gesture: T, isEnabled: Bool = true) -> some View where T: Gesture {
+        if #available(iOS 18, *) {
+            simultaneousGesture(gesture, isEnabled: isEnabled)
+        }
+        else {
+            self
+        }
+    }
+}
+
 extension View {
     func headerStyle() -> some View {
 #if os(tvOS)


### PR DESCRIPTION
## Description

Following #1192 and #1194, we still have an issue with the tap/skip gestures on iOS 18. The user interface does not disappear during skipping but actually should.

We could introduce a round of new conditions (and bugs) again, but #1192 and #1194 are ultimately an artifact of poor support for simultaneous gestures in view hierarchies pre-iOS 18, as illustrated with the following example:

```swift
import SwiftUI

struct ContentView: View {
    var body: some View {
        ZStack {
            Color.red
                .simultaneousGesture(
                    TapGesture().onEnded { _ in
                        print("--> child")
                    }
                )
        }
        .gesture(
            TapGesture()
                .onEnded { _ in
                    print("--> parent")
                }
        )
        .ignoresSafeArea()
    }
}

#Preview {
    ContentView()
}
```

On iOS 17 only the child gesture incorrectly fires, on iOS 18 both the child and parent gestures at the same time.

### Remark

iOS 18 also makes gesture behavior more resilient to reordering of `gesture` and `simultaneousGesture` on the same view. The code below:

```swift
import SwiftUI

struct ContentView: View {
    var body: some View {
        ZStack {
            Color.red
                .simultaneousGesture(
                    TapGesture().onEnded { _ in
                        print("--> A")
                    }
                )
                .gesture(
                    TapGesture()
                        .onEnded { _ in
                            print("--> B")
                        }
                )
        }
        .ignoresSafeArea()
    }
}

#Preview {
    ContentView()
}
```

fires A and B events on iOS 18 but only A ones on iOS 17.

A simple fix that works correctly on all iOS versions and does not yield additional complexity is to simply swap gestures so that simultaneous gestures are applied last:

```swift
import SwiftUI

struct ContentView: View {
    var body: some View {
        ZStack {
            Color.red
                .gesture(
                    TapGesture()
                        .onEnded { _ in
                            print("--> B")
                        }
                )
                .simultaneousGesture(
                    TapGesture().onEnded { _ in
                        print("--> A")
                    }
                )
        }
        .ignoresSafeArea()
    }
}

#Preview {
    ContentView()
}
```

## Changes made

Our playback view has a similar gesture hierarchy and gestures as described above, leading to the toggle gesture previously not working on iOS 17. But in attempting to fix what is a SwiftUI issue in the first place, we create an endless trail of new bugs and make the code more complicated than it should. Gestures must namely carefully be applied so that:

- Double-tapping on UI buttons does not trigger skipping mode.
- Entering skip mode hides the UI (the UI might still briefly appear if the double-tap gesture is started with a hidden UI).
- UI toggling works.
- Single-tapping on a button does not make the UI vanish.
- Other gestures work (e.g., pinch).

on iOS 16, 17 and 18. This set of requirements if becoming too complex to guarantee if we want to keep our implementation simple.

To put an end to this cycle I propose to simply provide a way to mark optional but potentially problematic simultaneous gestures in view hierarchies using a dedicated gesture modifier, which we can later remove once iOS 18 is the minimum version we support. This way such potentially problematic optional gestures will simply be disabled on iOS 17 and below and our code will be able to reflect the intended result, without introducing workarounds for older iOS versions.

By removing skip gestures below iOS 18 we can loosen the set of constraints above a bit and make our life easier.

The changes made are therefore:

- Revert to the code which existed before #1192 and that represents the intended implementation on iOS 18 and above.
- Introduce the `optionalNestedSimultaneousGesture(_:isEnabled:)` modifier. The modifier is not defined on tvOS 18 since we won't implement custom UIs on this platform anyway.
- Use this modifier when adding skip gestures.
- Reorder sibling gestures and simultaneous gestures so that they work correctly on iOS 17.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
