### PR TITLE
Remove non-existing streaming constants

### DIFF
--- a/Sources/CoreBusiness/Model/MediaComposition+StreamingMethod.swift
+++ b/Sources/CoreBusiness/Model/MediaComposition+StreamingMethod.swift
@@ -22,12 +22,6 @@ public extension MediaComposition {
         /// Real-Time Messaging Protocol.
         case rtmp = "RTMP"
 
-        /// Streaming served over HTTP.
-        case http = "HTTP"
-
-        /// Streaming served over HTTPS.
-        case https = "HTTPS"
-
         /// Dynamic Adaptive Streaming over HTTP.
         case dash = "DASH"
 
@@ -35,6 +29,6 @@ public extension MediaComposition {
         case unknown = "UNKNOWN"
 
         /// The supported streaming methods on Apple platforms.
-        public static let supportedMethods: [Self] = [.hls, .https, .http, .m3uPlaylist, .progressive]
+        public static let supportedMethods: [Self] = [.hls, .m3uPlaylist, .progressive]
     }
 }


### PR DESCRIPTION
## Description

`HTTP` and `HTTPS` streaming constants have been removed [a while ago](https://github.com/mmz-srf/integrationlayer/commit/b794c43da6933ced8ded0c45eb6a4bdda3f8fdaa).

### Remark

These constants were ported over from SRG Data Provider, in which we will just keep them to avoid introducing a breaking change.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
