### PR TITLE
Prefix plugin name to avoid conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
                 .linkedFramework("AdSupport")
             ],
             plugins: [
-                .plugin(name: "PackageInfoPlugin")
+                .plugin(name: "PillarboxPackageInfoPlugin")
             ]
         ),
         .target(
@@ -79,7 +79,7 @@ let package = Package(
                 .process("Resources")
             ],
             plugins: [
-                .plugin(name: "PackageInfoPlugin")
+                .plugin(name: "PillarboxPackageInfoPlugin")
             ]
         ),
         .target(
@@ -112,7 +112,7 @@ let package = Package(
                 .process("Resources")
             ],
             plugins: [
-                .plugin(name: "PackageInfoPlugin")
+                .plugin(name: "PillarboxPackageInfoPlugin")
             ]
         ),
         .target(
@@ -122,12 +122,12 @@ let package = Package(
                 .process("Resources")
             ]
         ),
-        .binaryTarget(name: "PackageInfo", path: "Artifacts/PackageInfo.artifactbundle"),
+        .binaryTarget(name: "PillarboxPackageInfo", path: "Artifacts/PackageInfo.artifactbundle"),
         .plugin(
-            name: "PackageInfoPlugin",
+            name: "PillarboxPackageInfoPlugin",
             capability: .buildTool(),
             dependencies: [
-                .target(name: "PackageInfo")
+                .target(name: "PillarboxPackageInfo")
             ]
         ),
         .testTarget(

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -177,7 +177,7 @@
       }
     },
     "Playback Speed" : {
-      "comment" : "Playback speed menu title",
+      "comment" : "Playback setting menu title",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
## Description

This PR fixes potential package resolution errors which might arise if two plugins belonging to different packages share the same name (which was the case with our [Castor SDK](https://github.com/SRGSSR/castor)).

## Changes made

- Prefix plugin name.
- Fix translation comment.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
