### PR TITLE
Fix performance issues due to access log and date retrieval

### DIFF
--- a/Demo/Sources/Metrics/DataVolumeChart.swift
+++ b/Demo/Sources/Metrics/DataVolumeChart.swift
@@ -9,7 +9,7 @@ import PillarboxPlayer
 import SwiftUI
 
 struct DataVolumeChart: View {
-    private static let megabytes: String = {
+    private static let megabytes = {
         let formatter = MeasurementFormatter()
         formatter.unitStyle = .short
         return formatter.string(from: UnitInformationStorage.megabytes)

--- a/Demo/Sources/Metrics/MetricEventCell.swift
+++ b/Demo/Sources/Metrics/MetricEventCell.swift
@@ -9,14 +9,14 @@ import PillarboxPlayer
 import SwiftUI
 
 struct MetricEventCell: View {
-    private static let dateFormatter: DateFormatter = {
+    private static let dateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter
     }()
 
-    private static let durationFormatter: DateComponentsFormatter = {
+    private static let durationFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.zeroFormattingBehavior = .pad

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -587,21 +587,21 @@ private struct TimeBar: View {
 }
 
 private struct TimeSlider: View {
-    private static let shortFormatter: DateComponentsFormatter = {
+    private static let shortFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.second, .minute]
         formatter.zeroFormattingBehavior = .pad
         return formatter
     }()
 
-    private static let longFormatter: DateComponentsFormatter = {
+    private static let longFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.second, .minute, .hour]
         formatter.zeroFormattingBehavior = .pad
         return formatter
     }()
 
-    private static let timeFormatter: DateFormatter = {
+    private static let timeFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .medium

--- a/Demo/Sources/Players/PlayerView.swift
+++ b/Demo/Sources/Players/PlayerView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 private struct ChapterCell: View {
     private static let width: CGFloat = 200
 
-    private static let durationFormatter: DateComponentsFormatter = {
+    private static let durationFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.second, .minute]
         formatter.zeroFormattingBehavior = .pad

--- a/Sources/Analytics/ComScore/ComScoreService.swift
+++ b/Sources/Analytics/ComScore/ComScoreService.swift
@@ -8,9 +8,7 @@ import ComScore
 import Foundation
 
 struct ComScoreService {
-    private var applicationVersion: String {
-        Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
-    }
+    private static let applicationVersion = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
 
     func start(with configuration: Analytics.Configuration, globals: ComScoreGlobals?) {
         let publisherConfiguration = SCORPublisherConfiguration { builder in
@@ -25,11 +23,11 @@ struct ComScoreService {
         if let comScoreConfiguration = SCORAnalytics.configuration() {
             comScoreConfiguration.addClient(with: publisherConfiguration)
 
-            comScoreConfiguration.applicationVersion = applicationVersion
+            comScoreConfiguration.applicationVersion = Self.applicationVersion
             comScoreConfiguration.preventAdSupportUsage = true
             comScoreConfiguration.addPersistentLabels([
                 "mp_brand": configuration.vendor.rawValue,
-                "mp_v": applicationVersion
+                "mp_v": Self.applicationVersion
             ])
             if let globals {
                 comScoreConfiguration.addStartLabels(globals.labels)

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -4,52 +4,61 @@
 //  License information is available from the LICENSE file.
 //
 
+import PillarboxCore
 import TCServerSide
 
 final class CommandersActService {
     private var serverSide: ServerSide?
     private var vendor: Vendor?
 
+    private let lock = NSRecursiveLock()
+
     func start(with configuration: Analytics.Configuration) {
-        vendor = configuration.vendor
+        withLock(lock) {
+            vendor = configuration.vendor
 
-        if let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey.rawValue) {
-            serverSide.addPermanentData("app_library_version", withValue: Analytics.version)
-            serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
-            serverSide.addPermanentData("navigation_device", withValue: Self.device)
-            serverSide.enableRunningInBackground()
-            serverSide.waitForUserAgent()
-            self.serverSide = serverSide
+            if let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey.rawValue) {
+                serverSide.addPermanentData("app_library_version", withValue: Analytics.version)
+                serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
+                serverSide.addPermanentData("navigation_device", withValue: Self.device)
+                serverSide.enableRunningInBackground()
+                serverSide.waitForUserAgent()
+                self.serverSide = serverSide
+            }
+
+            // Use the legacy V4 identifier as unique identifier in V5.
+            TCDevice.sharedInstance().sdkID = TCPredefinedVariables.sharedInstance().uniqueIdentifier()
+            TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
         }
-
-        // Use the legacy V4 identifier as unique identifier in V5.
-        TCDevice.sharedInstance().sdkID = TCPredefinedVariables.sharedInstance().uniqueIdentifier()
-        TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
     }
 
     func trackPageView(_ pageView: CommandersActPageView) {
-        guard let serverSide, let event = TCPageViewEvent(type: pageView.type) else { return }
-        pageView.labels.forEach { key, value in
-            event.addAdditionalProperty(key, withStringValue: value)
+        withLock(lock) {
+            guard let serverSide, let event = TCPageViewEvent(type: pageView.type) else { return }
+            pageView.labels.forEach { key, value in
+                event.addAdditionalProperty(key, withStringValue: value)
+            }
+            event.pageName = pageView.name
+            event.addNonBlankAdditionalProperty("navigation_property_type", withStringValue: "app")
+            event.addNonBlankAdditionalProperty("content_bu_owner", withStringValue: vendor?.rawValue)
+            pageView.levels.enumerated().forEach { index, level in
+                guard index < 8 else { return }
+                event.addNonBlankAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)
+            }
+            AnalyticsListener.capture(event)
+            serverSide.execute(event)
         }
-        event.pageName = pageView.name
-        event.addNonBlankAdditionalProperty("navigation_property_type", withStringValue: "app")
-        event.addNonBlankAdditionalProperty("content_bu_owner", withStringValue: vendor?.rawValue)
-        pageView.levels.enumerated().forEach { index, level in
-            guard index < 8 else { return }
-            event.addNonBlankAdditionalProperty("navigation_level_\(index + 1)", withStringValue: level)
-        }
-        AnalyticsListener.capture(event)
-        serverSide.execute(event)
     }
 
     func sendEvent(_ event: CommandersActEvent) {
-        guard let serverSide, let customEvent = TCCustomEvent(name: event.name) else { return }
-        event.labels.forEach { key, value in
-            customEvent.addNonBlankAdditionalProperty(key, withStringValue: value)
+        withLock(lock) {
+            guard let serverSide, let customEvent = TCCustomEvent(name: event.name) else { return }
+            event.labels.forEach { key, value in
+                customEvent.addNonBlankAdditionalProperty(key, withStringValue: value)
+            }
+            AnalyticsListener.capture(customEvent)
+            serverSide.execute(customEvent)
         }
-        AnalyticsListener.capture(customEvent)
-        serverSide.execute(customEvent)
     }
 }
 

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -54,7 +54,7 @@ final class CommandersActService {
 }
 
 extension CommandersActService {
-    private static var device: String = {
+    private static let device = {
         guard !ProcessInfo.processInfo.isRunningOnMac else { return "desktop" }
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:

--- a/Sources/Core/Lock.swift
+++ b/Sources/Core/Lock.swift
@@ -6,7 +6,8 @@
 
 import Foundation
 
-func withLock<T>(_ lock: NSLocking, execute: () -> T) -> T {
+/// Automatically manages a lock around the code to execute.
+public func withLock<T>(_ lock: NSLocking, execute: () -> T) -> T {
     lock.lock()
     let result = execute()
     lock.unlock()

--- a/Sources/Core/ReplaySubject.swift
+++ b/Sources/Core/ReplaySubject.swift
@@ -12,10 +12,11 @@ import Foundation
 /// Upon subscription new subscribers automatically receive recent values available from the buffer, as well as
 /// any relevant completion.
 public final class ReplaySubject<Output, Failure>: Subject where Failure: Error {
-    private let buffer: LimitedBuffer<Output>
-    private var completion: Subscribers.Completion<Failure>?
-    private let lock = NSRecursiveLock()
     var subscriptions: [ReplaySubscription] = []
+    private var completion: Subscribers.Completion<Failure>?
+
+    private let buffer: LimitedBuffer<Output>
+    private let lock = NSRecursiveLock()
 
     /// Creates a subject able to buffer the provided number of values.
     ///

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// Metadata associated with content loaded from a URN.
 public struct MediaMetadata {
-    private static let dateFormatter: DateFormatter = {
+    private static let dateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(identifier: "Europe/Zurich")
         dateFormatter.dateStyle = .long

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -129,12 +129,19 @@ private extension MetricsTracker {
                 model: Self.deviceModel,
                 type: Self.deviceType
             ),
-            os: .init(name: UIDevice.current.systemName, version: UIDevice.current.systemVersion),
+            os: .init(
+                name: UIDevice.current.systemName,
+                version: UIDevice.current.systemVersion
+            ),
             screen: .init(
                 width: Int(UIScreen.main.nativeBounds.width),
                 height: Int(UIScreen.main.nativeBounds.height)
             ),
-            player: .init(name: "Pillarbox", platform: "Apple", version: Player.version),
+            player: .init(
+                name: "Pillarbox",
+                platform: "Apple",
+                version: Player.version
+            ),
             media: .init(
                 assetUrl: metadata?.assetUrl,
                 id: configuration.identifier,

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -232,6 +232,11 @@ private extension MetricsTracker {
 
         MetricHitListener.capture(payload)
     }
+
+    func sendHeartbeat() {
+        guard let properties else { return }
+        sendEvent(name: .heartbeat, data: statusData(from: properties))
+    }
 }
 
 private extension MetricsTracker {
@@ -246,8 +251,7 @@ private extension MetricsTracker {
             .map { _ in }
             .prepend(())
             .sink { [weak self] _ in
-                guard let self, let properties else { return }
-                sendEvent(name: .heartbeat, data: statusData(from: properties))
+                self?.sendHeartbeat()
             }
             .store(in: &cancellables)
     }

--- a/Sources/Monitoring/MetricsTracker.swift
+++ b/Sources/Monitoring/MetricsTracker.swift
@@ -205,7 +205,7 @@ private extension MetricsTracker {
 }
 
 private extension MetricsTracker {
-    static let jsonEncoder: JSONEncoder = {
+    static let jsonEncoder = {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         return encoder
@@ -228,13 +228,8 @@ private extension MetricsTracker {
 }
 
 private extension MetricsTracker {
-    static let applicationId: String? = {
-        Bundle.main.bundleIdentifier
-    }()
-
-    static let applicationVersion: String? = {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    }()
+    static let applicationId = Bundle.main.bundleIdentifier
+    static let applicationVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
 }
 
 private extension MetricsTracker {
@@ -256,11 +251,9 @@ private extension MetricsTracker {
 }
 
 private extension MetricsTracker {
-    static let deviceId: String? = {
-        UIDevice.current.identifierForVendor?.uuidString.lowercased()
-    }()
+    static let deviceId = UIDevice.current.identifierForVendor?.uuidString.lowercased()
 
-    static let deviceModel: String = {
+    static let deviceModel = {
         var systemInfo = utsname()
         uname(&systemInfo)
         return withUnsafePointer(to: &systemInfo.machine.0) { pointer in
@@ -268,7 +261,7 @@ private extension MetricsTracker {
         }
     }()
 
-    static let deviceType: String = {
+    static let deviceType = {
         guard !ProcessInfo.processInfo.isRunningOnMac else { return "Computer" }
         switch UIDevice.current.userInterfaceIdiom {
         case .phone:

--- a/Sources/Player/Metrics/MetricEvent.swift
+++ b/Sources/Player/Metrics/MetricEvent.swift
@@ -91,14 +91,14 @@ extension MetricEvent.Kind: CustomStringConvertible {
 }
 
 extension MetricEvent: CustomStringConvertible {
-    private static let dateFormatter: DateFormatter = {
+    private static let dateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter
     }()
 
-    private static let durationFormatter: DateComponentsFormatter = {
+    private static let durationFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.zeroFormattingBehavior = .pad

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -130,7 +130,7 @@ public final class Player: ObservableObject, Equatable {
             .eraseToAnyPublisher()
     }()
 
-    /// A Boolean setting whether the audio output of the player must be muted.
+    /// A Boolean setting indicating whether the audio output of the player must be muted.
     public var isMuted: Bool {
         get {
             properties.isMuted

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -25,6 +25,7 @@ public final class PlayerItem: Hashable {
 
     @Published private(set) var content: AssetContent
     private let trackerAdapters: [any PlayerItemTracking]
+    private let queue = DispatchQueue(label: "ch.srgssr.player-item")
 
     let id = UUID()
 
@@ -289,36 +290,46 @@ extension PlayerItem {
     }
 
     func enableTrackers(matchingBehavior behavior: TrackingBehavior, for player: AVPlayer) {
-        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.enable(for: player)
+        queue.async {
+            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
+                adapter.enable(for: player)
+            }
         }
     }
 
     func updateTrackersProperties(matchingBehavior behavior: TrackingBehavior, to properties: PlayerProperties) {
-        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.updateProperties(to: .init(
-                playerProperties: properties,
-                time: properties.time(),
-                date: properties.date(),
-                metrics: properties.metrics()
-            ))
+        let time = properties.time()
+        queue.async {
+            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
+                adapter.updateProperties(to: .init(
+                    playerProperties: properties,
+                    time: time,
+                    date: properties.date(),
+                    metrics: properties.metrics()
+                ))
+            }
         }
     }
 
     func updateTrackersMetricEvents(matchingBehavior behavior: TrackingBehavior, to events: [MetricEvent]) {
-        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.updateMetricEvents(to: events)
+        queue.async {
+            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
+                adapter.updateMetricEvents(to: events)
+            }
         }
     }
 
     func disableTrackers(matchingBehavior behavior: TrackingBehavior, with properties: PlayerProperties) {
-        trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-            adapter.disable(with: .init(
-                playerProperties: properties,
-                time: properties.time(),
-                date: properties.date(),
-                metrics: properties.metrics()
-            ))
+        let time = properties.time()
+        queue.async {
+            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
+                adapter.disable(with: .init(
+                    playerProperties: properties,
+                    time: time,
+                    date: properties.date(),
+                    metrics: properties.metrics()
+                ))
+            }
         }
     }
 

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -305,7 +305,7 @@ extension PlayerItem {
             let trackerProperties = TrackerProperties(
                 playerProperties: properties,
                 time: time,
-                date: properties.date(),
+                date: properties.date(at: time),
                 metrics: properties.metrics()
             )
             adapters.forEach { adapter in
@@ -330,7 +330,7 @@ extension PlayerItem {
             let trackerProperties = TrackerProperties(
                 playerProperties: properties,
                 time: time,
-                date: properties.date(),
+                date: properties.date(at: time),
                 metrics: properties.metrics()
             )
             adapters.forEach { adapter in

--- a/Sources/Player/PlayerItem.swift
+++ b/Sources/Player/PlayerItem.swift
@@ -300,13 +300,16 @@ extension PlayerItem {
     func updateTrackersProperties(matchingBehavior behavior: TrackingBehavior, to properties: PlayerProperties) {
         let time = properties.time()
         queue.async {
-            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-                adapter.updateProperties(to: .init(
-                    playerProperties: properties,
-                    time: time,
-                    date: properties.date(),
-                    metrics: properties.metrics()
-                ))
+            let adapters = self.trackerAdapters(matchingBehavior: behavior)
+            guard !adapters.isEmpty else { return }
+            let trackerProperties = TrackerProperties(
+                playerProperties: properties,
+                time: time,
+                date: properties.date(),
+                metrics: properties.metrics()
+            )
+            adapters.forEach { adapter in
+                adapter.updateProperties(to: trackerProperties)
             }
         }
     }
@@ -322,13 +325,16 @@ extension PlayerItem {
     func disableTrackers(matchingBehavior behavior: TrackingBehavior, with properties: PlayerProperties) {
         let time = properties.time()
         queue.async {
-            self.trackerAdapters(matchingBehavior: behavior).forEach { adapter in
-                adapter.disable(with: .init(
-                    playerProperties: properties,
-                    time: time,
-                    date: properties.date(),
-                    metrics: properties.metrics()
-                ))
+            let adapters = self.trackerAdapters(matchingBehavior: behavior)
+            guard !adapters.isEmpty else { return }
+            let trackerProperties = TrackerProperties(
+                playerProperties: properties,
+                time: time,
+                date: properties.date(),
+                metrics: properties.metrics()
+            )
+            adapters.forEach { adapter in
+                adapter.disable(with: trackerProperties)
             }
         }
     }

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import os
 
 private let kContentKeySession = AVContentKeySession(keySystem: .fairPlayStreaming)
-private let kContentKeySessionQueue = DispatchQueue(label: "ch.srgssr.player.content_key_session")
+private let kContentKeySessionQueue = DispatchQueue(label: "ch.srgssr.player.content-key-session")
 
 enum Resource {
     case simple(url: URL)

--- a/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
+++ b/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
@@ -6,7 +6,7 @@
 
 import AVFoundation
 
-private let kResourceLoaderQueue = DispatchQueue(label: "ch.srgssr.player.resource_loader")
+private let kResourceLoaderQueue = DispatchQueue(label: "ch.srgssr.player.resource-loader")
 
 /// An item which stores its own custom resource loader delegate.
 final class ResourceLoadedPlayerItem: AVPlayerItem {

--- a/Sources/Player/Tracking/PlayerItemTracker.swift
+++ b/Sources/Player/Tracking/PlayerItemTracker.swift
@@ -41,6 +41,8 @@ public protocol PlayerItemTracker: AnyObject {
     /// A method called when the tracker is enabled for a player.
     ///
     /// - Parameter player: The player for which the tracker must be enabled.
+    ///
+    /// > Important: This method is called on a background thread.
     func enable(for player: AVPlayer)
 
     /// A method called when metadata is updated.
@@ -48,6 +50,8 @@ public protocol PlayerItemTracker: AnyObject {
     /// - Parameter metadata: The updated metadata.
     ///
     /// This method is always called, whether the tracker is currently active or not.
+    ///
+    /// > Important: This method is called on a background thread.
     func updateMetadata(to metadata: Metadata)
 
     /// A method called when player properties have changed.
@@ -56,6 +60,8 @@ public protocol PlayerItemTracker: AnyObject {
     ///
     /// This method can be called quite often, but only when the tracker is active. Implementations should avoid
     /// performing significant work unnecessarily.
+    ///
+    /// > Important: This method is called on a background thread.
     func updateProperties(to properties: TrackerProperties)
 
     /// A method called when metric events are updated.
@@ -63,11 +69,15 @@ public protocol PlayerItemTracker: AnyObject {
     /// - Parameter events: All events that have currently been recorded for the item.
     ///
     /// This method is only called when the tracker is active.
+    ///
+    /// > Important: This method is called on a background thread.
     func updateMetricEvents(to events: [MetricEvent])
 
     /// A method called when the tracker is disabled.
     ///
     /// - Parameter properties: The updated properties.
+    ///
+    /// > Important: This method is called on a background thread.
     func disable(with properties: TrackerProperties)
 }
 

--- a/Sources/Player/Types/Chapter.swift
+++ b/Sources/Player/Types/Chapter.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// A chapter representation.
 public struct Chapter: Equatable {
-    private static let placeholderImage: UIImage = {
+    private static let placeholderImage = {
         let rect = CGRect(x: 0, y: 0, width: 16, height: 9)
         let renderer = UIGraphicsImageRenderer(bounds: rect)
         return renderer.image { context in

--- a/Sources/Player/Types/ItemProperties.swift
+++ b/Sources/Player/Types/ItemProperties.swift
@@ -30,8 +30,7 @@ struct ItemProperties: Equatable {
 
 extension ItemProperties {
     func time() -> CMTime {
-        guard let item else { return .invalid }
-        return item.currentTime()
+        item?.currentTime() ?? .invalid
     }
 
     func date() -> Date? {

--- a/Sources/Player/Types/PlayerProperties.swift
+++ b/Sources/Player/Types/PlayerProperties.swift
@@ -128,6 +128,11 @@ extension PlayerProperties {
     func metrics() -> Metrics? {
         coreProperties.metrics()
     }
+
+    func date(at otherTime: CMTime) -> Date? {
+        guard let date = coreProperties.date() else { return nil }
+        return date.addingTimeInterval((otherTime - time()).seconds)
+    }
 }
 
 extension PlayerProperties {

--- a/Sources/Player/UserInterface/ProgressTracker.swift
+++ b/Sources/Player/UserInterface/ProgressTracker.swift
@@ -133,7 +133,7 @@ public final class ProgressTracker: ObservableObject {
                     return Just(nil).eraseToAnyPublisher()
                 }
                 return Publishers.CombineLatest(
-                    Self.currentTimePublisher(for: player, interval: interval, isInteracting: $isInteracting),
+                    Self.currentTimePublisher(for: player, interval: interval, isInteractingPublisher: $isInteracting),
                     player.propertiesPublisher.slice(at: \.seekableTimeRange)
                 )
                 .map { time, seekableTimeRange in
@@ -151,11 +151,11 @@ public final class ProgressTracker: ObservableObject {
     private static func currentTimePublisher(
         for player: Player,
         interval: CMTime,
-        isInteracting: Published<Bool>.Publisher
+        isInteractingPublisher: Published<Bool>.Publisher
     ) -> AnyPublisher<CMTime, Never> {
         Publishers.CombineLatest(
             player.queuePlayer.smoothCurrentTimePublisher(interval: interval, queue: .main),
-            isInteracting
+            isInteractingPublisher
         )
         .compactMap { time, isInteracting in
             !isInteracting ? time : nil


### PR DESCRIPTION
## Description

This PR fixes performance issues due to `AVPlayerItem` access to `accessLog()` and `currentDate()`. These potentially require RPCs to `mediaplaybackd` taking tens of ms, leading to hitches (#1049) and severe hiccups when seeking with a slider.

### Slider performance comparison

Observe how the progress bar, previously jumping during seeks, is now much smoother:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/1d8914cc-d993-4cfa-883c-114401dbee7f"/> | <video src="https://github.com/user-attachments/assets/a2eb38dd-1570-4500-8c79-de90a1345bc1"/> | 

There might remain minor hiccups when scrolling within a buffered area for some content. These can also be observed with `VideoPlayer`, `AVPlayer` and a sufficiently large `preferredForwardBufferDuration`.

### Hitches

Observe that there are no more frame drops when swiping between stories:

| Header | Header |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f8c9c955-9b8b-41cf-84f9-2adc05c47896"/> | <video src="https://github.com/user-attachments/assets/b6e4b887-a537-44ed-81f3-93db097c6a58"/> | 

## Changes made

> Please list the specific changes made in this pull request.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
