### PR TITLE
Fix dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,4 +34,4 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "Difference"
+      - dependency-name: "github.com/krzysztofzablocki/difference"


### PR DESCRIPTION
## Description

This PR fixes #1242, which did not deliver the expected results. According to Dependabot logs visible in the [Insights](https://github.com/SRGSSR/pillarbox-apple/network/updates) section the dependency name should be `github.com/krzysztofzablocki/difference` and not simply `Difference`.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
