### PR TITLE
Allow to start Picture-in-Picture automatically for inline contents

### DIFF
--- a/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
@@ -23,6 +23,9 @@ final class CustomPictureInPicture: NSObject {
     override init() {
         super.init()
         controller?.delegate = self
+#if os(ios)
+        controller?.canStartPictureInPictureAutomaticallyFromInline = true
+#endif
         configureIsPossiblePublisher()
     }
 

--- a/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
@@ -50,6 +50,7 @@ final class SystemPictureInPicture: NSObject {
             let playerViewController = PlayerViewController()
             playerViewController.allowsPictureInPicturePlayback = true
 #if os(iOS)
+            playerViewController.canStartPictureInPictureAutomaticallyFromInline = true
             playerViewController.updatesNowPlayingInfoCenter = false
 #endif
             playerViewController.delegate = self


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- The property `canStartPictureInPictureAutomaticallyFromInline` is to `true` by default.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
