### PR TITLE
Support empty media selection

### DIFF
--- a/Demo/Sources/Showcase/TransitionView.swift
+++ b/Demo/Sources/Showcase/TransitionView.swift
@@ -59,13 +59,13 @@ private extension Player {
             kCMTextMarkupAttribute_ItalicStyle: true
         ])
         textStyleRules = [textStyleRule]
-        setMediaSelection(preferredLanguages: [language], for: .legible)
+        setMediaSelectionPreference(.on(languages: language), for: .legible)
         isMuted = true
     }
 
     func disableSilentPlayback() {
         textStyleRules = []
-        setMediaSelection(preferredLanguages: [], for: .legible)
+        setMediaSelectionPreference(.off, for: .legible)
         isMuted = false
     }
 }

--- a/Sources/Player/Extensions/Notification.Name.swift
+++ b/Sources/Player/Extensions/Notification.Name.swift
@@ -10,6 +10,7 @@ enum SeekNotificationKey: String {
     case time
 }
 
+// swiftlint:disable:next type_name
 enum MediaSelectionCriteriaUpdateNotificationKey: String {
     case mediaSelection
 }

--- a/Sources/Player/Extensions/Notification.Name.swift
+++ b/Sources/Player/Extensions/Notification.Name.swift
@@ -6,8 +6,12 @@
 
 import Foundation
 
-enum SeekKey: String {
+enum SeekNotificationKey: String {
     case time
+}
+
+enum MediaSelectionCriteriaUpdateNotificationKey: String {
+    case mediaSelection
 }
 
 extension Notification.Name {

--- a/Sources/Player/Extensions/Notification.Name.swift
+++ b/Sources/Player/Extensions/Notification.Name.swift
@@ -13,4 +13,5 @@ enum SeekKey: String {
 extension Notification.Name {
     static let willSeek = Notification.Name("PillarboxPlayer_willSeekNotification")
     static let didSeek = Notification.Name("PillarboxPlayer_didSeekNotification")
+    static let didUpdateMediaSelectionCriteria = Notification.Name("PillarboxPlayer_didUpdateMediaSelectionCriteriaNotification")
 }

--- a/Sources/Player/Interfaces/MediaSelector.swift
+++ b/Sources/Player/Interfaces/MediaSelector.swift
@@ -22,7 +22,7 @@ protocol MediaSelector {
     /// - Returns: The selected media option.
     ///
     /// Use available information to refine the choice of the selected media option to return.
-    func selectedMediaOption(in selection: AVMediaSelection, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption
+    func selectedMediaOption(in selection: AVMediaSelection?, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption
 
     /// Selects the provided option, applying it on the specified item.
     ///

--- a/Sources/Player/MediaSelection/AudibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/AudibleMediaSelector.swift
@@ -15,8 +15,11 @@ struct AudibleMediaSelector: MediaSelector {
         return options.count > 1 ? options.map { .on($0) } : []
     }
 
-    func selectedMediaOption(in selection: AVMediaSelection, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption {
-        if let option = selection.selectedMediaOption(in: group) {
+    func selectedMediaOption(
+        in selection: AVMediaSelection?,
+        with selectionCriteria: AVPlayerMediaSelectionCriteria?
+    ) -> MediaSelectionOption {
+        if let option = selection?.selectedMediaOption(in: group) {
             return .on(option)
         }
         else {

--- a/Sources/Player/MediaSelection/LegibleMediaSelector.swift
+++ b/Sources/Player/MediaSelection/LegibleMediaSelector.swift
@@ -21,11 +21,14 @@ struct LegibleMediaSelector: MediaSelector {
         return options
     }
 
-    func selectedMediaOption(in selection: AVMediaSelection, with selectionCriteria: AVPlayerMediaSelectionCriteria?) -> MediaSelectionOption {
-        if selectionCriteria == nil {
+    func selectedMediaOption(
+        in selection: AVMediaSelection?,
+        with selectionCriteria: AVPlayerMediaSelectionCriteria?
+    ) -> MediaSelectionOption {
+        guard let preferredLanguages = selectionCriteria?.preferredLanguages, !preferredLanguages.isEmpty else {
             return persistedMediaOption(in: selection)
         }
-        else if let option = selection.selectedMediaOption(in: group) {
+        if let option = selection?.selectedMediaOption(in: group) {
             return .on(option)
         }
         else {
@@ -33,10 +36,10 @@ struct LegibleMediaSelector: MediaSelector {
         }
     }
 
-    private func persistedMediaOption(in selection: AVMediaSelection) -> MediaSelectionOption {
+    private func persistedMediaOption(in selection: AVMediaSelection?) -> MediaSelectionOption {
         switch MACaptionAppearanceGetDisplayType(.user) {
         case .alwaysOn:
-            if let option = selection.selectedMediaOption(in: group) {
+            if let option = selection?.selectedMediaOption(in: group) {
                 return .on(option)
             }
             else {

--- a/Sources/Player/MediaSelection/MediaSelectionPreference.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionPreference.swift
@@ -26,6 +26,10 @@ public struct MediaSelectionPreference {
 
     let kind: Kind
 
+    private init(kind: Kind) {
+        self.kind = kind
+    }
+
     /// Enabled.
     ///
     /// - Parameter languages: A list of strings containing language identifiers, in order of desirability, that are

--- a/Sources/Player/MediaSelection/MediaSelectionPreference.swift
+++ b/Sources/Player/MediaSelection/MediaSelectionPreference.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+/// A preference for media selection (audible, legible, etc.).
+public struct MediaSelectionPreference {
+    enum Kind {
+        case automatic
+        case off
+        case on(languages: [String])
+    }
+
+    /// Automatic selection based on system language and accessibility settings.
+    public static var automatic: Self {
+        .init(kind: .automatic)
+    }
+
+    /// Disabled.
+    ///
+    /// Options might still be forced where applicable.
+    public static var off: Self {
+        .init(kind: .off)
+    }
+
+    let kind: Kind
+
+    /// Enabled.
+    ///
+    /// - Parameter languages: A list of strings containing language identifiers, in order of desirability, that are
+    ///   preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T
+    ///   language codes.
+    public static func on(languages: String...) -> Self {
+        .init(kind: .on(languages: languages))
+    }
+}

--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
@@ -33,7 +33,7 @@ For optimal compatibility with the ``PillarboxPlayer`` framework, certain specif
 - **CC:** Use the `CLOSED-CAPTIONS` type and set `AUTOSELECT` to `YES`.
 - **SDH:** Use the `SUBTITLES` type with the `public.accessibility.transcribes-spoken-dialog` and `public.accessibility.describes-music-and-sound` characteristics, and set `AUTOSELECT` to `YES`.
 
-Within a group of renditions (`EXT-X-MEDIA` tags with the same `TYPE` and `GROUP-ID`), tags that share the same `LANGUAGE` value must be [ordered](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Multivariant-Playlist) from most general (fewest or no `CHARACTERISTICS`) to most specific (the most `CHARACTERISTICS`). This ordering ensures that when no accessibility preferences are set, Pillarbox’s ``Player/setMediaSelection(preferredLanguages:for:)`` will match the general tags first.
+Within a group of renditions (`EXT-X-MEDIA` tags with the same `TYPE` and `GROUP-ID`), tags that share the same `LANGUAGE` value must be [ordered](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Multivariant-Playlist) from most general (fewest or no `CHARACTERISTICS`) to most specific (the most `CHARACTERISTICS`). This ordering ensures that when no accessibility preferences are set, Pillarbox’s ``Player/setMediaSelectionPreference(_:for:)`` will match the general tags first.
 
 > Note: If no closed caption content is available, you should [explicitly declare](https://developer.apple.com/library/archive/qa/qa1801/_index.html) this in the playlist by adding `CLOSED-CAPTIONS=NONE` to the `EXT-X-STREAM-INF` tag. This prevents the player from showing a CC option unnecessarily, particularly when no subtitles are present either.
 
@@ -45,7 +45,7 @@ If renditions are not handled correctly (e.g., automatic selection does not work
 2. **Check System Settings**: Ensure the device’s system settings are configured with appropriate:
     - **Languages:** List and order preferred languages correctly.
     - **Accessibility Settings:** Enable or disable AD and SDH/CC preferences as needed.
-3. **Inspect your Code:** Make sure ``Player/setMediaSelection(preferredLanguages:for:)`` isn’t accidentally overriding the automatic selection when it shouldn’t.
+3. **Inspect your Code:** Make sure ``Player/setMediaSelectionPreference(_:for:)`` isn’t accidentally overriding the automatic selection when it shouldn’t.
 
 > Tip: Refer to the _Inspecting and testing streams_ section for useful troubleshooting tools.
 

--- a/Sources/Player/Player.docc/Articles/subtitles-and-alternative-audio-tracks-article.md
+++ b/Sources/Player/Player.docc/Articles/subtitles-and-alternative-audio-tracks-article.md
@@ -33,7 +33,7 @@ Use the following APIs to manage media selection programmatically:
 
 ``Player`` automatically selects the best combination of audio tracks and subtitles based on system language, accessibility settings, and available renditions.
 
-To override default preferences, call ``Player/setMediaSelection(preferredLanguages:for:)``. Preferences can be updated during playback or configured beforehand, which is useful if your app includes a custom language preference setting that should take precedence over system defaults.
+To override default preferences, call ``Player/setMediaSelectionPreference(_:for:)``. Preferences can be updated during playback or configured beforehand, which is useful if your app includes a custom language preference setting that should take precedence over system defaults.
 
 > Note: In most cases, rely on system defaults. They optimize user experience by incorporating accessibility preferences and recent user selections from other media apps.
 

--- a/Sources/Player/Player.docc/Extensions/player-extension.md
+++ b/Sources/Player/Player.docc/Extensions/player-extension.md
@@ -108,10 +108,9 @@
 - ``mediaOption(for:)``
 - ``mediaSelectionCharacteristics``
 - ``mediaSelectionOptions(for:)``
-- ``mediaSelectionPreferredLanguages(for:)``
 - ``select(mediaOption:for:)``
 - ``selectedMediaOption(for:)``
-- ``setMediaSelection(preferredLanguages:for:)``
+- ``setMediaSelectionPreference(_:for:)``
 
 ### Controlling Playback Speed
 

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -113,7 +113,7 @@ public extension Player {
     ///     include `.audible`, `.legible`, and `.visual`.
     ///
     /// This method can be used to override the default media option selection for some characteristic, e.g., to start
-    /// playback with a predefined language for audio and / or subtitles.
+    /// playback with a predefined language for audio and/or subtitles.
     ///
     /// > Important: Media selection only works when HLS playlists are correctly formatted. If selection does not behave
     ///   as expected, see the troubleshooting section in <doc:stream-encoding-and-packaging-advice-article> to identify
@@ -122,19 +122,11 @@ public extension Player {
         if let item = queuePlayer.currentItem {
             properties.mediaSelectionProperties.reset(for: characteristic, in: item)
         }
-        if !languages.isEmpty {
-            let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
-                preferredLanguages: Self.preferredLanguages(for: characteristic),
-                preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
-            )
-            queuePlayer.setMediaSelectionCriteria(
-                selectionCriteria.selectionCriteria(byAdding: languages),
-                forMediaCharacteristic: characteristic
-            )
-        }
-        else {
-            queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
-        }
+        let selectionCriteria = AVPlayerMediaSelectionCriteria(
+            preferredLanguages: languages,
+            preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
+        )
+        queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
     }
 
     /// Returns media selection preferred languages for the specified media characteristic.

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -123,11 +123,25 @@ public extension Player {
         if let item = queuePlayer.currentItem {
             properties.mediaSelectionProperties.reset(for: characteristic, in: item)
         }
-        let selectionCriteria = AVPlayerMediaSelectionCriteria(
-            preferredLanguages: languages,
-            preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
-        )
-        queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
+        if !languages.isEmpty {
+            let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
+                preferredLanguages: Self.preferredLanguages(for: characteristic),
+                preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
+            )
+            queuePlayer.setMediaSelectionCriteria(
+                selectionCriteria.selectionCriteria(byAdding: languages),
+                forMediaCharacteristic: characteristic
+            )
+        }
+        else {
+            queuePlayer.setMediaSelectionCriteria(
+                AVPlayerMediaSelectionCriteria(
+                    preferredLanguages: [],
+                    preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
+                ),
+                forMediaCharacteristic: characteristic
+            )
+        }
     }
 
     /// Resets media selection preferred languages for the specified media characteristic.

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -113,7 +113,8 @@ public extension Player {
     ///     include `.audible`, `.legible`, and `.visual`.
     ///
     /// This method can be used to override the default media option selection for some characteristic, e.g., to start
-    /// playback with a predefined language for audio and/or subtitles.
+    /// playback with a predefined language for audio and/or subtitles. Accessibility preferences are automatically
+    /// applied to pick the best matching option.
     ///
     /// > Important: Media selection only works when HLS playlists are correctly formatted. If selection does not behave
     ///   as expected, see the troubleshooting section in <doc:stream-encoding-and-packaging-advice-article> to identify

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -14,6 +14,15 @@ public extension Player {
         properties.mediaSelectionProperties.characteristics
     }
 
+    private static func emptyMediaSelectionCriteria(for characteristic: AVMediaCharacteristic) -> AVPlayerMediaSelectionCriteria? {
+        switch characteristic {
+        case .legible:
+            return .init(preferredLanguages: [], preferredMediaCharacteristics: [])
+        default:
+            return nil
+        }
+    }
+
     private static func preferredLanguages(for characteristic: AVMediaCharacteristic) -> [String] {
         switch characteristic {
         case .legible:
@@ -134,10 +143,7 @@ public extension Player {
             )
         }
         else {
-            queuePlayer.setMediaSelectionCriteria(
-                AVPlayerMediaSelectionCriteria(preferredLanguages: [], preferredMediaCharacteristics: []),
-                forMediaCharacteristic: characteristic
-            )
+            queuePlayer.setMediaSelectionCriteria(Self.emptyMediaSelectionCriteria(for: characteristic), forMediaCharacteristic: characteristic)
         }
     }
 

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -112,27 +112,29 @@ public extension Player {
         properties.currentMediaOption(for: characteristic)
     }
 
-    /// Sets media selection preferred languages for the specified media characteristic.
+    /// Sets desired media selection preference for the specified media characteristic.
     ///
     /// - Parameters:
-    ///   - languages: An Array of strings containing language identifiers, in order of desirability, that are
-    ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T
-    ///     language codes. Use an empty list to prefer no language selection if possible.
-    ///   - characteristic: The media characteristic for which the selection criteria are to be applied. Supported values
+    ///   - preference: The preference to apply.
+    ///   - characteristic: The media characteristic for which the preference must be applied. Supported values
     ///     include `.audible`, `.legible`, and `.visual`.
     ///
     /// This method can be used to override the default media option selection for some characteristic, e.g., to start
-    /// playback with a predefined language for audio and/or subtitles. Accessibility preferences are automatically
-    /// applied to pick the best matching option.
+    /// playback with a predefined language for audio and/or subtitles.
     ///
     /// > Important: Media selection only works when HLS playlists are correctly formatted. If selection does not behave
     ///   as expected, see the troubleshooting section in <doc:stream-encoding-and-packaging-advice-article> to identify
     ///   which requirements may not have been met.
-    func setMediaSelection(preferredLanguages languages: [String], for characteristic: AVMediaCharacteristic) {
+    func setMediaSelectionPreference(_ preference: MediaSelectionPreference, for characteristic: AVMediaCharacteristic) {
         if let item = queuePlayer.currentItem {
             properties.mediaSelectionProperties.reset(for: characteristic, in: item)
         }
-        if !languages.isEmpty {
+        switch preference.kind {
+        case .automatic:
+            queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
+        case .off:
+            queuePlayer.setMediaSelectionCriteria(Self.emptyMediaSelectionCriteria(for: characteristic), forMediaCharacteristic: characteristic)
+        case let .on(languages: languages):
             let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic) ?? AVPlayerMediaSelectionCriteria(
                 preferredLanguages: Self.preferredLanguages(for: characteristic),
                 preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
@@ -142,27 +144,6 @@ public extension Player {
                 forMediaCharacteristic: characteristic
             )
         }
-        else {
-            queuePlayer.setMediaSelectionCriteria(Self.emptyMediaSelectionCriteria(for: characteristic), forMediaCharacteristic: characteristic)
-        }
-    }
-
-    /// Resets media selection preferred languages for the specified media characteristic.
-    ///
-    /// This method removes any overrides, returning the behavior to default media option selection.
-    func resetMediaSelectionPreferredLanguages(for characteristic: AVMediaCharacteristic) {
-        queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
-    }
-
-    /// Returns media selection preferred languages for the specified media characteristic.
-    ///
-    /// - Parameter characteristic: The characteristic.
-    func mediaSelectionPreferredLanguages(for characteristic: AVMediaCharacteristic) -> [String] {
-        guard let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic),
-              let preferredLanguages = selectionCriteria.preferredLanguages else {
-            return []
-        }
-        return preferredLanguages
     }
 
     private func mediaSelector(for characteristic: AVMediaCharacteristic) -> MediaSelector? {

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -108,7 +108,7 @@ public extension Player {
     /// - Parameters:
     ///   - languages: An Array of strings containing language identifiers, in order of desirability, that are
     ///     preferred for selection. Languages can be indicated via BCP 47 language identifiers or via ISO 639-2/T
-    ///     language codes.
+    ///     language codes. Use an empty list to prefer no language selection if possible.
     ///   - characteristic: The media characteristic for which the selection criteria are to be applied. Supported values
     ///     include `.audible`, `.legible`, and `.visual`.
     ///
@@ -127,6 +127,13 @@ public extension Player {
             preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
         )
         queuePlayer.setMediaSelectionCriteria(selectionCriteria, forMediaCharacteristic: characteristic)
+    }
+
+    /// Resets media selection preferred languages for the specified media characteristic.
+    ///
+    /// This method removes any overrides, returning the behavior to default media option selection.
+    func resetMediaSelectionPreferredLanguages(for characteristic: AVMediaCharacteristic) {
+        queuePlayer.setMediaSelectionCriteria(nil, forMediaCharacteristic: characteristic)
     }
 
     /// Returns media selection preferred languages for the specified media characteristic.

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -135,10 +135,7 @@ public extension Player {
         }
         else {
             queuePlayer.setMediaSelectionCriteria(
-                AVPlayerMediaSelectionCriteria(
-                    preferredLanguages: [],
-                    preferredMediaCharacteristics: Self.preferredMediaCharacteristics(for: characteristic)
-                ),
+                AVPlayerMediaSelectionCriteria(preferredLanguages: [], preferredMediaCharacteristics: []),
                 forMediaCharacteristic: characteristic
             )
         }

--- a/Sources/Player/Player/Player+MediaSelection.swift
+++ b/Sources/Player/Player/Player+MediaSelection.swift
@@ -53,11 +53,11 @@ public extension Player {
     ///
     /// You can use `mediaSelectionCharacteristics` to retrieve available characteristics.
     func selectedMediaOption(for characteristic: AVMediaCharacteristic) -> MediaSelectionOption {
-        guard let selection = properties.mediaSelectionProperties.selection, let selector = mediaSelector(for: characteristic) else {
+        guard let selector = mediaSelector(for: characteristic) else {
             return .off
         }
         let selectionCriteria = queuePlayer.mediaSelectionCriteria(forMediaCharacteristic: characteristic)
-        let option = selector.selectedMediaOption(in: selection, with: selectionCriteria)
+        let option = selector.selectedMediaOption(in: properties.mediaSelectionProperties.selection, with: selectionCriteria)
         return selector.supports(mediaSelectionOption: option) ? option : .off
     }
 

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -222,7 +222,6 @@ public final class Player: ObservableObject, Equatable {
         configureMetadataPublisher()
         configureBlockedTimeRangesPublishers()
         configureAudioSessionPublisher()
-        configureMediaSelectionCriteriaPublisher()
     }
 
     /// Creates a player with a single item in its queue.
@@ -341,14 +340,6 @@ private extension Player {
                 }
                 .store(in: &cancellables)
         }
-    }
-
-    func configureMediaSelectionCriteriaPublisher() {
-        queuePlayer.mediaSelectionCriteriaUpdatePublisher()
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
     }
 
     func updateTracker(with items: QueueItems?) {

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -345,7 +345,6 @@ private extension Player {
 
     func configureMediaSelectionCriteriaPublisher() {
         queuePlayer.mediaSelectionCriteriaUpdatePublisher()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -222,6 +222,7 @@ public final class Player: ObservableObject, Equatable {
         configureMetadataPublisher()
         configureBlockedTimeRangesPublishers()
         configureAudioSessionPublisher()
+        configureMediaSelectionCriteriaPublisher()
     }
 
     /// Creates a player with a single item in its queue.
@@ -340,6 +341,14 @@ private extension Player {
                 }
                 .store(in: &cancellables)
         }
+    }
+
+    func configureMediaSelectionCriteriaPublisher() {
+        queuePlayer.mediaSelectionCriteriaUpdatePublisher()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
 
     func updateTracker(with items: QueueItems?) {

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -345,6 +345,7 @@ private extension Player {
 
     func configureMediaSelectionCriteriaPublisher() {
         queuePlayer.mediaSelectionCriteriaUpdatePublisher()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }

--- a/Sources/Player/Publishers/QueuePlayerPublishers.swift
+++ b/Sources/Player/Publishers/QueuePlayerPublishers.swift
@@ -57,4 +57,10 @@ extension QueuePlayer {
         .removeDuplicates()
         .eraseToAnyPublisher()
     }
+
+    func mediaSelectionCriteriaUpdatePublisher() -> AnyPublisher<Void, Never> {
+        Self.notificationCenter.weakPublisher(for: .didUpdateMediaSelectionCriteria, object: self)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/Player/Publishers/QueuePlayerPublishers.swift
+++ b/Sources/Player/Publishers/QueuePlayerPublishers.swift
@@ -60,12 +60,15 @@ extension QueuePlayer {
         .eraseToAnyPublisher()
     }
 
-    func mediaSelectionCriteriaPublisher() -> AnyPublisher<[AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?], Never> {
+    func mediaSelectionCriteriaPublisher() -> AnyPublisher<[AVMediaCharacteristic: AVPlayerMediaSelectionCriteria], Never> {
         Self.notificationCenter.weakPublisher(for: .didUpdateMediaSelectionCriteria, object: self)
             .map { notification in
+                // swiftlint:disable:next line_length
                 notification.userInfo?[MediaSelectionCriteriaUpdateNotificationKey.mediaSelection] as? [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] ?? [:]
             }
             .prepend(mediaSelectionCriteria)
+            .map { $0.compactMapValues(\.self) }
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/Player/Types/CoreProperties.swift
+++ b/Sources/Player/Types/CoreProperties.swift
@@ -12,7 +12,7 @@ struct CoreProperties: Equatable {
     let itemProperties: ItemProperties
     let mediaSelectionProperties: MediaSelectionProperties
     let playbackProperties: PlaybackProperties
-    let mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?]
+    let mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria]
 }
 
 // MARK: ItemProperties

--- a/Sources/Player/Types/CoreProperties.swift
+++ b/Sources/Player/Types/CoreProperties.swift
@@ -4,14 +4,15 @@
 //  License information is available from the LICENSE file.
 //
 
-import CoreMedia
+import AVFoundation
 
 struct CoreProperties: Equatable {
-    static let empty = Self(itemProperties: .empty, mediaSelectionProperties: .empty, playbackProperties: .empty)
+    static let empty = Self(itemProperties: .empty, mediaSelectionProperties: .empty, playbackProperties: .empty, mediaSelectionCriteria: [:])
 
     let itemProperties: ItemProperties
     let mediaSelectionProperties: MediaSelectionProperties
     let playbackProperties: PlaybackProperties
+    let mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?]
 }
 
 // MARK: ItemProperties

--- a/Sources/Player/Types/QueuePlayer.swift
+++ b/Sources/Player/Types/QueuePlayer.swift
@@ -15,11 +15,7 @@ class QueuePlayer: AVQueuePlayer {
 
     // Starting with iOS 17 accessing media selection criteria might be slow. Use a cache for the lifetime of the
     // player.
-    private var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:] {
-        didSet {
-            Self.notificationCenter.post(name: .didUpdateMediaSelectionCriteria, object: self)
-        }
-    }
+    private var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:]
 
     private var targetSeek: Seek? {
         pendingSeeks.last
@@ -149,5 +145,6 @@ class QueuePlayer: AVQueuePlayer {
     override func setMediaSelectionCriteria(_ criteria: AVPlayerMediaSelectionCriteria?, forMediaCharacteristic mediaCharacteristic: AVMediaCharacteristic) {
         mediaSelectionCriteria[mediaCharacteristic] = criteria
         super.setMediaSelectionCriteria(criteria, forMediaCharacteristic: mediaCharacteristic)
+        Self.notificationCenter.post(name: .didUpdateMediaSelectionCriteria, object: self)
     }
 }

--- a/Sources/Player/Types/QueuePlayer.swift
+++ b/Sources/Player/Types/QueuePlayer.swift
@@ -15,7 +15,7 @@ class QueuePlayer: AVQueuePlayer {
 
     // Starting with iOS 17 accessing media selection criteria might be slow. Use a cache for the lifetime of the
     // player.
-    private var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:]
+    private(set) var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:]
 
     private var targetSeek: Seek? {
         pendingSeeks.last
@@ -119,7 +119,7 @@ class QueuePlayer: AVQueuePlayer {
     }
 
     private func notifySeekStart(at time: CMTime) {
-        Self.notificationCenter.post(name: .willSeek, object: self, userInfo: [SeekKey.time: time])
+        Self.notificationCenter.post(name: .willSeek, object: self, userInfo: [SeekNotificationKey.time: time])
     }
 
     private func notifySeekEnd() {
@@ -145,6 +145,8 @@ class QueuePlayer: AVQueuePlayer {
     override func setMediaSelectionCriteria(_ criteria: AVPlayerMediaSelectionCriteria?, forMediaCharacteristic mediaCharacteristic: AVMediaCharacteristic) {
         mediaSelectionCriteria[mediaCharacteristic] = criteria
         super.setMediaSelectionCriteria(criteria, forMediaCharacteristic: mediaCharacteristic)
-        Self.notificationCenter.post(name: .didUpdateMediaSelectionCriteria, object: self)
+        Self.notificationCenter.post(name: .didUpdateMediaSelectionCriteria, object: self, userInfo: [
+            MediaSelectionCriteriaUpdateNotificationKey.mediaSelection: mediaSelectionCriteria
+        ])
     }
 }

--- a/Sources/Player/Types/QueuePlayer.swift
+++ b/Sources/Player/Types/QueuePlayer.swift
@@ -15,7 +15,11 @@ class QueuePlayer: AVQueuePlayer {
 
     // Starting with iOS 17 accessing media selection criteria might be slow. Use a cache for the lifetime of the
     // player.
-    private var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:]
+    private var mediaSelectionCriteria: [AVMediaCharacteristic: AVPlayerMediaSelectionCriteria?] = [:] {
+        didSet {
+            Self.notificationCenter.post(name: .didUpdateMediaSelectionCriteria, object: self)
+        }
+    }
 
     private var targetSeek: Seek? {
         pendingSeeks.last

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -84,7 +84,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             ]
         ))
 
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .audible)
         player.play()
         expect(player.playbackState).toEventually(equal(.playing))
 
@@ -127,7 +127,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
             ]
         ))
 
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         player.play()
         expect(player.playbackState).toEventually(equal(.playing))
 

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -14,37 +14,37 @@ import PillarboxStreams
 final class PreferredLanguagesForMediaSelectionTests: TestCase {
     func testAudibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .audible)
         expect(player.selectedMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testLegibleOptionMatchesAvailablePreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
     func testAudibleOptionIgnoresInvalidPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["xy"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "xy"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
     func testLegibleOptionIgnoresInvalidPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["xy"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "xy"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("xy"), until: .seconds(2))
     }
 
     func testAudibleOptionIgnoresUnsupportedPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["it"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "it"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
     func testLegibleOptionIgnoresUnsupportedPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["it"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "it"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("it"), until: .seconds(2))
     }
 
@@ -56,7 +56,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
             option.languageIdentifier == "fr"
         }!, for: .audible)
 
-        player.setMediaSelection(preferredLanguages: ["en"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "en"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
@@ -68,7 +68,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
             option.languageIdentifier == "ja"
         }!, for: .legible)
 
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
@@ -77,7 +77,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
         ])
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
 
         player.advanceToNextItem()
@@ -89,7 +89,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
             .simple(url: Stream.onDemandWithOptions.url),
             .simple(url: Stream.onDemandWithOptions.url)
         ])
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
 
         player.advanceToNextItem()
@@ -102,13 +102,13 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
             .simple(url: Stream.onDemandWithManyLegibleAndAudibleOptions.url)
         ])
 
-        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "en"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
 
         player.advanceToNextItem()
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
 
-        player.setMediaSelection(preferredLanguages: ["it"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "it"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("it"))
 
         player.returnToPrevious()
@@ -117,9 +117,9 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testEmptyAudibleMediaSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelection(preferredLanguages: [], for: .audible)
+        player.setMediaSelectionPreference(.off, for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
@@ -127,9 +127,9 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        player.setMediaSelectionPreference(.off, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
     }
 
@@ -137,7 +137,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "en"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
 
         player.select(mediaOption: .off, for: .legible)
@@ -148,7 +148,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "en"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
 
         player.select(mediaOption: .automatic, for: .legible)
@@ -159,7 +159,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        player.setMediaSelectionPreference(.off, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
 
         player.select(mediaOption: .off, for: .legible)
@@ -170,7 +170,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        player.setMediaSelectionPreference(.off, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
 
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
@@ -184,7 +184,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        player.setMediaSelectionPreference(.off, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
 
         player.select(mediaOption: .automatic, for: .legible)
@@ -197,8 +197,8 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
-        player.setMediaSelection(preferredLanguages: [], for: .audible)
-        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        player.setMediaSelectionPreference(.off, for: .audible)
+        player.setMediaSelectionPreference(.off, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
 
         player.select(mediaOption: .automatic, for: .legible)
@@ -206,21 +206,21 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("ja"), until: .seconds(1))
     }
 
-    func testAudibleMediaSelectionReset() {
+    func testAutomaticAudibleMediaSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-        player.resetMediaSelectionPreferredLanguages(for: .audible)
+        player.setMediaSelectionPreference(.automatic, for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testLegibleMediaSelectionReset() {
+    func testAutomaticLegibleMediaSelection() {
         MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
 
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        player.setMediaSelectionPreference(.on(languages: "fr"), for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
-        player.resetMediaSelectionPreferredLanguages(for: .legible)
+        player.setMediaSelectionPreference(.automatic, for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 }

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -134,7 +134,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
     }
 
-    func testAudibleMediaSelectionReset() {
+    func testEmptyAudibleMediaSelection() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
@@ -142,11 +142,31 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
     }
 
-    func testLegibleMediaSelectionReset() {
+    func testEmptyLegibleMediaSelection() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
         player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+    }
+
+    func testAudibleMediaSelectionReset() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+        player.resetMediaSelectionPreferredLanguages(for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testLegibleMediaSelectionReset() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.resetMediaSelectionPreferredLanguages(for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
 }

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -8,6 +8,7 @@
 
 import AVFoundation
 import Nimble
+import PillarboxCircumspect
 import PillarboxStreams
 
 final class PreferredLanguagesForMediaSelectionTests: TestCase {
@@ -168,5 +169,14 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
         player.resetMediaSelectionPreferredLanguages(for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
+    }
+
+    func testMediaSelectionUpdatePublishesPlayerUpdate() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.play()
+        expect(player.time().seconds).toEventually(beGreaterThan(1))
+        expectChange(from: player, timeout: .milliseconds(500)) {
+            player.setMediaSelection(preferredLanguages: [], for: .legible)
+        }
     }
 }

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -111,7 +111,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("it"))
 
         player.returnToPrevious()
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
     }
 
     func testSelectLegibleOffOptionWithPreferredLanguage() {
@@ -134,11 +134,19 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
     }
 
-    func testMediaSelectionReset() {
+    func testAudibleMediaSelectionReset() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
         player.setMediaSelection(preferredLanguages: [], for: .audible)
         expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testLegibleMediaSelectionReset() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
     }
 }

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -135,6 +135,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testSelectLegibleOffOptionWithPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
         player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
@@ -145,6 +146,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testSelectLegibleAutomaticOptionWithPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
         player.setMediaSelection(preferredLanguages: ["en"], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("en"))
@@ -155,6 +157,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testSelectLegibleOffOptionWithEmptyLanguages() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
         player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
@@ -165,6 +168,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testSelectLegibleOptionWithEmptyLanguages() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
         player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
@@ -178,6 +182,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
     func testSelectLegibleAutomaticOptionWithEmptyLanguages() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
         player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -115,6 +115,24 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
     }
 
+    func testEmptyAudibleMediaSelection() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelection(preferredLanguages: [], for: .audible)
+        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
+    }
+
+    func testEmptyLegibleMediaSelection() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+    }
+
     func testSelectLegibleOffOptionWithPreferredLanguage() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
 
@@ -135,22 +153,37 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
     }
 
-    func testEmptyAudibleMediaSelection() {
+    func testSelectLegibleOffOptionWithEmptyLanguages() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("fr"))
-        player.setMediaSelection(preferredLanguages: [], for: .audible)
-        expect(player.currentMediaOption(for: .audible)).toEventually(haveLanguageIdentifier("en"))
-    }
 
-    func testEmptyLegibleMediaSelection() {
-        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
-
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.setMediaSelection(preferredLanguages: ["fr"], for: .legible)
-        expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
         player.setMediaSelection(preferredLanguages: [], for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+
+        player.select(mediaOption: .off, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.off))
+    }
+
+    func testSelectLegibleOptionWithEmptyLanguages() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+        player.select(mediaOption: player.mediaSelectionOptions(for: .legible).first { option in
+            option.languageIdentifier == "fr"
+        }!, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
+    }
+
+    func testSelectLegibleAutomaticOptionWithEmptyLanguages() {
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+
+        player.select(mediaOption: .automatic, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
     }
 
     func testAudibleMediaSelectionReset() {

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -223,13 +223,4 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         player.resetMediaSelectionPreferredLanguages(for: .legible)
         expect(player.currentMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("ja"))
     }
-
-    func testMediaSelectionUpdatePublishesPlayerUpdate() {
-        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
-        player.play()
-        expect(player.time().seconds).toEventually(beGreaterThan(1))
-        expectChange(from: player, timeout: .milliseconds(500)) {
-            player.setMediaSelection(preferredLanguages: [], for: .legible)
-        }
-    }
 }

--- a/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
+++ b/Tests/PlayerTests/MediaSelection/PreferredLanguagesForMediaSelectionTests.swift
@@ -180,7 +180,7 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
         expect(player.selectedMediaOption(for: .legible)).toEventually(haveLanguageIdentifier("fr"))
     }
 
-    func testSelectLegibleAutomaticOptionWithEmptyLanguages() {
+    func testSelectLegibleAutomaticOptionWithEmptyLegibleLanguages() {
         let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
         expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
 
@@ -189,6 +189,21 @@ final class PreferredLanguagesForMediaSelectionTests: TestCase {
 
         player.select(mediaOption: .automatic, for: .legible)
         expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
+    }
+
+    func testSelectLegibleAutomaticOptionWithEmptyAudibleAndLegibleLanguages() {
+        MediaAccessibilityDisplayType.alwaysOn(languageCode: "ja").apply()
+
+        let player = Player(item: .simple(url: Stream.onDemandWithOptions.url))
+        expect(player.mediaSelectionOptions(for: .legible)).toEventuallyNot(beEmpty())
+
+        player.setMediaSelection(preferredLanguages: [], for: .audible)
+        player.setMediaSelection(preferredLanguages: [], for: .legible)
+        expect(player.currentMediaOption(for: .legible)).toEventually(equal(.off))
+
+        player.select(mediaOption: .automatic, for: .legible)
+        expect(player.selectedMediaOption(for: .legible)).toEventually(equal(.automatic))
+        expect(player.currentMediaOption(for: .legible)).toNever(haveLanguageIdentifier("ja"), until: .seconds(1))
     }
 
     func testAudibleMediaSelectionReset() {

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerMediaSelectionCriteriaPublisherTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerMediaSelectionCriteriaPublisherTests.swift
@@ -1,0 +1,68 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@testable import PillarboxPlayer
+
+import AVFoundation
+import PillarboxCircumspect
+
+final class QueuePlayerMediaSelectionCriteriaPublisherTests: TestCase {
+    func testDefault() {
+        let player = QueuePlayer()
+        expectAtLeastEqualPublished(
+            values: [[:]],
+            from: player.mediaSelectionCriteriaPublisher()
+        )
+    }
+
+    func testInitialValue() {
+        let player = QueuePlayer()
+        let criteria = AVPlayerMediaSelectionCriteria(
+            preferredLanguages: ["en", "fr"],
+            preferredMediaCharacteristics: [.transcribesSpokenDialogForAccessibility, .describesMusicAndSoundForAccessibility]
+        )
+        player.setMediaSelectionCriteria(criteria, forMediaCharacteristic: .legible)
+        expectAtLeastEqualPublished(
+            values: [
+                [.legible: criteria]
+            ],
+            from: player.mediaSelectionCriteriaPublisher()
+        )
+    }
+
+    func testUpdate() {
+        let player = QueuePlayer()
+        let criteria = AVPlayerMediaSelectionCriteria(
+            preferredLanguages: ["en", "fr"],
+            preferredMediaCharacteristics: [.transcribesSpokenDialogForAccessibility, .describesMusicAndSoundForAccessibility]
+        )
+        expectAtLeastEqualPublishedNext(
+            values: [
+                [.legible: criteria]
+            ],
+            from: player.mediaSelectionCriteriaPublisher()
+        ) {
+            player.setMediaSelectionCriteria(criteria, forMediaCharacteristic: .legible)
+        }
+    }
+
+    func testReset() {
+        let player = QueuePlayer()
+        let criteria = AVPlayerMediaSelectionCriteria(
+            preferredLanguages: ["en", "fr"],
+            preferredMediaCharacteristics: [.transcribesSpokenDialogForAccessibility, .describesMusicAndSoundForAccessibility]
+        )
+        player.setMediaSelectionCriteria(criteria, forMediaCharacteristic: .legible)
+        expectAtLeastEqualPublishedNext(
+            values: [
+                [.legible: nil]
+            ],
+            from: player.mediaSelectionCriteriaPublisher()
+        ) {
+            player.setMediaSelectionCriteria(nil, forMediaCharacteristic: .legible)
+        }
+    }
+}

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerMediaSelectionCriteriaPublisherTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerMediaSelectionCriteriaPublisherTests.swift
@@ -9,6 +9,7 @@
 import AVFoundation
 import PillarboxCircumspect
 
+// swiftlint:disable:next type_name
 final class QueuePlayerMediaSelectionCriteriaPublisherTests: TestCase {
     func testDefault() {
         let player = QueuePlayer()
@@ -57,9 +58,7 @@ final class QueuePlayerMediaSelectionCriteriaPublisherTests: TestCase {
         )
         player.setMediaSelectionCriteria(criteria, forMediaCharacteristic: .legible)
         expectAtLeastEqualPublishedNext(
-            values: [
-                [.legible: nil]
-            ],
+            values: [[:]],
             from: player.mediaSelectionCriteriaPublisher()
         ) {
             player.setMediaSelectionCriteria(nil, forMediaCharacteristic: .legible)

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSeekTests.swift
@@ -50,7 +50,7 @@ final class QueuePlayerSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -68,10 +68,10 @@ final class QueuePlayerSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
             Notification(name: .didSeek, object: player),
 
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -91,8 +91,8 @@ final class QueuePlayerSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -112,8 +112,8 @@ final class QueuePlayerSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -210,7 +210,7 @@ final class QueuePlayerSeekTests: TestCase {
                 QueuePlayer.notificationCenter.post(name: notificationName, object: self)
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time]),
             Notification(name: .didSeek, object: player),
             Notification(name: notificationName, object: self)
         ]), from: QueuePlayer.notificationCenter))
@@ -233,8 +233,8 @@ final class QueuePlayerSeekTests: TestCase {
                 QueuePlayer.notificationCenter.post(name: notificationName2, object: self)
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: notificationName1, object: self),
             Notification(name: .didSeek, object: player),
             Notification(name: notificationName2, object: self)

--- a/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
+++ b/Tests/PlayerTests/QueuePlayer/QueuePlayerSmoothSeekTests.swift
@@ -31,7 +31,7 @@ final class QueuePlayerSmoothSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -49,10 +49,10 @@ final class QueuePlayerSmoothSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.to(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
             Notification(name: .didSeek, object: player),
 
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -72,8 +72,8 @@ final class QueuePlayerSmoothSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }
@@ -93,8 +93,8 @@ final class QueuePlayerSmoothSeekTests: TestCase {
                 expect(finished).to(beTrue())
             }
         }.toEventually(postNotifications(equalDiff([
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time1]),
-            Notification(name: .willSeek, object: player, userInfo: [SeekKey.time: time2]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time1]),
+            Notification(name: .willSeek, object: player, userInfo: [SeekNotificationKey.time: time2]),
             Notification(name: .didSeek, object: player)
         ]), from: QueuePlayer.notificationCenter))
     }


### PR DESCRIPTION
## Description

When [returning from Google Cast playback](https://github.com/SRGSSR/castor/issues/144) in our Castor demo implementation, the user might have disabled subtitles on the receiver. In such cases it is natural to attempt to restore the same setting on a Pillarbox instance (used in the Castor demo as local player) when resuming playback locally, but `Player.setMediaSelection(preferredLanguages:for:)` currently provides no way to prefer no selection at all before starting playback, since setting an empty list removes media selection overrides instead.

This PR enhances our API to support setting no language at all as media selection preference (if possible; some characteristics might force a selection).

## Changes made

- Introduce `MediaSelectionPreference` to convey media selection preference settings. This type is a `struct` so that languages can be specified as a variadic parameter (thus forcing at least one value to be provided and enums do not support variadic associated values). Values `.automatic`, `.on` and `.off` are provided, mirroring the usual media options.
- Update media selection API to take a `MediaSelectionPreference` as parameter (breaking API change).
- Remove API to read media selection preference, an operation with no real added value.
- Publish a `Player` update when the media selection changes. Previously we could change the media selection but the player would not publish any observable change, preventing current option selection from being reflected until the next update. Since media selection is part of core player updates it is natural that media selection changes must lead to similar updates as well.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
