### PR TITLE
Avoid blurry images for skip buttons

### DIFF
--- a/Demo/Sources/Extensions/Image.swift
+++ b/Demo/Sources/Extensions/Image.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 extension Image {
     static func goBackward(withInterval interval: TimeInterval) -> Self {
-        if let uiImage = UIImage(systemName: "gobackward.\(Int(interval))") {
-            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        let imageName = "gobackward.\(Int(interval))"
+        if UIImage(systemName: imageName) != nil {
+            return Image(systemName: imageName)
         }
         else {
             return Image(systemName: "gobackward.minus")
@@ -18,8 +19,9 @@ extension Image {
     }
 
     static func goForward(withInterval interval: TimeInterval) -> Self {
-        if let uiImage = UIImage(systemName: "goforward.\(Int(interval))") {
-            return Image(uiImage: uiImage.withRenderingMode(.alwaysTemplate))
+        let imageName = "goforward.\(Int(interval))"
+        if UIImage(systemName: imageName) != nil {
+            return Image(systemName: imageName)
         }
         else {
             return Image(systemName: "goforward.plus")

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -325,6 +325,7 @@ private struct ControlsView: View {
             PlaybackButton(player: player)
             SkipForwardButton(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
         }
+        .preventsTouchPropagation()
         ._debugBodyCounter(color: .green)
         .animation(.defaultLinear, value: player.playbackState)
         .bind(progressTracker, to: player)


### PR DESCRIPTION
## Description

Self-explanatory.

## Changes made

- The API `Image(systemName:)` has been preferred to `Image(uiImage:)`


| Previous | Current |
|--------|--------|
| ![Simulator Screenshot - iPad (A16) - 2025-06-23 at 09 45 45](https://github.com/user-attachments/assets/c1c8a0a8-fc85-45e7-932d-db17bb81e119) | ![Simulator Screenshot - iPad (A16) - 2025-06-23 at 09 45 19](https://github.com/user-attachments/assets/528f8f58-cc24-40a2-96de-a76815c2be6f) | 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
