### PR TITLE
Make it possible to update the player item start position

### DIFF
--- a/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistViewModel.swift
@@ -79,8 +79,4 @@ final class PlaylistViewModel: ObservableObject, PictureInPicturePersistable {
             .assign(to: \.limits, on: player)
             .store(in: &cancellables)
     }
-
-    private func entry(for item: PlayerItem) -> PlaylistEntry? {
-        entries.first { $0.item == item }
-    }
 }

--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -134,6 +134,6 @@ private extension PlayerItem {
         // Limit buffering and force the player to return to the live edge when re-buffering. This ensures
         // livestreams cannot be paused and resumed in the past, as requested by business people.
         guard resource.streamType == .live else { return configuration }
-        return .init(position: configuration.position, automaticallyPreservesTimeOffsetFromLive: true, preferredForwardBufferDuration: 1)
+        return .init(automaticallyPreservesTimeOffsetFromLive: true, preferredForwardBufferDuration: 1)
     }
 }

--- a/Sources/Player/Types/PlaybackConfiguration.swift
+++ b/Sources/Player/Types/PlaybackConfiguration.swift
@@ -19,7 +19,7 @@ public struct PlaybackConfiguration {
     /// - Live edge for a livestream supporting DVR.
     ///
     /// Note that starting at the default position is always efficient, no matter which tolerances have been requested.
-    public let position: Position
+    public let position: () -> Position
 
     /// A Boolean value that indicates whether the player preserves its time offset from the live time after a
     /// buffering operation.
@@ -31,7 +31,7 @@ public struct PlaybackConfiguration {
 
     /// Creates a playback configuration.
     public init(
-        position: Position = at(.zero),
+        position: @escaping @autoclosure () -> Position = at(.zero),
         automaticallyPreservesTimeOffsetFromLive: Bool = false,
         preferredForwardBufferDuration: TimeInterval = 0
     ) {
@@ -41,8 +41,9 @@ public struct PlaybackConfiguration {
     }
 
     func apply(to item: AVPlayerItem, with metadata: PlayerMetadata) {
-        let position = position.after(metadata.blockedTimeRanges) ?? position
-        item.seek(to: position.time, toleranceBefore: position.toleranceBefore, toleranceAfter: position.toleranceAfter, completionHandler: nil)
+        let position = position()
+        let seekPosition = position.after(metadata.blockedTimeRanges) ?? position
+        item.seek(to: seekPosition.time, toleranceBefore: seekPosition.toleranceBefore, toleranceAfter: seekPosition.toleranceAfter, completionHandler: nil)
         item.automaticallyPreservesTimeOffsetFromLive = automaticallyPreservesTimeOffsetFromLive
         item.preferredForwardBufferDuration = preferredForwardBufferDuration
     }

--- a/Sources/Player/Types/PlaybackConfiguration.swift
+++ b/Sources/Player/Types/PlaybackConfiguration.swift
@@ -11,25 +11,25 @@ public struct PlaybackConfiguration {
     /// The default configuration.
     public static let `default` = Self()
 
-    /// The position to start playback at.
+    private let position: () -> Position
+    private let automaticallyPreservesTimeOffsetFromLive: Bool
+    private let preferredForwardBufferDuration: TimeInterval
+
+    /// Creates a playback configuration.
+    ///
+    /// - Parameters:
+    ///   - position: The position to start playback at.
+    ///   - automaticallyPreservesTimeOffsetFromLive: A Boolean value that indicates whether the player preserves its
+    ///     time offset from the live time after a buffering operation.
+    ///   - preferredForwardBufferDuration: The duration the player should buffer media from the network ahead of the
+    ///     playhead to guard against playback disruption.
     ///
     /// When the position time is `.zero`, playback efficiently starts at the default position:
     ///
     /// - Zero for an on-demand stream.
     /// - Live edge for a livestream supporting DVR.
     ///
-    /// Note that starting at the default position is always efficient, no matter which tolerances have been requested.
-    public let position: () -> Position
-
-    /// A Boolean value that indicates whether the player preserves its time offset from the live time after a
-    /// buffering operation.
-    public let automaticallyPreservesTimeOffsetFromLive: Bool
-
-    /// The duration the player should buffer media from the network ahead of the playhead to guard against playback
-    /// disruption.
-    public let preferredForwardBufferDuration: TimeInterval
-
-    /// Creates a playback configuration.
+    /// > Note: Starting at the default position is always efficient, no matter which tolerances have been requested.
     public init(
         position: @escaping @autoclosure () -> Position = at(.zero),
         automaticallyPreservesTimeOffsetFromLive: Bool = false,

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -117,4 +117,18 @@ final class SeekTests: TestCase {
         let player = Player(item: .simple(url: Stream.dvr.url, configuration: configuration))
         expect(player.time().seconds).toEventually(equal(10))
     }
+
+    func testPositionUpdate() {
+        var position = at(.init(value: 10, timescale: 1))
+        let configuration = PlaybackConfiguration(position: position)
+        let item = PlayerItem.simple(url: Stream.dvr.url, configuration: configuration)
+
+        let player = Player(item: item)
+        expect(player.time().seconds).toEventually(equal(10))
+        player.removeAllItems()
+
+        position = at(.init(value: 20, timescale: 1))
+        player.items = [item]
+        expect(player.time().seconds).toEventually(equal(20))
+    }
 }


### PR DESCRIPTION
## Description

This PR improves `PlaybackConfiguration` so that the start position is always read before an `AVPlayerItem` is created from the `PlayerItem` it configures. This makes it possible to support dynamic scenarios, e.g. retrieval of the most recent played position from a history.

## Changes made

- Retrieve position through a closure. Make it an autoclosure for more ergonomic use.
- Hide position property (now a closure). For consistency all other configuration properties have been hidden as well (they were not so useful publicly anyway).
- Use default position for livestream items delivered by the Core Business package.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
