### PR TITLE
Only return chapters for episodes

### DIFF
--- a/Sources/CoreBusiness/Model/MediaComposition.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition.swift
@@ -45,7 +45,8 @@ public struct MediaComposition: Decodable {
 
 extension MediaComposition {
     func chapters(relatedTo chapter: Chapter) -> [Chapter] {
-        chapters.filter { $0.fullLengthUrn == chapter.urn && $0.mediaType == chapter.mediaType }
+        guard chapter.contentType == .episode else { return [] }
+        return chapters.filter { $0.fullLengthUrn == chapter.urn && $0.mediaType == chapter.mediaType }
     }
 
     func chapter(for urn: String) -> Chapter? {


### PR DESCRIPTION
## Description

This PR ensures chapters are only returned for episodes. In particular this ensures that livestreams never get chapters, since those are not updated while the livestream is still running anyway.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
