### PR TITLE
Avoid using isActive as published var

### DIFF
--- a/Sources/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player+ControlCenter.swift
@@ -127,7 +127,7 @@ extension Player {
     }
 
     func nowPlayingPublisher() -> AnyPublisher<NowPlaying, Never> {
-        Publishers.CombineLatest($isActive, queuePublisher)
+        Publishers.CombineLatest(isActivePublisher, queuePublisher)
             .map { [weak self] isActive, queue in
                 guard let self, isActive, !queue.isActive else { return Just(NowPlaying.empty).eraseToAnyPublisher() }
                 return Publishers.CombineLatest(

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -56,15 +56,22 @@ public final class Player: ObservableObject, Equatable {
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
-    @Published var isActive = false {
-        didSet {
-            if isActive {
+    // swiftlint:disable:next private_subject
+    let isActivePublisher = CurrentValueSubject<Bool, Never>(false)
+
+    var isActive: Bool {
+        get {
+            isActivePublisher.value
+        }
+        set {
+            if newValue {
                 nowPlayingSession.becomeActiveIfPossible()
                 queuePlayer.allowsExternalPlayback = configuration.allowsExternalPlayback
             }
             else {
                 queuePlayer.allowsExternalPlayback = false
             }
+            isActivePublisher.send(newValue)
         }
     }
 

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -56,7 +56,7 @@ public final class Player: ObservableObject, Equatable {
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
-    var isActive: Bool {
+    private var isActive: Bool {
         get {
             isActivePublisher.value
         }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -56,9 +56,6 @@ public final class Player: ObservableObject, Equatable {
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
-    // swiftlint:disable:next private_subject
-    let isActivePublisher = CurrentValueSubject<Bool, Never>(false)
-
     var isActive: Bool {
         get {
             isActivePublisher.value
@@ -207,10 +204,13 @@ public final class Player: ObservableObject, Equatable {
     var commandRegistrations: [any RemoteCommandRegistrable] = []
 
     // swiftlint:disable:next private_subject
-    var desiredPlaybackSpeedPublisher = PassthroughSubject<Float, Never>()
+    let isActivePublisher = CurrentValueSubject<Bool, Never>(false)
 
     // swiftlint:disable:next private_subject
-    var textStyleRulesPublisher = CurrentValueSubject<[AVTextStyleRule], Never>([])
+    let desiredPlaybackSpeedPublisher = PassthroughSubject<Float, Never>()
+
+    // swiftlint:disable:next private_subject
+    let textStyleRulesPublisher = CurrentValueSubject<[AVTextStyleRule], Never>([])
 
     /// Creates a player with a given item queue.
     ///

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -56,7 +56,7 @@ public final class Player: ObservableObject, Equatable {
     @Published var storedItems: Deque<PlayerItem>
     @Published var _playbackSpeed: PlaybackSpeed = .indefinite
 
-    private var isActive: Bool {
+    var isActive: Bool {
         get {
             isActivePublisher.value
         }

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -463,13 +463,12 @@ private extension Player {
     }
 
     func configureControlCenterRemoteCommandUpdatePublisher() {
-        Publishers.CombineLatest3(
+        Publishers.CombineLatest(
             queuePublisher,
-            propertiesPublisher,
-            $isActive
+            propertiesPublisher
         )
         .receiveOnMainThread()
-        .sink { [weak self] queue, properties, _ in
+        .sink { [weak self] queue, properties in
             guard let self else { return }
             let areSkipsEnabled = queue.elements.count <= 1 && properties.streamType != .live
             let hasError = queue.error != nil


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- `isActive` published var has been converted into a var with an associated publisher/subject.
- `textStyleRulesPublisher` and `desiredPlaybackSpeedPublisher` have been converted into constants.
- The update regarding the remote command of the Control Center no longer relies on the `isActive` publisher.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
