### PR TITLE
Fix incorrect busy state

### DIFF
--- a/Sources/Player/Types/PlayerProperties.swift
+++ b/Sources/Player/Types/PlayerProperties.swift
@@ -44,7 +44,7 @@ public extension PlayerProperties {
 
     /// A Boolean describing whether the player is currently buffering.
     var isBuffering: Bool {
-        !isEmpty && !timeProperties.isPlaybackLikelyToKeepUp
+        !isEmpty && !timeProperties.isPlaybackLikelyToKeepUp && coreProperties.itemProperties.item?.error == nil
     }
 
     /// A Boolean describing whether the player is currently busy (buffering or seeking).

--- a/Tests/PlayerTests/Player/ErrorTests.swift
+++ b/Tests/PlayerTests/Player/ErrorTests.swift
@@ -46,4 +46,10 @@ final class ErrorTests: TestCase {
         player.removeAllItems()
         expect(player.error).toEventually(beNil())
     }
+
+    func testNotBusyWhenError() {
+        let player = Player(item: .simple(url: Stream.unavailable.url))
+        expect(player.error).toEventuallyNot(beNil())
+        expect(player.properties.isBusy).to(beFalse())
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue related to the player `isBusy` property, which returned an incorrect state when the player failed to play an item.

## Changes made

- The `isBusy` state has been fixed. The player no longer indicates it is busy when the playback fails.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
