### PR TITLE
Fix performance issues with immediate seeks in audio content

### DIFF
--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -173,17 +173,6 @@ extension AVPlayerItem {
 }
 
 extension AVPlayerItem {
-    func metricsStatePublisher() -> AnyPublisher<MetricsState, Never> {
-        NotificationCenter.default.weakPublisher(for: AVPlayerItem.newAccessLogEntryNotification, object: self)
-            .compactMap { $0.object as? AVPlayerItem }
-            .prepend(self)
-            .compactMap { .init(from: $0) }
-            .removeDuplicates()
-            .eraseToAnyPublisher()
-    }
-}
-
-extension AVPlayerItem {
     func metricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
         Publishers.Merge4(
             assetMetricEventPublisher(),

--- a/Sources/Player/Types/SeekBehavior.swift
+++ b/Sources/Player/Types/SeekBehavior.swift
@@ -7,6 +7,8 @@
 /// A behavior for progress updates during a seek operation.
 public enum SeekBehavior {
     /// A behavior updating progress immediately during a seek.
+    ///
+    /// > Note: This behavior is only applied to video content.
     case immediate
 
     /// A behavior deferring progress update after a seek ends.

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -83,7 +83,7 @@ public final class ProgressTracker: ObservableObject {
         set {
             guard _progress != nil else { return }
             _progress = Self.validProgress(newValue, in: range)
-            guard seekBehavior == .immediate else { return }
+            guard seeksImmediately() else { return }
             seek(to: newValue, optimal: true)
         }
     }
@@ -197,7 +197,7 @@ public final class ProgressTracker: ObservableObject {
     }
 
     private func pausePlaybackIfNeeded(with player: Player?) {
-        guard let player, player.playbackState == .playing, seekBehavior == .immediate else { return }
+        guard let player, player.playbackState == .playing, seeksImmediately() else { return }
         player.pause()
         wasPaused = true
     }
@@ -206,6 +206,11 @@ public final class ProgressTracker: ObservableObject {
         guard let player, wasPaused else { return }
         player.play()
         wasPaused = false
+    }
+
+    private func seeksImmediately() -> Bool {
+        guard let player else { return false }
+        return seekBehavior == .immediate && player.mediaType == .video
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes performance issues due to `AVPlayerItem` access log explosion when seeking continuously in an audio content. This most notably occurs when a `ProgressTracker` is used in `.immediate` mode.

More information is available from the [related issue](https://github.com/SRGSSR/pillarbox-apple/issues/1162#issuecomment-2888555731). 

## Changes made

- Never apply `.immediate` progress tracker seek behavior for audio content. This is not useful anyway since there is nothing to be heard during a seek (unlike trick mode for video content).
- Remove dead publisher code.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
