### PR TITLE
Improve standard settings menu

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -9,9 +9,33 @@
     },
     "%g× %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$g× %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "%1$g× %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$g× %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$g× %2$@"
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "%1$g× %2$@"
           }
         }

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -4,14 +4,10 @@
     " in Switzerland" : {
 
     },
-    "-" : {
-
-    },
     "-%llds" : {
 
     },
     "%g× %@" : {
-      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -21,13 +17,13 @@
         }
       }
     },
-    "%lf seconds" : {
-
-    },
     "%lld seconds" : {
 
     },
     "+%llds" : {
+
+    },
+    "360° videos" : {
 
     },
     "Action at item end" : {
@@ -51,7 +47,13 @@
     "Append" : {
 
     },
+    "Apple streams" : {
+
+    },
     "Application" : {
+
+    },
+    "Aspect ratios" : {
 
     },
     "Asset" : {
@@ -64,6 +66,12 @@
 
     },
     "Backward by" : {
+
+    },
+    "BBC Test Card streams" : {
+
+    },
+    "Bitmovin streams" : {
 
     },
     "Blue" : {
@@ -96,10 +104,16 @@
     "Continues if possible" : {
 
     },
+    "Corner cases" : {
+
+    },
     "Curr. %.02f Mbps" : {
 
     },
     "Current position" : {
+
+    },
+    "Custom Player and Picture in Picture (PiP) support" : {
 
     },
     "Data volume" : {
@@ -220,15 +234,21 @@
 
     },
     "Metrics" : {
-      "comment" : "Playback setting menu title"
+
     },
     "Min. %.02f Mbps" : {
+
+    },
+    "Miscellaneous player features (using Pillarbox)" : {
 
     },
     "Mode" : {
 
     },
     "Multiplier" : {
+
+    },
+    "Mux streams" : {
 
     },
     "Next" : {
@@ -270,6 +290,9 @@
     "Picture in Picture" : {
 
     },
+    "Picture in Picture Corner Cases" : {
+
+    },
     "Play" : {
 
     },
@@ -295,6 +318,9 @@
 
     },
     "Project" : {
+
+    },
+    "Protected streams (URNs)" : {
 
     },
     "Quality" : {
@@ -342,6 +368,9 @@
     "Source code" : {
 
     },
+    "SRG SSR streams (URNs)" : {
+
+    },
     "Stalls" : {
 
     },
@@ -369,7 +398,16 @@
     "System player (using Pillarbox)" : {
 
     },
+    "System Player and Picture in Picture (PiP) support" : {
+
+    },
     "TestFlight builds" : {
+
+    },
+    "Third-party streams" : {
+
+    },
+    "Time ranges" : {
 
     },
     "Top" : {
@@ -393,6 +431,12 @@
     "Type" : {
 
     },
+    "Unbuffered streams" : {
+
+    },
+    "Unified Streaming streams" : {
+
+    },
     "URI" : {
 
     },
@@ -403,9 +447,6 @@
 
     },
     "URL with SRG SSR token protection" : {
-
-    },
-    "URN" : {
 
     },
     "URN (Production)" : {
@@ -421,6 +462,9 @@
 
     },
     "Value" : {
+
+    },
+    "Various streams (URLs)" : {
 
     },
     "Version information" : {

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -207,7 +207,7 @@ struct ExamplesView: View {
         section(title: "Corner cases", medias: model.cornerCaseMedias)
     }
 
-    private func section(title: String, medias: [Media]) -> some View {
+    private func section(title: LocalizedStringKey, medias: [Media]) -> some View {
         CustomSection(title) {
             ForEach(medias, id: \.self) { media in
                 Cell(title: media.title, subtitle: media.subtitle, imageUrl: media.imageUrl) {

--- a/Demo/Sources/Model/SeekBehaviorSetting.swift
+++ b/Demo/Sources/Model/SeekBehaviorSetting.swift
@@ -4,14 +4,14 @@
 //  License information is available from the LICENSE file.
 //
 
-import Foundation
+import SwiftUI
 
 @objc
 enum SeekBehaviorSetting: Int, CaseIterable {
     case immediate
     case deferred
 
-    var name: String {
+    var name: LocalizedStringKey {
         switch self {
         case .immediate:
             return "Immediate"

--- a/Demo/Sources/Views/CustomSection.swift
+++ b/Demo/Sources/Views/CustomSection.swift
@@ -33,7 +33,7 @@ struct CustomSection<Content, Header>: View where Content: View, Header: View {
 }
 
 extension CustomSection where Header == Text {
-    init(_ title: String, @ViewBuilder content: @escaping () -> Content) {
+    init(_ title: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
         self.init {
             content()
         } header: {

--- a/Sources/Player/MediaSelection/MediaSelectionOption.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionOption.swift
@@ -25,9 +25,9 @@ public enum MediaSelectionOption: Hashable {
     public var displayName: String {
         switch self {
         case .automatic:
-            return String(localized: "Auto (Recommended)", bundle: .module, comment: "Subtitle selection option")
+            return String(localized: "Auto (Recommended)", bundle: .module, comment: "Media selection option")
         case .off:
-            return String(localized: "Off", bundle: .module, comment: "Subtitle selection option")
+            return String(localized: "Off", bundle: .module, comment: "Media selection option")
         case let .on(option):
             return option.displayName
         }

--- a/Sources/Player/Player+SettingsMenu.swift
+++ b/Sources/Player/Player+SettingsMenu.swift
@@ -50,7 +50,7 @@ private struct MediaSelectionMenuContent: View {
     private var title: String {
         switch characteristic {
         case .audible:
-            "Languages"
+            "Audio"
         case .legible:
             "Subtitles"
         default:
@@ -113,7 +113,7 @@ private struct SettingsMenuContent: View {
             mediaSelectionMenuContent(characteristic: .audible)
         } label: {
             Button(action: {}) {
-                Text("Languages", bundle: .module, comment: "Playback setting menu title")
+                Text("Audio", bundle: .module, comment: "Playback setting menu title")
                 Text(player.selectedMediaOption(for: .audible).displayName)
                 Image(systemName: "waveform.circle")
             }

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -36,6 +36,17 @@
         }
       }
     },
+    "Audio" : {
+      "comment" : "Playback setting menu title",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio"
+          }
+        }
+      }
+    },
     "Auto (Recommended)" : {
       "comment" : "Subtitle selection option",
       "localizations" : {
@@ -102,41 +113,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "E%lld"
-          }
-        }
-      }
-    },
-    "Languages" : {
-      "comment" : "Playback setting menu title",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Languages"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langues"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lingue"
-          }
-        },
-        "rm" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linguas"
           }
         }
       }

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -39,7 +39,31 @@
     "Audio" : {
       "comment" : "Playback setting menu title",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio"
+          }
+        },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio"
+          }
+        },
+        "rm" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Audio"

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -48,7 +48,7 @@
       }
     },
     "Auto (Recommended)" : {
-      "comment" : "Subtitle selection option",
+      "comment" : "Media selection option",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -118,7 +118,7 @@
       }
     },
     "Off" : {
-      "comment" : "Subtitle selection option",
+      "comment" : "Media selection option",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
## Description

This PR improves consistency of our standard settings menu with the system player menu.

## Changes made

- Replace _Languages_ with _Audio_.
- Ensure correct localization file embedding by providing at least one localization.
- Improve demo localization extraction.

### Remark

In comparison to the current system player menu we use a singular form for all option selection needs. The current system player menu applies a plural form to options related to subtitles, but implementing the same behavior for our menu is not entirely trivial (we already expose a `displayName` that is common for all options, but audio and subtitles use singular, resp. plural forms in the system player menu).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
