### PR TITLE
Fix non-working toggle tap gesture on iOS 26

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -102,7 +102,7 @@ private struct MainView: View {
             ZStack {
                 video()
                     .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
-                    .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(skipGesture(in: geometry))
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -260,7 +260,7 @@ private struct MainView: View {
             ZStack {
                 Color(white: 0, opacity: 0.5)
                     .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
-                    .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(skipGesture(in: geometry))
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
             }

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -37,11 +37,16 @@ private struct MainView: View {
     }
 
     private var shouldHideInterface: Bool {
-        isUserInterfaceHidden || (isInteracting && seekBehaviorSetting == .optimal && !shouldKeepControlsAlwaysVisible)
+        !shouldKeepControlsAlwaysVisible &&
+            (isUserInterfaceHidden || (isInteracting && seekBehaviorSetting == .optimal) || skipTracker.isSkipping)
     }
 
     private var shouldKeepControlsAlwaysVisible: Bool {
         player.isExternalPlaybackActive || player.mediaType != .video
+    }
+
+    private var isToggleGestureEnabled: Bool {
+        !isInteracting && !skipTracker.isSkipping
     }
 
     var body: some View {
@@ -96,6 +101,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 video()
+                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
                     .accessibilityElement()
                     .accessibilityLabel("Video")
@@ -105,7 +111,6 @@ private struct MainView: View {
                 controls()
             }
             .animation(.defaultLinear, values: isUserInterfaceHidden, isInteracting)
-            .gesture(toggleGesture(), isEnabled: !isInteracting)
             .simultaneousGesture(magnificationGesture(), isEnabled: layoutInfo.isOverCurrentContext)
             .simultaneousGesture(visibilityResetGesture())
             .overlay(alignment: .center) {
@@ -254,6 +259,7 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 Color(white: 0, opacity: 0.5)
+                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .optionalNestedSimultaneousGesture(skipGesture(in: geometry))
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -86,21 +86,6 @@ extension View {
     }
 }
 
-@available(tvOS, unavailable)
-extension View {
-    /// Support for simultaneous gestures applied on nested hierarchies has been improved in iOS 18 so that all gestures
-    /// are correctly triggered.
-    @ViewBuilder
-    func optionalNestedSimultaneousGesture<T>(_ gesture: T, isEnabled: Bool = true) -> some View where T: Gesture {
-        if #available(iOS 18, *) {
-            simultaneousGesture(gesture, isEnabled: isEnabled)
-        }
-        else {
-            self
-        }
-    }
-}
-
 extension View {
     func headerStyle() -> some View {
 #if os(tvOS)


### PR DESCRIPTION
## Description

This PR fixes the UI toggle tap gesture of our custom player UI on iOS 26, which was not working anymore.

Some changes were made in iOS 26, mentioned as 155581361 in the [release notes](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes), which led to this bug.

We could have simply solved the issue by replacing `.gesture` with `.simultaneousGesture` for the tap gesture, but this would have broken another UI behavior, namely precedence of control buttons over tap gestures (e.g. tapping the play/pause button repeatedly would have enabled skipping, which is not what we want).

To solve the issue properly we now need to duplicate the toggle tap gesture so that one instance is located below the control buttons and one is located on top of the video view when no controls are visible.

Thanks to this change we could also enable the skip gesture on all versions of iOS again.

## Changes made

- Duplicate the tap gesture to avoid it taking precedence over buttons. The gesture has been made simultaneous as well since this seems more aligned with the expected behavior (per release notes, 155581361). 
- Remove `optionalNestedSimultaneousGesture`. Skip gestures are now again possible on all iOS versions.
- Tweak visibility and gesture availability conditions to get correct UI behavior and avoid tap gestures being triggered unnecessarily.

Note that the tap and skip gestures are now duplicate in pair. We could have introduced a common modifier concept but it was likely a bit too much at this stage IMHO.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
