### PR TITLE
Improve demo slider

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -688,7 +688,7 @@ private struct TimeSlider: View {
             .clipShape(.capsule)
             .shadow(color: .init(white: 0.2, opacity: 0.8), radius: 15)
             .opacity(isVisible ? 1 : 0)
-            .animation(.easeInOut(duration: 0.3), value: progressTracker.isInteracting)
+            .animation(.defaultLinear, values: progressTracker.isInteracting, buffer)
         }
         .onEditingChanged { isEditing in
             progressTracker.isInteracting = isEditing
@@ -719,7 +719,6 @@ private struct TimeSlider: View {
         Color.white
             .opacity(0.3)
             .frame(width: CGFloat(buffer) * width)
-            .animation(.linear(duration: 0.5), value: buffer)
     }
 
     private func sliderTrack(progress: CGFloat, width: CGFloat) -> some View {

--- a/Demo/Sources/Views/HSlider.swift
+++ b/Demo/Sources/Views/HSlider.swift
@@ -40,6 +40,7 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
                     state = value
                 }
         )
+        .preventsTouchPropagation()
     }
 
     /// Creates a slider to select a value from a given range.


### PR DESCRIPTION
## Description

This PR makes two minor improvements to the demo slider implementation.

## Changes made

- The buffer track was animated differently, leading to track frames separating during main track and buffer animations. I propose to apply the same more snappy animation for both.
- The slider track can expand but the tracking gesture was only on the non-expanded tracker when idle. I propose to add an almost transparent overlay, thus offering more space for the user interaction (8px is quite small for interactions).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
