### PR TITLE
Avoid simultaneous dismissal gesture recognition

### DIFF
--- a/Demo/Sources/Views/Modal.swift
+++ b/Demo/Sources/Views/Modal.swift
@@ -29,7 +29,7 @@ private struct PresentedModifier: ViewModifier {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .preventsTouchPropagation()
-            .simultaneousGesture(
+            .gesture(
                 DragGesture(minimumDistance: distance)
                     .onEnded { value in
                         guard value.translation.height > distance else { return }


### PR DESCRIPTION
## Description

This PR reverts a change introduced in #1296, which intended to fix a dismissal gesture on iOS 26.0 where `VideoPlayer` is used.

This changed itself introduced new issues:

- The dismissal gesture is easily triggered when navigating the metrics view.
- The dismissal gesture is easily triggered when navigating 360° videos vertically.

We could verify that the issue originally identified seems fixed in iPadOS 26.1 (hopefully iOS 26.1 as well, but we currently have no test device running this version). It is therefore better to revert this change and, if 26.1 somehow does not fix it everywhere, figure another better strategy for views involving `VideoPlayer`.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
