### PR TITLE
Fix tap gesture behavior

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -101,8 +101,8 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 video()
-                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .simultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .accessibilityElement()
                     .accessibilityLabel("Video")
                     .accessibilityHint("Double tap to toggle controls")
@@ -259,8 +259,8 @@ private struct MainView: View {
         GeometryReader { geometry in
             ZStack {
                 Color(white: 0, opacity: 0.5)
-                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .simultaneousGesture(skipGesture(in: geometry))
+                    .simultaneousGesture(toggleGesture(), isEnabled: isToggleGestureEnabled)
                     .ignoresSafeArea()
                 ControlsView(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
             }


### PR DESCRIPTION
## Description

When double-tapping with controls hidden, we expect one skip to be performed and controls to return to a non-visible state afterwards. This behavior was recently broken in #1263 and is fixed by this PR. Note that the behavior with > 2 taps was still correct.

Due to tweaks made to gestures in recent iOS versions this fix delivers the intended behavior on iOS 18+. The issue remains on iOS 16 and 17 but should be acceptable.

## Changes made

- Invert gestures in the hierarchy to inhibit undesired tap gesture recognition on double-tap.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
