### PR TITLE
Add recommendations for the `DEFAULT` attribute

### DIFF
--- a/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
+++ b/Sources/Player/Player.docc/Articles/stream-encoding-and-packaging-advice-article/stream-encoding-and-packaging-advice-article.md
@@ -21,12 +21,15 @@ For optimal compatibility with the ``PillarboxPlayer`` framework, certain specif
 #### Audio renditions
 
 - Include the `public.accessibility.describes-video` characteristic for audio description [renditions](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1).
+- Set the `DEFAULT` attribute to `YES` **only** for the rendition that should be selected when the user has not made an explicit choice.
 - Set the `AUTOSELECT` attribute to `YES` for all renditions to enable automatic selection.
 
 #### Subtitle renditions
 
 - **Unforced Subtitles:** Set `AUTOSELECT` to `YES` for `SUBTITLES` and `CLOSED-CAPTIONS` renditions to allow selection in _Automatic_ mode.
 - **Forced Subtitles:** [Ensure](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#Subtitles) `FORCED` and `AUTOSELECT` are set to `YES`. ``Player`` adheres to [Apple's' recommendations](https://developer.apple.com/library/archive/releasenotes/AudioVideo/RN-AVFoundation/index.html#//apple_ref/doc/uid/TP40010717-CH1-DontLinkElementID_3) and never returns forced subtitles for explicit user selection.
+
+> Note: In general, players should not display subtitles by default unless the user has explicitly chosen them. For this reason, subtitle renditions should avoid setting `DEFAULT` to `YES`.
 
 #### Closed Captions (CC) and Subtitles for the Deaf or Hard-of-Hearing (SDH)
 


### PR DESCRIPTION
## Description

This PR improves our packaging advice documentation with remarks about the `DEFAULT` attribute. We namely discovered SRG SSR content that was packaged with incorrectly set `DEFAULT` values:

- `DEFAULT` means that players should force selection [in the absence of user selection](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1), which is expected for one default audio renditions but very unlikely for subtitle renditions (even forced subtitles).
- [Only one rendition at most](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1.1) must have `DEFAULT` set to `YES` in a group.

This will also help our Pillarbox Android player avoid automatically displaying subtitles (ExoPlayer better observes the `DEFAULT` attribute for subtitle renditions).

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
