### PR TITLE
Revert closure-based position retrieval API

### DIFF
--- a/Sources/Player/Types/PlaybackConfiguration.swift
+++ b/Sources/Player/Types/PlaybackConfiguration.swift
@@ -11,27 +11,27 @@ public struct PlaybackConfiguration {
     /// The default configuration.
     public static let `default` = Self()
 
-    private let position: () -> Position
-    private let automaticallyPreservesTimeOffsetFromLive: Bool
-    private let preferredForwardBufferDuration: TimeInterval
-
-    /// Creates a playback configuration.
-    ///
-    /// - Parameters:
-    ///   - position: The position to start playback at.
-    ///   - automaticallyPreservesTimeOffsetFromLive: A Boolean value that indicates whether the player preserves its
-    ///     time offset from the live time after a buffering operation.
-    ///   - preferredForwardBufferDuration: The duration the player should buffer media from the network ahead of the
-    ///     playhead to guard against playback disruption.
+    /// The position to start playback at.
     ///
     /// When the position time is `.zero`, playback efficiently starts at the default position:
     ///
     /// - Zero for an on-demand stream.
     /// - Live edge for a livestream supporting DVR.
     ///
-    /// > Note: Starting at the default position is always efficient, no matter which tolerances have been requested.
+    /// Note that starting at the default position is always efficient, no matter which tolerances have been requested.
+    public let position: Position
+
+    /// A Boolean value that indicates whether the player preserves its time offset from the live time after a
+    /// buffering operation.
+    public let automaticallyPreservesTimeOffsetFromLive: Bool
+
+    /// The duration the player should buffer media from the network ahead of the playhead to guard against playback
+    /// disruption.
+    public let preferredForwardBufferDuration: TimeInterval
+
+    /// Creates a playback configuration.
     public init(
-        position: @escaping @autoclosure () -> Position = at(.zero),
+        position: Position = at(.zero),
         automaticallyPreservesTimeOffsetFromLive: Bool = false,
         preferredForwardBufferDuration: TimeInterval = 0
     ) {
@@ -41,9 +41,8 @@ public struct PlaybackConfiguration {
     }
 
     func apply(to item: AVPlayerItem, with metadata: PlayerMetadata) {
-        let position = position()
-        let seekPosition = position.after(metadata.blockedTimeRanges) ?? position
-        item.seek(to: seekPosition.time, toleranceBefore: seekPosition.toleranceBefore, toleranceAfter: seekPosition.toleranceAfter, completionHandler: nil)
+        let position = position.after(metadata.blockedTimeRanges) ?? position
+        item.seek(to: position.time, toleranceBefore: position.toleranceBefore, toleranceAfter: position.toleranceAfter, completionHandler: nil)
         item.automaticallyPreservesTimeOffsetFromLive = automaticallyPreservesTimeOffsetFromLive
         item.preferredForwardBufferDuration = preferredForwardBufferDuration
     }

--- a/Tests/PlayerTests/Player/SeekTests.swift
+++ b/Tests/PlayerTests/Player/SeekTests.swift
@@ -117,18 +117,4 @@ final class SeekTests: TestCase {
         let player = Player(item: .simple(url: Stream.dvr.url, configuration: configuration))
         expect(player.time().seconds).toEventually(equal(10))
     }
-
-    func testPositionUpdate() {
-        var position = at(.init(value: 10, timescale: 1))
-        let configuration = PlaybackConfiguration(position: position)
-        let item = PlayerItem.simple(url: Stream.dvr.url, configuration: configuration)
-
-        let player = Player(item: item)
-        expect(player.time().seconds).toEventually(equal(10))
-        player.removeAllItems()
-
-        position = at(.init(value: 20, timescale: 1))
-        player.items = [item]
-        expect(player.time().seconds).toEventually(equal(20))
-    }
 }


### PR DESCRIPTION
## Description

This PR reverts most changes introduced in #1262. There was a flaw in the (auto-)closure strategy, whose purpose was to provide a way to retrieve updated positions right before playback.

This is simply not guaranteed by what was done in #1262. Since we preload a number of items (currently 2) to make continuous gapless playback possible, a second `AVPlayerItem` loaded after the current one has its position retrieved at the same time the first `AVPlayerItem` is loaded, not just before it finishes. If the current item is played for a long time, we simply cannot say that the start position of the second item is up-to-date.

This also means that the current `PlaybackConfiguration` position API is meant to set a permanent per-item start position. If we want to set a transient start position we likely need to design a new API.

## Changes made

- Revert changes made in #1262, keeping only minor unrelated improvements.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
