### PR TITLE
Remove picker label where superfluous

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -218,9 +218,6 @@
     "Insert before" : {
 
     },
-    "Insertion options" : {
-
-    },
     "Jump to live" : {
 
     },
@@ -264,9 +261,6 @@
 
     },
     "Miscellaneous player features (using Pillarbox)" : {
-
-    },
-    "Mode" : {
 
     },
     "Multiplier" : {

--- a/Demo/Sources/ContentLists/ContentListsView.swift
+++ b/Demo/Sources/ContentLists/ContentListsView.swift
@@ -116,10 +116,12 @@ struct ContentListsView: View {
 #if os(iOS)
     private func serverSettingsMenu() -> some View {
         Menu {
-            Picker("Server", selection: $selectedServerSetting) {
+            Picker(selection: $selectedServerSetting) {
                 ForEach(ServerSetting.allCases, id: \.self) { service in
                     Text(service.title).tag(service)
                 }
+            } label: {
+                EmptyView()
             }
         } label: {
             Label("Server", systemImage: "server.rack")

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -476,10 +476,12 @@ private struct QualityMenu: View {
 
     var body: some View {
         Menu {
-            Picker("Quality", selection: $qualitySetting) {
+            Picker(selection: $qualitySetting) {
                 ForEach(QualitySetting.allCases, id: \.self) { quality in
                     Text(quality.name).tag(quality)
                 }
+            } label: {
+                EmptyView()
             }
             .pickerStyle(.inline)
         } label: {

--- a/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistSelectionView.swift
@@ -72,11 +72,13 @@ struct PlaylistSelectionView: View {
     }
 
     private func picker() -> some View {
-        Picker("Insertion options", selection: $selectedInsertionOption) {
+        Picker(selection: $selectedInsertionOption) {
             ForEach(InsertionOption.allCases, id: \.self) { option in
                 Text(option.name)
                     .tag(option)
             }
+        } label: {
+            EmptyView()
         }
         .pickerStyle(.segmented)
         .padding(.horizontal)

--- a/Demo/Sources/Showcase/TwinsView.swift
+++ b/Demo/Sources/Showcase/TwinsView.swift
@@ -30,10 +30,12 @@ struct TwinsView: View {
             }
             .background(.black)
 
-            Picker("Mode", selection: $mode) {
+            Picker(selection: $mode) {
                 Text("Both").tag(Mode.both)
                 Text("Top").tag(Mode.top)
                 Text("Bottom").tag(Mode.bottom)
+            } label: {
+                EmptyView()
             }
             .pickerStyle(.segmented)
             .padding()

--- a/Sources/Player/Player+SettingsMenu.swift
+++ b/Sources/Player/Player+SettingsMenu.swift
@@ -15,10 +15,12 @@ private struct PlaybackSpeedMenuContent: View {
     @ObservedObject var player: Player
 
     var body: some View {
-        Picker("Playback Speed", selection: selection) {
+        Picker(selection: selection) {
             ForEach(playbackSpeeds, id: \.self) { speed in
                 Text("\(speed, specifier: "%g×")", comment: "Speed multiplier").tag(speed)
             }
+        } label: {
+            EmptyView()
         }
         .pickerStyle(.inline)
     }
@@ -47,22 +49,13 @@ private struct MediaSelectionMenuContent: View {
 
     @ObservedObject var player: Player
 
-    private var title: String {
-        switch characteristic {
-        case .audible:
-            "Audio"
-        case .legible:
-            "Subtitles"
-        default:
-            ""
-        }
-    }
-
     var body: some View {
-        Picker(title, selection: selection(for: characteristic)) {
+        Picker(selection: selection(for: characteristic)) {
             ForEach(mediaOptions, id: \.self) { option in
                 Text(option.displayName).tag(option)
             }
+        } label: {
+            EmptyView()
         }
         .pickerStyle(.inline)
     }


### PR DESCRIPTION
## Description

This PR removes superfluous (redundant) picker labels, most notably when using the segmented or inline styles.

### Remark

The `.inline` picker style must be provided so that menus can be displayed when running the iPad app on macOS. Note that there is still a bug that makes empty menus appear on this platform, though.

## Changes made

- Remove segmented/inline picker labels. Replace with `EmptyView` to avoid inserting a dummy string which would require localization.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
