### PR TITLE
Fix slider interaction issues

### DIFF
--- a/Demo/Sources/Views/HSlider.swift
+++ b/Demo/Sources/Views/HSlider.swift
@@ -34,13 +34,13 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
                     update(for: value, in: geometry)
                 }
         }
+        .preventsTouchPropagation()
         .gesture(
             DragGesture(minimumDistance: 0)
                 .updating($gestureValue) { value, state, _ in
                     state = value
                 }
         )
-        .preventsTouchPropagation()
     }
 
     /// Creates a slider to select a value from a given range.

--- a/Demo/Sources/Views/HSlider.swift
+++ b/Demo/Sources/Views/HSlider.swift
@@ -76,7 +76,8 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
             .onChanged { value in
                 onChanged(with: value, in: geometry)
             }
-            .onEnded { _ in
+            .onEnded { value in
+                onChanged(with: value, in: geometry)
                 onEnded(in: geometry)
             }
     }

--- a/Demo/Sources/Views/HSlider.swift
+++ b/Demo/Sources/Views/HSlider.swift
@@ -18,6 +18,7 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
 
     @State private var isInteracting = false
     @State private var initialProgress: Value = 0
+
     @GestureState private var gestureValue: DragGesture.Value?
 
     private var progress: Value {
@@ -30,17 +31,16 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
             content(.init(progress), geometry.size.width)
                 // Use center alignment instead of top leading alignment used by `GeometryReader`.
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .preventsTouchPropagation()
+                .gesture(dragGesture(in: geometry))
                 .onChange(of: gestureValue) { value in
-                    update(for: value, in: geometry)
+                    // Gesture cancellation can only be detected via gesture value observation,
+                    // see https://developer.apple.com/documentation/swiftui/adding-interactivity-with-gestures#Update-transient-UI-state
+                    if value == nil {
+                        onEnded(in: geometry)
+                    }
                 }
         }
-        .preventsTouchPropagation()
-        .gesture(
-            DragGesture(minimumDistance: 0)
-                .updating($gestureValue) { value, state, _ in
-                    state = value
-                }
-        )
     }
 
     /// Creates a slider to select a value from a given range.
@@ -68,22 +68,35 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
         ((value - bounds.lowerBound) / (bounds.upperBound - bounds.lowerBound)).clamped(to: bounds)
     }
 
-    private func update(for value: DragGesture.Value?, in geometry: GeometryProxy) {
-        if let value {
-            onDragging()
-            if !isInteracting {
-                isInteracting = true
-                initialProgress = progress
-                onEditingChanged(true)
+    private func dragGesture(in geometry: GeometryProxy) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .updating($gestureValue) { value, state, _ in
+                state = value
             }
-            let delta = (geometry.size.width != 0) ? Value(value.translation.width / geometry.size.width) : 0
-            self.value = Self.value(for: initialProgress + delta, in: bounds)
+            .onChanged { value in
+                onChanged(with: value, in: geometry)
+            }
+            .onEnded { _ in
+                onEnded(in: geometry)
+            }
+    }
+
+    private func onChanged(with value: DragGesture.Value, in geometry: GeometryProxy) {
+        onDragging()
+        if !isInteracting {
+            isInteracting = true
+            initialProgress = progress
+            onEditingChanged(true)
         }
-        else {
-            initialProgress = 0
-            isInteracting = false
-            onEditingChanged(false)
-        }
+        let delta = (geometry.size.width != 0) ? Value(value.translation.width / geometry.size.width) : 0
+        self.value = Self.value(for: initialProgress + delta, in: bounds)
+    }
+
+    private func onEnded(in geometry: GeometryProxy) {
+        guard isInteracting else { return }
+        initialProgress = 0
+        isInteracting = false
+        onEditingChanged(false)
     }
 }
 


### PR DESCRIPTION
## Description

This PR addresses two slider interaction issues:

- Drag gesture not working when the slider body is transparent. This isn’t a problem in our demo, but it could affect others reusing or adapting our code.
- Slider sometimes getting stuck in an active state, especially during abrupt seeking (see video below).

https://github.com/user-attachments/assets/05c2accb-d51b-40c2-ae63-11285f732982

### Remark

Though I have not verified it explicitly, I think that this also explains seek bar interaction issues experienced when seeking in an audio HLS stream. I guess that the fast growing item access log in this case (see #1225) generates performance issues that make the `onChange`/`updating` call order sometimes different, leading to sometimes incorrect state. This PR and #1225 fix this issue as well.

## Changes made

- Applied the opacity workaround before attaching the gesture modifier.
- Reworked the gesture implementation to reliably handle gesture completion and cancellation.

## Fix for stuck gestures

SwiftUI currently offers two action modifiers for gestures:

- `onChanged`
- `onEnded`

However, there’s no built-in way to handle gesture cancellation directly.

To detect cancellations, one must use a `@GestureState` and update it via the `updating` modifier. This state resets to `nil` automatically when the gesture ends or is cancelled — but the `updating` closure isn’t called on cancellation. The recommended way to observe this is by monitoring changes to the `@GestureState` using the `onChange` view modifier. ([Apple documentation reference](https://developer.apple.com/documentation/swiftui/adding-interactivity-with-gestures#Update-transient-UI-state))

In #528, we addressed a state issue where gestures could get cancelled when switching apps while dragging. We did this by implementing an `updating` modifier to maintain a `@GestureState`, and observing it via `onChange`. To simplify, we also replaced the `onChanged` and `onEnded` modifiers with this single `onChange` view observation. However, this introduced a subtle issue: in certain cases where a gesture ends normally, no `nil` change is detected by `onChange`, which causes the slider to remain stuck in an active state.

This PR resolves the issue by:

- Restoring `onChanged` and `onEnded` modifiers for proper gesture lifecycle tracking.
- Retaining the `@GestureState` for detecting cancellation, observing only its reset to `nil`.
- Using the existing `isInteracting` state to prevent interaction-ending logic from running multiple times — both via `onEnded` and in response to cancellation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
