### PR TITLE
Ignore Difference package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
       packages:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "Difference"


### PR DESCRIPTION
## Description

This PR disables Dependabot updates for [Difference](https://github.com/krzysztofzablocki/Difference), see #244.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
