### PR TITLE
Update packaging advice for reliable media selection handling

### DIFF
--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
@@ -33,7 +33,7 @@ For optimal compatibility with the ``PillarboxPlayer`` framework, certain specif
 - **CC:** Use the `CLOSED-CAPTIONS` type and set `AUTOSELECT` to `YES`.
 - **SDH:** Use the `SUBTITLES` type with the `public.accessibility.transcribes-spoken-dialog` and `public.accessibility.describes-music-and-sound` characteristics, and set `AUTOSELECT` to `YES`.
 
-Within a group of renditions (`EXT-X-MEDIA` tags with the same `TYPE` and `GROUP-ID`), tags that share the same `LANGUAGE` value must be ordered from most general (fewest or no `CHARACTERISTICS`) to most specific (the most `CHARACTERISTICS`). This ordering ensures that when no accessibility preferences are set, Pillarbox’s ``Player/setMediaSelection(preferredLanguages:for:)`` will match the general tags first.
+Within a group of renditions (`EXT-X-MEDIA` tags with the same `TYPE` and `GROUP-ID`), tags that share the same `LANGUAGE` value must be [ordered](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Multivariant-Playlist) from most general (fewest or no `CHARACTERISTICS`) to most specific (the most `CHARACTERISTICS`). This ordering ensures that when no accessibility preferences are set, Pillarbox’s ``Player/setMediaSelection(preferredLanguages:for:)`` will match the general tags first.
 
 > Note: If no closed caption content is available, you should [explicitly declare](https://developer.apple.com/library/archive/qa/qa1801/_index.html) this in the playlist by adding `CLOSED-CAPTIONS=NONE` to the `EXT-X-STREAM-INF` tag. This prevents the player from showing a CC option unnecessarily, particularly when no subtitles are present either.
 

--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
@@ -33,17 +33,19 @@ For optimal compatibility with the ``PillarboxPlayer`` framework, certain specif
 - **CC:** Use the `CLOSED-CAPTIONS` type and set `AUTOSELECT` to `YES`.
 - **SDH:** Use the `SUBTITLES` type with the `public.accessibility.transcribes-spoken-dialog` and `public.accessibility.describes-music-and-sound` characteristics, and set `AUTOSELECT` to `YES`.
 
+Within a group of renditions (`EXT-X-MEDIA` tags with the same `TYPE` and `GROUP-ID`), tags that share the same `LANGUAGE` value must be ordered from most general (fewest or no `CHARACTERISTICS`) to most specific (the most `CHARACTERISTICS`). This ordering ensures that when no accessibility preferences are set, Pillarbox’s ``Player/setMediaSelection(preferredLanguages:for:)`` will match the general tags first.
+
 > Note: If no closed caption content is available, you should [explicitly declare](https://developer.apple.com/library/archive/qa/qa1801/_index.html) this in the playlist by adding `CLOSED-CAPTIONS=NONE` to the `EXT-X-STREAM-INF` tag. This prevents the player from showing a CC option unnecessarily, particularly when no subtitles are present either.
 
 #### Troubleshooting rendition selection
 
-If renditions are not handled as expected:
+If renditions are not handled correctly (e.g., automatic selection does not work as intended, or the selected value seems incorrect):
 
-1. **Validate the Master Playlist:** Confirm attributes like `AUTOSELECT`, `FORCED`, and accessibility characteristics are correctly set.
+1. **Validate the Master Playlist:** Confirm attributes like `AUTOSELECT`, `FORCED`, and accessibility characteristics are correctly set. Within each language of a rendition group, ensure that tags without `CHARACTERISTICS` come first, followed by those with `CHARACTERISTICS`.
 2. **Check System Settings**: Ensure the device’s system settings are configured with appropriate:
     - **Languages:** List and order preferred languages correctly.
     - **Accessibility Settings:** Enable or disable AD and SDH/CC preferences as needed.
-3. **Inspect your Code:** Verify that ``Player/setMediaSelection(preferredLanguages:for:)`` is not overriding automatic selection.
+3. **Inspect your Code:** Make sure ``Player/setMediaSelection(preferredLanguages:for:)`` isn’t accidentally overriding the automatic selection when it shouldn’t.
 
 > Tip: Refer to the _Inspecting and testing streams_ section for useful troubleshooting tools.
 

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -114,6 +114,10 @@ public extension Player {
     ///
     /// This method can be used to override the default media option selection for some characteristic, e.g., to start
     /// playback with a predefined language for audio and / or subtitles.
+    ///
+    /// > Important: Media selection only works when HLS playlists are correctly formatted. If selection does not behave
+    ///   as expected, see the troubleshooting section in <doc:stream-encoding-and-packaging-advice-article> to identify
+    ///   which requirements may not have been met.
     func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
         if let item = queuePlayer.currentItem {
             properties.mediaSelectionProperties.reset(for: characteristic, in: item)


### PR DESCRIPTION
## Description

When [working on subtitle/audio track restoration](https://github.com/SRGSSR/castor/issues/144) in the Castor demo, I encountered issues with a few streams for which some tracks were not correctly restored in remote-to-local transfer scenarios.

After careful inspection it appears that these contents have playlists which fail to meet requirements from the [HLS Authoring Specification for Apple Devices](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Multivariant-Playlist) and the Pillarbox packaging advice we derived from it.

For example:

- Apple Dolby Atmos: If using `Player.setMediaSelection(preferredLanguages:for:)` to set the subtitles language to Italian, for example, Italian subtitles are displayed but the menu displays _Off_. This is because several Italian tags coexist for the same rendition group in the master playlist, with tags bearing characteristics appearing first. The `AVPlayer.setMediaSelectionCriteria(_:forMediaCharacteristic:)` finds a match in order and, providing Accessibility settings have not been enabled (most notably SDH), here returns the Italian (SDH) option instead of the raw Italian option. Since SDH subtitles are not considered as available options (again, if the corresponding Accessibility setting is not enabled), the subtitles menu displays _Off_ instead but subtitles are still visible on the video view.
- Bonjour la Suisse 5/5: Using `Player.setMediaSelection(preferredLanguages:for:)` to enable Italian audio does not work. This is because `AUTOSELECT` is incorrectly `NO` in the master playlist. Note that this requirement was already documented in our packaging advice.

This PR improves our packaging advice to mention these requirements more explicitly.

## Changes made

- Update encoding and packaging advice to mention tag ordering requirements.
- Link encoding and packaging advice documentation from media selection API documentation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
