### PR TITLE
Remove explicit equatable conformance

### DIFF
--- a/Sources/Player/Types/TimeRange.swift
+++ b/Sources/Player/Types/TimeRange.swift
@@ -7,9 +7,9 @@
 import CoreMedia
 
 /// Represents a time range.
-public struct TimeRange: Hashable, Equatable {
+public struct TimeRange: Hashable {
     /// The range type.
-    public enum Kind: Hashable, Equatable {
+    public enum Kind: Hashable {
         /// Credits.
         case credits(Credits)
 


### PR DESCRIPTION
## Description

This PR simplifies the conformance declaration by removing the explicit `Equatable` conformance from the `TimeRange` and `TimeRange.Kind` types, since they already conform to `Hashable`.

## Changes made

- The `Equatable` conformance from `TimeRange` and `TimeRange.Kind` has been removed.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
