### PR TITLE
Fix flaky test

### DIFF
--- a/Tests/PlayerTests/Asset/ResourceItemTests.swift
+++ b/Tests/PlayerTests/Asset/ResourceItemTests.swift
@@ -7,16 +7,23 @@
 @testable import PillarboxPlayer
 
 import AVFoundation
+import Combine
 import PillarboxCircumspect
 import PillarboxStreams
 
 final class ResourceItemTests: TestCase {
+    private static func isPlaybackLikelyToKeepUpPublisher(for item: AVPlayerItem) -> AnyPublisher<Bool, Never> {
+        item.publisher(for: \.isPlaybackLikelyToKeepUp)
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     func testNativePlayerItem() {
         let item = Resource.simple(url: Stream.onDemand.url).playerItem(configuration: .default)
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false, true],
-            from: item.publisher(for: \.isPlaybackLikelyToKeepUp)
+            from: Self.isPlaybackLikelyToKeepUpPublisher(for: item)
         )
     }
 
@@ -25,7 +32,7 @@ final class ResourceItemTests: TestCase {
         _ = AVPlayer(playerItem: item)
         expectAtLeastEqualPublished(
             values: [false],
-            from: item.publisher(for: \.isPlaybackLikelyToKeepUp)
+            from: Self.isPlaybackLikelyToKeepUpPublisher(for: item)
         )
     }
 


### PR DESCRIPTION
## Description

This PR fixes a flaky test, whose tested `isPlaybackLikelyToKeepUp` value stream sometimes provides the same value twice in a row.

### Remark

We checked where this stream is implemented in our implementation and found no other place where removing duplicates is needed.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
