### PR TITLE
Fix stale values returned in heartbeats

### DIFF
--- a/Sources/Analytics/CommandersAct/CommandersActHeartbeat.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActHeartbeat.swift
@@ -45,7 +45,7 @@ final class CommandersActHeartbeat {
         guard let properties else { return }
         Analytics.shared.sendEvent(commandersAct: .init(
             name: event.rawValue,
-            labels: labels(properties)
+            labels: labels(properties.current())
         ))
     }
 }

--- a/Sources/Monitoring/Tracker/MetricsTracker.swift
+++ b/Sources/Monitoring/Tracker/MetricsTracker.swift
@@ -91,7 +91,7 @@ public final class MetricsTracker: PlayerItemTracker {
     private func sendHeartbeat() {
         withLock(lock) {
             guard let properties else { return }
-            sendEvent(name: .heartbeat, data: statusData(from: properties))
+            sendEvent(name: .heartbeat, data: statusData(from: properties.current()))
         }
     }
 }

--- a/Sources/Player/Types/TrackerProperties.swift
+++ b/Sources/Player/Types/TrackerProperties.swift
@@ -7,6 +7,9 @@
 import AVFoundation
 
 /// A type describing properties accessible to tracker implementations.
+///
+/// Properties reflect time, date and metrics at the time of their capture. Updated values can be obtained by calling
+/// `current()`.
 public struct TrackerProperties {
     private let playerProperties: PlayerProperties
 
@@ -28,6 +31,16 @@ public struct TrackerProperties {
         self.time = time
         self.date = date
         self.metrics = metrics
+    }
+
+    /// Returns properties updated to match the current state.
+    public func current() -> Self {
+        .init(
+            playerProperties: playerProperties,
+            time: playerProperties.time(),
+            date: playerProperties.date(),
+            metrics: playerProperties.metrics()
+        )
     }
 }
 


### PR DESCRIPTION
## Description

This PR ensures that values returned in heartbeats (Commanders Act, monitoring) are current. For implementation options and why this proposal is made, please have a look at the associated issue.

## Changes made

- Add `current()` method to `TrackerProperties` for generation of recent values.
- Use current values in heartbeats.
- Tests have not been updated. We use small intervals and we know from experience that such tests are sadly flaky.

Current values should ideally be refreshed on a background queue. Would be straightforward with implementation changes made on `954-crashes-related-to-replaysubscription`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
