### PR TITLE
Improve CI reliability

### DIFF
--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -9,6 +9,7 @@
 import Nimble
 import PillarboxCircumspect
 import TCServerSide
+import XCTest
 
 final class CommandersActEventTests: CommandersActTestCase {
     func testMergingWithGlobals() {
@@ -35,8 +36,10 @@ final class CommandersActEventTests: CommandersActTestCase {
         ]))
     }
 
-    func testBlankName() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testBlankName() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(Analytics.shared.sendEvent(commandersAct: .init(name: " "))).to(throwAssertion())
     }
 

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -8,6 +8,7 @@
 
 import Nimble
 import PillarboxCircumspect
+import XCTest
 
 final class CommandersActPageViewTests: CommandersActTestCase {
     func testMergingWithGlobals() {
@@ -77,13 +78,17 @@ final class CommandersActPageViewTests: CommandersActTestCase {
         }
     }
 
-    func testBlankTitle() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testBlankTitle() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(Analytics.shared.trackPageView(commandersAct: .init(name: " ", type: "type"))).to(throwAssertion())
     }
 
-    func testBlankType() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testBlankType() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(Analytics.shared.trackPageView(commandersAct: .init(name: "name", type: " "))).to(throwAssertion())
     }
 

--- a/Tests/CoreTests/RangeReplaceableCollectionTests.swift
+++ b/Tests/CoreTests/RangeReplaceableCollectionTests.swift
@@ -35,15 +35,19 @@ final class RangeReplaceableCollectionTests: XCTestCase {
         expect(array).to(equalDiff([1, 2, 3, 4, 5, 6, 7]))
     }
 
-    func testMoveFromInvalidIndex() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testMoveFromInvalidIndex() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: -1, to: 2)).to(throwAssertion())
         expect(array.move(from: 8, to: 2)).to(throwAssertion())
     }
 
-    func testMoveToInvalidIndex() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testMoveToInvalidIndex() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         var array = [1, 2, 3, 4, 5, 6, 7]
         expect(array.move(from: 2, to: -1)).to(throwAssertion())
         expect(array.move(from: 2, to: 8)).to(throwAssertion())

--- a/Tests/PlayerTests/AudioSession/AVAudioSessionNotificationTests.swift
+++ b/Tests/PlayerTests/AudioSession/AVAudioSessionNotificationTests.swift
@@ -8,14 +8,20 @@
 
 import AVFAudio
 import Nimble
+import XCTest
 
 final class AVAudioSessionNotificationTests: TestCase {
     override func setUp() {
-        AVAudioSession.enableUpdateNotifications()
-        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, policy: .default, options: [])
+        if #unavailable(iOS 18, tvOS 18) {
+            AVAudioSession.enableUpdateNotifications()
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, policy: .default, options: [])
+        }
     }
 
     func testUpdateWithSetCategoryModePolicyOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, mode: .default, policy: .default, options: [.duckOthers])
@@ -25,6 +31,9 @@ final class AVAudioSessionNotificationTests: TestCase {
     }
 
     func testNoUpdateWithSetCategoryModePolicyOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, mode: .default, policy: .default, options: [])
@@ -34,6 +43,9 @@ final class AVAudioSessionNotificationTests: TestCase {
     }
 
     func testUpdateWithSetCategoryModeOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, mode: .default, options: [.duckOthers])
@@ -43,6 +55,9 @@ final class AVAudioSessionNotificationTests: TestCase {
     }
 
     func testNoUpdateWithSetCategoryModeOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, mode: .default, options: [])
@@ -52,6 +67,9 @@ final class AVAudioSessionNotificationTests: TestCase {
     }
 
     func testUpdateWithSetCategoryOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, options: [.duckOthers])
@@ -61,6 +79,9 @@ final class AVAudioSessionNotificationTests: TestCase {
     }
 
     func testNoUpdateWithSetCategoryOptions() throws {
+        if #available(iOS 18, tvOS 18, *) {
+            throw XCTSkip("Skipped on iOS/tvOS 18 and later.")
+        }
         let audioSession = AVAudioSession.sharedInstance()
         expect {
             try audioSession.setCategory(.playback, options: [])

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -11,6 +11,7 @@ import Nimble
 import OrderedCollections
 import PillarboxCircumspect
 import PillarboxStreams
+import XCTest
 
 private class QueuePlayerMock: QueuePlayer {
     var seeks: Int = 0
@@ -22,8 +23,10 @@ private class QueuePlayerMock: QueuePlayer {
 }
 
 final class QueuePlayerSeekTests: TestCase {
-    func testNotificationsForSeekWithInvalidTime() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testNotificationsForSeekWithInvalidTime() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         let item = AVPlayerItem(url: Stream.onDemand.url)
         let player = QueuePlayer(playerItem: item)
         expect { player.seek(to: .invalid) }.to(throwAssertion())

--- a/Tests/PlayerTests/UserInterface/SkipTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/SkipTrackerTests.swift
@@ -10,6 +10,7 @@ import Nimble
 import ObjectiveC
 import PillarboxCircumspect
 import PillarboxStreams
+import XCTest
 
 #if os(iOS)
 final class SkipTrackerTests: TestCase {
@@ -101,13 +102,17 @@ final class SkipTrackerTests: TestCase {
         expect(player.time().seconds).toEventually(beGreaterThan(5))
     }
 
-    func testInvalidCount() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testInvalidCount() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(SkipTracker(delay: 0)).to(throwAssertion())
     }
 
-    func testInvalidDelay() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testInvalidDelay() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(SkipTracker(count: 0)).to(throwAssertion())
     }
 

--- a/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
+++ b/Tests/PlayerTests/UserInterface/VisibilityTrackerTests.swift
@@ -10,6 +10,7 @@ import Nimble
 import ObjectiveC
 import PillarboxCircumspect
 import PillarboxStreams
+import XCTest
 
 #if os(iOS)
 final class VisibilityTrackerTests: TestCase {
@@ -124,8 +125,10 @@ final class VisibilityTrackerTests: TestCase {
         expect(visibilityTracker.isUserInterfaceHidden).toEventually(beTrue())
     }
 
-    func testInvalidDelay() {
-        guard nimbleThrowAssertionsAvailable() else { return }
+    func testInvalidDelay() throws {
+        guard nimbleThrowAssertionsAvailable() else {
+            throw XCTSkip("Skipped due to missing throw assertion test support.")
+        }
         expect(VisibilityTracker(delay: -5)).to(throwAssertion())
     }
 


### PR DESCRIPTION
## Description

This PR skips tests that trigger a failure in Nimble notification observation code we don't own.

## Changes made

- Disable tests for `AVAudioSession` notifications on iOS/tvOS 18 and above. The code we introduced is only relevant for iOS/tvOS 16 and 17 anyway and is only meant to test behavior for these OS versions. Our CI runs on iOS/tvOS 18, these tests are therefore not useful.
- Explicitly skip tests relying on the availabilty of Nimble throw assertions.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
