### PR TITLE
Fix player observability when empty

### DIFF
--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -97,12 +97,7 @@ public final class Player: ObservableObject, Equatable {
     /// When implementing a custom SwiftUI user interface, you should use `View.onReceive(player:assign:to:)` to read
     /// fast-paced property changes into corresponding local bindings.
     public lazy var propertiesPublisher: AnyPublisher<PlayerProperties, Never> = {
-        currentPlayerItemPublisher()
-            .map { [queuePlayer] item in
-                guard let item else { return Just(PlayerProperties.empty).eraseToAnyPublisher() }
-                return item.propertiesPublisher(with: queuePlayer)
-            }
-            .switchToLatest()
+        queuePlayer.propertiesPublisher(withPlayerItemPropertiesPublisher: currentPlayerItemPropertiesPublisher())
             .share(replay: 1)
             .eraseToAnyPublisher()
     }()

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -39,28 +39,6 @@ extension AVPlayerItem {
         .eraseToAnyPublisher()
     }
 
-    func propertiesPublisher(with player: QueuePlayer) -> AnyPublisher<PlayerProperties, Never> {
-        Publishers.CombineLatest3(
-            propertiesPublisher(),
-            player.playbackPropertiesPublisher(),
-            player.seekTimePublisher()
-        )
-        .map { playerItemProperties, playbackProperties, seekTime in
-            .init(
-                coreProperties: .init(
-                    itemProperties: playerItemProperties.itemProperties,
-                    mediaSelectionProperties: playerItemProperties.mediaSelectionProperties,
-                    playbackProperties: playbackProperties
-                ),
-                timeProperties: playerItemProperties.timeProperties,
-                isEmpty: playerItemProperties.isEmpty,
-                seekTime: seekTime
-            )
-        }
-        .removeDuplicates()
-        .eraseToAnyPublisher()
-    }
-
     private func timePropertiesPublisher() -> AnyPublisher<TimeProperties, Never> {
         Publishers.CombineLatest3(
             publisher(for: \.loadedTimeRanges),

--- a/Sources/Player/Publishers/PlayerPublishers.swift
+++ b/Sources/Player/Publishers/PlayerPublishers.swift
@@ -16,4 +16,14 @@ extension Player {
     func currentPlayerItemPublisher() -> AnyPublisher<AVPlayerItem?, Never> {
         queuePublisher.slice(at: \.itemState.item)
     }
+
+    func currentPlayerItemPropertiesPublisher() -> AnyPublisher<PlayerItemProperties, Never> {
+        currentPlayerItemPublisher()
+            .map { item in
+                guard let item else { return Just(PlayerItemProperties.empty).eraseToAnyPublisher() }
+                return item.propertiesPublisher()
+            }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/Player/Publishers/QueuePlayerPublishers.swift
+++ b/Sources/Player/Publishers/QueuePlayerPublishers.swift
@@ -33,4 +33,28 @@ extension QueuePlayer {
         .removeDuplicates()
         .eraseToAnyPublisher()
     }
+
+    func propertiesPublisher(
+        withPlayerItemPropertiesPublisher playerItemPropertiesPublisher: AnyPublisher<PlayerItemProperties, Never>
+    ) -> AnyPublisher<PlayerProperties, Never> {
+        Publishers.CombineLatest3(
+            playerItemPropertiesPublisher,
+            playbackPropertiesPublisher(),
+            seekTimePublisher()
+        )
+        .map { playerItemProperties, playbackProperties, seekTime in
+            PlayerProperties(
+                coreProperties: .init(
+                    itemProperties: playerItemProperties.itemProperties,
+                    mediaSelectionProperties: playerItemProperties.mediaSelectionProperties,
+                    playbackProperties: playbackProperties
+                ),
+                timeProperties: playerItemProperties.timeProperties,
+                isEmpty: playerItemProperties.isEmpty,
+                seekTime: seekTime
+            )
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
 }

--- a/Sources/Player/Tracking/Tracker.swift
+++ b/Sources/Player/Tracking/Tracker.swift
@@ -77,11 +77,7 @@ final class Tracker {
     }
 
     private func configurePublishers() {
-        $playerItem
-            .map { [player] playerItem in
-                playerItem.propertiesPublisher(with: player)
-            }
-            .switchToLatest()
+        player.propertiesPublisher(withPlayerItemPropertiesPublisher: playerItemPropertiesPublisher())
             .handleEvents(receiveOutput: { [weak self] properties in
                 self?.updateTrackersProperties(to: properties)
             }, receiveCompletion: nil)
@@ -93,6 +89,13 @@ final class Tracker {
                 self?.updateTrackersMetricEvents(to: events)
             }
             .store(in: &cancellables)
+    }
+
+    private func playerItemPropertiesPublisher() -> AnyPublisher<PlayerItemProperties, Never> {
+        $playerItem
+            .map { $0.propertiesPublisher() }
+            .switchToLatest()
+            .eraseToAnyPublisher()
     }
 
     deinit {

--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -23,6 +23,13 @@ final class PlayerTests: TestCase {
         expect(weakPlayer).to(beNil())
     }
 
+    func testEmptyPlayerChangeObservation() {
+        let player = Player()
+        expectChange(from: player) {
+            player.togglePlayPause()
+        }
+    }
+
     func testTimesWhenEmpty() {
         let player = Player()
         expect(player.time()).toAlways(equal(.invalid), until: .seconds(1))


### PR DESCRIPTION
## Description

When working on [Castor playback state management](https://github.com/SRGSSR/castor/issues/59), most notably on a `shouldPlay` Boolean flag like the one we have in Pillarbox, I checked the behavior of our custom Pillarbox player UI by tweaking our demo code so that the playback button is displayed also when the player is empty. I was surprised to observe that toggling the playback button was not updating its icon accordingly.

Looking at the code I realized that player changes were not always reported when the player was empty, most notably for changes depending on the internal `QueuePlayer` itself (e.g. rate changes). The reason is that the publisher starting point [is a current item publisher](https://github.com/SRGSSR/pillarbox-apple/blob/acfe1e24959b7fef4d1f4187282baeca9f3bdecc/Sources/Player/Player.swift#L99-L108), which means that no changes are observable when there is no item loaded in the player.

This PR fixes this incorrect behavior.

## Changes made

We had factored out our properties publisher internal implementation into an `AVPlayerItem` method:

```swift
extension AVPlayerItem {
    func propertiesPublisher(with player: QueuePlayer) -> AnyPublisher<PlayerProperties, Never>
}
```
so that it can be used from two locations consistently:

- The `Player` implementation itself.
- Our `Tracker` manager.

We must avoid the dependency on the presence of an `AVPlayerItem`, so having this shared implementation in an `AVPlayerItem` extension is not possible. Instead it should be moved to `QueuePlayer`, whose lifecycle is larger. Since the two implementations above ultimately differ on their current item, we provide a player item properties publisher as parameter instead:

```swift
extension QueuePlayer {
    func propertiesPublisher(
        withPlayerItemPropertiesPublisher playerItemPropertiesPublisher: AnyPublisher<PlayerItemProperties, Never>
    ) -> AnyPublisher<PlayerProperties, Never>
}
````

This way queue player change observation does not depend on item availability anymore.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
