### PR TITLE
Improve PiP restoration flag consistency

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -180,7 +180,6 @@ file_header:
     \/\/  Copyright \(c\) SRG SSR. All rights reserved.
     \/\/
     \/\/  License information is available from the LICENSE file.
-    \/\/
 
 file_length:
   warning: 1000

--- a/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
@@ -135,7 +135,7 @@ extension CustomPictureInPicture: AVPictureInPictureControllerDelegate {
             delegate.pictureInPictureRestoreUserInterfaceForStop(with: completionHandler)
         }
         else {
-            completionHandler(true)
+            completionHandler(false)
         }
     }
 

--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -44,7 +44,7 @@ public final class PictureInPicture {
         custom.start()
     }
 
-    /// Stop Picture if Picture if running.
+    /// Gracefully stops Picture if Picture if running.
     ///
     /// The ``PictureInPictureDelegate/pictureInPictureRestoreUserInterfaceForStop(with:)`` method is called.
     public func stop() {
@@ -52,7 +52,7 @@ public final class PictureInPicture {
         system.stop()
     }
 
-    /// Close Picture in Picture.
+    /// Closes Picture in Picture.
     ///
     /// The ``PictureInPictureDelegate/pictureInPictureRestoreUserInterfaceForStop(with:)`` method is not called.
     public func close() {

--- a/Sources/Player/PictureInPicture/PictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/PictureInPicture.swift
@@ -84,7 +84,7 @@ extension PictureInPicture: PictureInPictureDelegate {
     // swiftlint:disable:next missing_docs
     public func pictureInPictureRestoreUserInterfaceForStop(with completion: @escaping (Bool) -> Void) {
         guard !isClosed else {
-            completion(true)
+            completion(false)
             return
         }
         if let delegate {
@@ -98,7 +98,7 @@ extension PictureInPicture: PictureInPictureDelegate {
             }
         }
         else {
-            completion(true)
+            completion(false)
         }
     }
 

--- a/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/SystemPictureInPicture.swift
@@ -113,7 +113,7 @@ extension SystemPictureInPicture: AVPlayerViewControllerDelegate {
             delegate.pictureInPictureRestoreUserInterfaceForStop(with: completionHandler)
         }
         else {
-            completionHandler(true)
+            completionHandler(false)
         }
     }
 

--- a/Sources/Player/UserInterface/SkipTracker.swift
+++ b/Sources/Player/UserInterface/SkipTracker.swift
@@ -79,7 +79,6 @@ public final class SkipTracker: ObservableObject {
     ///   - count: The number of requests required to enable skipping.
     ///   - delay: The delay after which skipping is disabled.
     public init(count: Int = 2, delay: TimeInterval = 0.4) {
-        // swiftlint:disable:next empty_count
         assert(count > 0 && delay > 0)
         minimumCount = count
         configureIdlePublisher(delay: delay)


### PR DESCRIPTION
## Description

This PR ensures that the PiP restoration completion handler is called with `false` when PiP restoration cannot be made. Though we could not prove that the system behaves differently based on this flag, this seems more aligned with the [standard player](https://developer.apple.com/documentation/avkit/adopting-picture-in-picture-in-a-standard-player#Restore-Your-Video-Playback-Interface) integration documentation.

## Changes made

- Update PiP restoration completion handler parameter to `false` where appropriate (no delegate or PiP closed).
- Update SwiftLint file header pattern to avoid SwiftLint regression introduced in 0.60.0. [A companion issue](https://github.com/SRGSSR/pillarbox-apple/issues/1281) has been created to report the issue and revert the change when possible.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
