### PR TITLE
Support dynamic skips symbols based on player configuration

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -21,6 +21,12 @@
         }
       }
     },
+    "%lf seconds" : {
+
+    },
+    "%lld seconds" : {
+
+    },
     "+%llds" : {
 
     },
@@ -55,6 +61,9 @@
 
     },
     "Automatic" : {
+
+    },
+    "Backward by" : {
 
     },
     "Blue" : {
@@ -130,6 +139,9 @@
 
     },
     "Font size" : {
+
+    },
+    "Forward by" : {
 
     },
     "Frame drops" : {
@@ -319,6 +331,9 @@
 
     },
     "Skip" : {
+
+    },
+    "Skips" : {
 
     },
     "Smart navigation" : {

--- a/Demo/Sources/Extensions/Image.swift
+++ b/Demo/Sources/Extensions/Image.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+extension Image {
+    init(systemName: String, placeholder: String) {
+        if let uiImage = UIImage(systemName: systemName)?.withRenderingMode(.alwaysTemplate) {
+            self = Image(uiImage: uiImage)
+        }
+        else {
+            self = Image(systemName: placeholder)
+        }
+    }
+}

--- a/Demo/Sources/Extensions/Image.swift
+++ b/Demo/Sources/Extensions/Image.swift
@@ -4,15 +4,25 @@
 //  License information is available from the LICENSE file.
 //
 
+import PillarboxPlayer
 import SwiftUI
 
 extension Image {
-    init(systemName: String, placeholder: String) {
-        if let uiImage = UIImage(systemName: systemName)?.withRenderingMode(.alwaysTemplate) {
-            self = Image(uiImage: uiImage)
+    static func goBackward(withInterval interval: TimeInterval) -> Self {
+        if let uiImage = UIImage(systemName: "gobackward.\(Int(interval))") {
+            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
         }
         else {
-            self = Image(systemName: placeholder)
+            return Image(systemName: "gobackward.minus")
+        }
+    }
+
+    static func goForward(withInterval interval: TimeInterval) -> Self {
+        if let uiImage = UIImage(systemName: "goforward.\(Int(interval))") {
+            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        }
+        else {
+            return Image(systemName: "goforward.plus")
         }
     }
 }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -335,9 +335,12 @@ private struct SkipBackwardButton: View {
 
     var body: some View {
         Button(action: skipBackward) {
-            Image(systemName: "gobackward.10")
-                .resizable()
-                .tint(.white)
+            Image(
+                systemName: "gobackward.\(Int(player.configuration.backwardSkipInterval))",
+                placeholder: "gobackward"
+            )
+            .resizable()
+            .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
@@ -359,9 +362,12 @@ private struct SkipForwardButton: View {
 
     var body: some View {
         Button(action: skipForward) {
-            Image(systemName: "goforward.10")
-                .resizable()
-                .tint(.white)
+            Image(
+                systemName: "goforward.\(Int(player.configuration.forwardSkipInterval))",
+                placeholder: "goforward"
+            )
+            .resizable()
+            .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -335,12 +335,9 @@ private struct SkipBackwardButton: View {
 
     var body: some View {
         Button(action: skipBackward) {
-            Image(
-                systemName: "gobackward.\(Int(player.configuration.backwardSkipInterval))",
-                placeholder: "gobackward"
-            )
-            .resizable()
-            .tint(.white)
+            Image.goBackward(withInterval: player.configuration.backwardSkipInterval)
+                .resizable()
+                .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)
@@ -362,12 +359,9 @@ private struct SkipForwardButton: View {
 
     var body: some View {
         Button(action: skipForward) {
-            Image(
-                systemName: "goforward.\(Int(player.configuration.forwardSkipInterval))",
-                placeholder: "goforward"
-            )
-            .resizable()
-            .tint(.white)
+            Image.goForward(withInterval: player.configuration.forwardSkipInterval)
+                .resizable()
+                .tint(.white)
         }
         .aspectRatio(contentMode: .fit)
         .frame(height: 45)

--- a/Demo/Sources/Players/PlayerConfiguration.swift
+++ b/Demo/Sources/Players/PlayerConfiguration.swift
@@ -12,7 +12,9 @@ extension PlayerConfiguration {
         let userDefaults = UserDefaults.standard
         return .init(
             usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
-            navigationMode: userDefaults.smartNavigationEnabled ? .smart(interval: 3) : .immediate
+            navigationMode: userDefaults.smartNavigationEnabled ? .smart(interval: 3) : .immediate,
+            backwardSkipInterval: userDefaults.skipBackwardSetting,
+            forwardSkipInterval: userDefaults.skipForwardSetting
         )
     }
 

--- a/Demo/Sources/Players/PlayerConfiguration.swift
+++ b/Demo/Sources/Players/PlayerConfiguration.swift
@@ -13,8 +13,8 @@ extension PlayerConfiguration {
         return .init(
             usesExternalPlaybackWhileMirroring: !userDefaults.presenterModeEnabled,
             navigationMode: userDefaults.smartNavigationEnabled ? .smart(interval: 3) : .immediate,
-            backwardSkipInterval: userDefaults.skipBackwardSetting,
-            forwardSkipInterval: userDefaults.skipForwardSetting
+            backwardSkipInterval: userDefaults.backwardSkipInterval,
+            forwardSkipInterval: userDefaults.forwardSkipInterval
         )
     }
 

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -141,7 +141,9 @@ extension SettingsView {
     private func content() -> some View {
         applicationSection()
         playerSection()
+#if os(iOS)
         skipsSection()
+#endif
         debuggingSection()
         playbackHudSection()
 #if os(iOS)

--- a/Demo/Sources/Settings/SettingsView.swift
+++ b/Demo/Sources/Settings/SettingsView.swift
@@ -63,11 +63,11 @@ struct SettingsView: View {
     @AppStorage(UserDefaults.DemoSettingKey.seekBehaviorSetting.rawValue)
     private var seekBehaviorSetting: SeekBehaviorSetting = .immediate
 
-    @AppStorage(UserDefaults.DemoSettingKey.skipBackwardSetting.rawValue)
-    private var skipBackwardSetting: TimeInterval = 10
+    @AppStorage(UserDefaults.DemoSettingKey.backwardSkipInterval.rawValue)
+    private var backwardSkipInterval: TimeInterval = 10
 
-    @AppStorage(UserDefaults.DemoSettingKey.skipForwardSetting.rawValue)
-    private var skipForwardSetting: TimeInterval = 10
+    @AppStorage(UserDefaults.DemoSettingKey.forwardSkipInterval.rawValue)
+    private var forwardSkipInterval: TimeInterval = 10
 
     @AppStorage(UserDefaults.DemoSettingKey.qualitySetting.rawValue)
     private var qualitySetting: QualitySetting = .high
@@ -180,8 +180,8 @@ extension SettingsView {
 
     private func skipsSection() -> some View {
         Section {
-            skipPicker("Backward by", selection: $skipBackwardSetting)
-            skipPicker("Forward by", selection: $skipForwardSetting)
+            skipPicker("Backward by", selection: $backwardSkipInterval)
+            skipPicker("Forward by", selection: $forwardSkipInterval)
         } header: {
              Text("Skips")
                 .headerStyle()

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -17,6 +17,8 @@ extension UserDefaults {
         case presenterModeEnabled
         case smartNavigationEnabled
         case seekBehaviorSetting
+        case skipBackwardSetting
+        case skipForwardSetting
         case serverSetting
         case qualitySetting
     }
@@ -42,6 +44,14 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: DemoSettingKey.seekBehaviorSetting.rawValue)) ?? .immediate
     }
 
+    @objc dynamic var skipBackwardSetting: TimeInterval {
+        double(forKey: DemoSettingKey.skipBackwardSetting.rawValue)
+    }
+
+    @objc dynamic var skipForwardSetting: TimeInterval {
+        double(forKey: DemoSettingKey.skipForwardSetting.rawValue)
+    }
+
     @objc dynamic var serverSetting: ServerSetting {
         .init(rawValue: integer(forKey: DemoSettingKey.serverSetting.rawValue)) ?? .production
     }
@@ -54,6 +64,8 @@ extension UserDefaults {
         UserDefaults.standard.register(defaults: [
             DemoSettingKey.presenterModeEnabled.rawValue: false,
             DemoSettingKey.seekBehaviorSetting.rawValue: SeekBehaviorSetting.immediate.rawValue,
+            DemoSettingKey.skipBackwardSetting.rawValue: 10,
+            DemoSettingKey.skipForwardSetting.rawValue: 10,
             DemoSettingKey.smartNavigationEnabled.rawValue: true,
             DemoSettingKey.serverSetting.rawValue: ServerSetting.production.rawValue,
             DemoSettingKey.qualitySetting.rawValue: QualitySetting.high.rawValue

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -17,8 +17,8 @@ extension UserDefaults {
         case presenterModeEnabled
         case smartNavigationEnabled
         case seekBehaviorSetting
-        case skipBackwardSetting
-        case skipForwardSetting
+        case backwardSkipInterval
+        case forwardSkipInterval
         case serverSetting
         case qualitySetting
     }
@@ -44,12 +44,12 @@ extension UserDefaults {
         .init(rawValue: integer(forKey: DemoSettingKey.seekBehaviorSetting.rawValue)) ?? .immediate
     }
 
-    @objc dynamic var skipBackwardSetting: TimeInterval {
-        double(forKey: DemoSettingKey.skipBackwardSetting.rawValue)
+    @objc dynamic var backwardSkipInterval: TimeInterval {
+        double(forKey: DemoSettingKey.backwardSkipInterval.rawValue)
     }
 
-    @objc dynamic var skipForwardSetting: TimeInterval {
-        double(forKey: DemoSettingKey.skipForwardSetting.rawValue)
+    @objc dynamic var forwardSkipInterval: TimeInterval {
+        double(forKey: DemoSettingKey.forwardSkipInterval.rawValue)
     }
 
     @objc dynamic var serverSetting: ServerSetting {
@@ -64,8 +64,8 @@ extension UserDefaults {
         UserDefaults.standard.register(defaults: [
             DemoSettingKey.presenterModeEnabled.rawValue: false,
             DemoSettingKey.seekBehaviorSetting.rawValue: SeekBehaviorSetting.immediate.rawValue,
-            DemoSettingKey.skipBackwardSetting.rawValue: 10,
-            DemoSettingKey.skipForwardSetting.rawValue: 10,
+            DemoSettingKey.backwardSkipInterval.rawValue: 10,
+            DemoSettingKey.forwardSkipInterval.rawValue: 10,
             DemoSettingKey.smartNavigationEnabled.rawValue: true,
             DemoSettingKey.serverSetting.rawValue: ServerSetting.production.rawValue,
             DemoSettingKey.qualitySetting.rawValue: QualitySetting.high.rawValue

--- a/Sources/Player/Player+Skip.swift
+++ b/Sources/Player/Player+Skip.swift
@@ -30,6 +30,7 @@ public extension Player {
 
     /// Checks whether skipping in some direction is possible.
     ///
+    /// - Parameter skip: The skip direction.
     /// - Returns: `true` if possible.
     func canSkip(_ skip: Skip) -> Bool {
         switch skip {


### PR DESCRIPTION
## Description

The Pillarbox player allows configuring skip intervals (10 seconds by default). However, in our demo app, these configured intervals are not reflected in the UI, as we are currently using `gobackward.10` and `goforward.10` symbols respectively for the skip backward button and skip forward button.

This PR allows us to solve this issue by using the player configuration intervals in the UI, whenever possible. The player configuration accepts any `TimeInterval` value, which means the possible values are unlimited unlike **SF Symbols** which provides for the moment only limited set of values (5, 10, 15, 30, 45, 60, 75 and 90).
In case of undefined symbol, we will use `gobackward` and `goforward` symbol with no associated value.

Modifying the following code in Pillarbox did not affect the demo behavior before this PR:

```swift
public struct PlayerConfiguration {
    // ...
    public init(
		// ...,
        backwardSkipInterval: TimeInterval = 5,
        forwardSkipInterval: TimeInterval = 15,
    ) {
		// ...
    }
}
```

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/378de49d-d9a1-4a14-87b6-599e3a76506e) | ![after](https://github.com/user-attachments/assets/22b3ce22-144e-42af-919b-e18a79c45deb) |

## Changes made

- An extension on `Image` has been introduced allowing to use a fallback symbol in case the provided system symbol name does not exist.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] The playground has been updated (if relevant).
