### PR TITLE
Make playback speed API simpler

### DIFF
--- a/Demo/Sources/Views/HighSpeedView~ios.swift
+++ b/Demo/Sources/Views/HighSpeedView~ios.swift
@@ -67,11 +67,11 @@ private struct HighSpeedView<Content>: View where Content: View {
     var body: some View {
         HighSpeedGestureView(content: content) { finished in
             if !finished {
-                speed = player.effectivePlaybackSpeed
-                player.setDesiredPlaybackSpeed(highSpeed)
+                speed = player.playbackSpeed
+                player.playbackSpeed = highSpeed
             }
             else if let speed {
-                player.setDesiredPlaybackSpeed(speed)
+                player.playbackSpeed = speed
                 self.speed = nil
             }
         }

--- a/Sources/Player/Player.docc/Articles/playback-speed-article.md
+++ b/Sources/Player/Player.docc/Articles/playback-speed-article.md
@@ -14,9 +14,7 @@ Many users prefer playing content at customized speeds, whether faster or slower
 
 Playback speed is part of the essential properties automatically published by a ``Player`` instance, as detailed in the <doc:state-observation-article> article. SwiftUI views observing a player instance will automatically update when the playback speed changes.
 
-To adjust the playback speed programmatically, use the ``Player/setDesiredPlaybackSpeed(_:)`` method. As the name implies, this method sets the desired speed. However, the actual speed may vary depending on the content’s limitations. You can query the current effective playback speed using ``Player/effectivePlaybackSpeed`` and retrieve the available speed range with ``Player/playbackSpeedRange``.
-
-> Tip: For custom user interfaces built in SwiftUI, use ``Player/playbackSpeed``. This provides a binding to the current playback speed, ensuring seamless integration with SwiftUI views.
+To adjust the playback speed programmatically, use the ``Player/playbackSpeed`` property. You can retrieve the available speed range with ``Player/playbackSpeedRange``.
 
 ### Provide speed controls
 

--- a/Sources/Player/Player/Player+PlaybackSpeed.swift
+++ b/Sources/Player/Player/Player+PlaybackSpeed.swift
@@ -9,33 +9,22 @@ import CoreMedia
 import SwiftUI
 
 public extension Player {
-    /// The currently applicable playback speed.
-    var effectivePlaybackSpeed: Float {
-        _playbackSpeed.effectiveValue
-    }
-
     /// The currently allowed playback speed range.
     var playbackSpeedRange: ClosedRange<Float> {
         _playbackSpeed.effectiveRange
     }
 
     /// A binding to read and write the current playback speed.
-    var playbackSpeed: Binding<Float> {
-        .init {
-            self.effectivePlaybackSpeed
-        } set: { newValue in
-            self.setDesiredPlaybackSpeed(newValue)
-        }
-    }
-
-    /// Sets the desired playback speed.
-    ///
-    /// - Parameter playbackSpeed: The playback speed. The default value is 1.
     ///
     /// This value might not be applied immediately or might not be applicable at all. You must check
     /// `effectivePlaybackSpeed` to obtain the actually applied speed.
-    func setDesiredPlaybackSpeed(_ playbackSpeed: Float) {
-        desiredPlaybackSpeedPublisher.send(playbackSpeed)
+    var playbackSpeed: Float {
+        get {
+            _playbackSpeed.effectiveValue
+        }
+        set {
+            desiredPlaybackSpeedPublisher.send(newValue)
+        }
     }
 }
 

--- a/Sources/Player/Player/Player+SettingsMenu.swift
+++ b/Sources/Player/Player/Player+SettingsMenu.swift
@@ -15,7 +15,7 @@ private struct PlaybackSpeedMenuContent: View {
     @ObservedObject var player: Player
 
     var body: some View {
-        Picker(selection: selection) {
+        Picker(selection: $player.playbackSpeed) {
             ForEach(playbackSpeeds, id: \.self) { speed in
                 Text("\(speed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier").tag(speed)
             }
@@ -34,9 +34,9 @@ private struct PlaybackSpeedMenuContent: View {
 
     private var selection: Binding<Float> {
         .init {
-            player.playbackSpeed.wrappedValue
+            player.playbackSpeed
         } set: { newValue in
-            player.playbackSpeed.wrappedValue = newValue
+            player.playbackSpeed = newValue
             action(newValue)
         }
     }
@@ -95,7 +95,7 @@ private struct SettingsMenuContent: View {
         } label: {
             Button(action: {}) {
                 Text("Playback Speed", bundle: .module, comment: "Playback setting menu title")
-                Text("\(player.playbackSpeed.wrappedValue, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
+                Text("\(player.playbackSpeed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
                 Image(systemName: "speedometer")
             }
         }

--- a/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
+++ b/Sources/Player/UserInterface/SystemVideoViewCoordinator.swift
@@ -45,7 +45,7 @@ private extension SystemVideoViewCoordinator {
     ) -> [UIMenuElement] {
         let speedActions = allowedSpeeds(from: range).sorted().map { allowedSpeed in
             UIAction(title: String(format: "%g×", allowedSpeed), state: speed == allowedSpeed ? .on : .off) { [weak player] action in
-                player?.playbackSpeed.wrappedValue = allowedSpeed
+                player?.playbackSpeed = allowedSpeed
                 action.state = .on
             }
         }

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerPlaybackSpeedTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerPlaybackSpeedTests.swift
@@ -18,7 +18,7 @@ final class ComScoreTrackerPlaybackSpeedTests: ComScoreTestCase {
                 ComScoreTracker.adapter { _ in .test }
             ]
         ))
-        player.setDesiredPlaybackSpeed(0.5)
+        player.playbackSpeed = 0.5
 
         expectAtLeastHits(
             play { labels in

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerRateTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerRateTests.swift
@@ -24,7 +24,7 @@ final class ComScoreTrackerRateTests: ComScoreTestCase {
                 expect(labels.ns_st_rt).to(equal(200))
             }
         ) {
-            player.setDesiredPlaybackSpeed(2)
+            player.playbackSpeed = 2
             player.play()
         }
     }
@@ -44,7 +44,7 @@ final class ComScoreTrackerRateTests: ComScoreTestCase {
                 expect(labels.ns_st_rt).to(equal(200))
             }
         ) {
-            player.setDesiredPlaybackSpeed(2)
+            player.playbackSpeed = 2
         }
     }
 
@@ -59,7 +59,7 @@ final class ComScoreTrackerRateTests: ComScoreTestCase {
         expect(player.playbackState).toEventually(equal(.playing))
 
         expectNoHits(during: .milliseconds(500)) {
-            player.setDesiredPlaybackSpeed(1)
+            player.playbackSpeed = 1
         }
     }
 }

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -184,7 +184,7 @@ final class ComScoreTrackerTests: ComScoreTestCase {
                 expect(labels.ns_st_rt).to(equal(200))
             }
         ) {
-            player.setDesiredPlaybackSpeed(2)
+            player.playbackSpeed = 2
             player.play()
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerMetadataTests.swift
@@ -30,7 +30,7 @@ final class CommandersActTrackerMetadataTests: CommandersActTestCase {
                     CommandersActTracker.adapter { _ in .test }
                 ]
             ))
-            player?.setDesiredPlaybackSpeed(0.5)
+            player?.playbackSpeed = 0.5
             player?.play()
         }
     }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
@@ -103,7 +103,7 @@ final class CommandersActTrackerTests: CommandersActTestCase {
                 CommandersActTracker.adapter { _ in .test }
             ]
         ))
-        player?.setDesiredPlaybackSpeed(2)
+        player?.playbackSpeed = 2
 
         player?.play()
         expect(player?.time().seconds).toEventually(beGreaterThan(2))

--- a/Tests/PlayerTests/Player/SpeedTests.swift
+++ b/Tests/PlayerTests/Player/SpeedTests.swift
@@ -13,35 +13,35 @@ import PillarboxStreams
 final class SpeedTests: TestCase {
     func testEmpty() {
         let player = Player()
-        expect(player.effectivePlaybackSpeed).toAlways(equal(1), until: .seconds(2))
+        expect(player.playbackSpeed).toAlways(equal(1), until: .seconds(2))
         expect(player.playbackSpeedRange).toAlways(equal(1...1), until: .seconds(2))
     }
 
     func testNoSpeedUpdateWhenEmpty() {
         let player = Player()
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toAlways(equal(1), until: .seconds(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toAlways(equal(1), until: .seconds(2))
         expect(player.playbackSpeedRange).toAlways(equal(1...1), until: .seconds(2))
     }
 
     func testOnDemand() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toEventually(equal(2))
         expect(player.playbackSpeedRange).toEventually(equal(0.1...2))
     }
 
     func testDvr() {
         let player = Player(item: .simple(url: Stream.dvr.url))
-        player.setDesiredPlaybackSpeed(0.5)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(0.5))
+        player.playbackSpeed = 0.5
+        expect(player.playbackSpeed).toEventually(equal(0.5))
         expect(player.playbackSpeedRange).toEventually(equal(0.1...1))
     }
 
     func testLive() {
         let player = Player(item: .simple(url: Stream.live.url))
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toAlways(equal(1), until: .seconds(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toAlways(equal(1), until: .seconds(2))
         expect(player.playbackSpeedRange).toAlways(equal(1...1), until: .seconds(2))
     }
 
@@ -55,8 +55,8 @@ final class SpeedTests: TestCase {
         }
 
         expect(player.playbackSpeedRange).toEventually(equal(0.1...2))
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toEventually(equal(2))
     }
 
     func testPlaylistOnDemandToLive() {
@@ -64,11 +64,11 @@ final class SpeedTests: TestCase {
         let item2 = PlayerItem(asset: .simple(url: Stream.live.url))
         let player = Player(items: [item1, item2])
 
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toEventually(equal(2))
 
         player.advanceToNextItem()
-        expect(player.effectivePlaybackSpeed).toEventually(equal(1))
+        expect(player.playbackSpeed).toEventually(equal(1))
         expect(player.playbackSpeedRange).toEventually(equal(1...1))
     }
 
@@ -76,11 +76,11 @@ final class SpeedTests: TestCase {
         let item1 = PlayerItem(asset: .simple(url: Stream.onDemand.url))
         let item2 = PlayerItem(asset: .simple(url: Stream.onDemand.url))
         let player = Player(items: [item1, item2])
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toEventually(equal(2))
 
         player.advanceToNextItem()
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        expect(player.playbackSpeed).toEventually(equal(2))
         expect(player.playbackSpeedRange).toEventually(equal(0.1...2))
     }
 
@@ -88,9 +88,9 @@ final class SpeedTests: TestCase {
         let player = Player(item: .simple(url: Stream.dvr.url))
         expectAtLeastEqualPublished(
             values: [1, 0.5],
-            from: player.changePublisher(at: \.effectivePlaybackSpeed).removeDuplicates()
+            from: player.changePublisher(at: \.playbackSpeed).removeDuplicates()
         ) {
-            player.setDesiredPlaybackSpeed(0.5)
+            player.playbackSpeed = 0.5
         }
     }
 
@@ -100,7 +100,7 @@ final class SpeedTests: TestCase {
             values: [1...1, 0.1...1],
             from: player.changePublisher(at: \.playbackSpeedRange).removeDuplicates()
         ) {
-            player.setDesiredPlaybackSpeed(0.5)
+            player.playbackSpeed = 0.5
         }
     }
 
@@ -114,34 +114,34 @@ final class SpeedTests: TestCase {
             }
         }
 
-        player.setDesiredPlaybackSpeed(2)
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        player.playbackSpeed = 2
+        expect(player.playbackSpeed).toEventually(equal(2))
         expect(player.playbackSpeedRange).toEventually(equal(0.1...2))
 
-        expect(player.effectivePlaybackSpeed).toEventually(equal(1))
+        expect(player.playbackSpeed).toEventually(equal(1))
         expect(player.playbackSpeedRange).toEventually(equal(0.1...1))
     }
 
     func testPlaylistEnd() {
         let player = Player(item: .simple(url: Stream.shortOnDemand.url))
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         player.play()
         expect(player.currentItem).toEventually(beNil())
 
-        expect(player.effectivePlaybackSpeed).toEventually(equal(1))
+        expect(player.playbackSpeed).toEventually(equal(1))
         expect(player.playbackSpeedRange).toEventually(equal(1...1))
     }
 
     func testItemAppendMustStartAtCurrentSpeed() {
         let player = Player()
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         player.append(.simple(url: Stream.onDemand.url))
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        expect(player.playbackSpeed).toEventually(equal(2))
     }
 
     func testInitialSpeedMustSetRate() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         player.play()
         expect(player.queuePlayer.defaultRate).toEventually(equal(2))
         expect(player.queuePlayer.rate).toEventually(equal(2))
@@ -152,7 +152,7 @@ final class SpeedTests: TestCase {
         player.play()
         expect(player.playbackState).toEventually(equal(.playing))
 
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         expect(player.queuePlayer.defaultRate).toEventually(equal(2))
         expect(player.queuePlayer.rate).toEventually(equal(2))
     }
@@ -161,7 +161,7 @@ final class SpeedTests: TestCase {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.playbackState).toEventually(equal(.paused))
 
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         player.play()
 
         expect(player.queuePlayer.defaultRate).toEventually(equal(2))
@@ -171,23 +171,23 @@ final class SpeedTests: TestCase {
     func testSpeedUpdateMustNotResumePlayback() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.playbackState).toEventually(equal(.paused))
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         expect(player.playbackState).toAlways(equal(.paused), until: .seconds(2))
     }
 
     func testPlayMustNotResetSpeed() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
-        player.setDesiredPlaybackSpeed(2)
+        player.playbackSpeed = 2
         player.play()
-        expect(player.effectivePlaybackSpeed).toEventually(equal(2))
+        expect(player.playbackSpeed).toEventually(equal(2))
     }
 
     func testRateChangeMustNotUpdatePlaybackSpeedOutsideAVPlayerViewController() {
         let player = Player(item: .simple(url: Stream.onDemand.url))
         expect(player.streamType).toEventually(equal(.onDemand))
         player.queuePlayer.rate = 2
-        expect(player.effectivePlaybackSpeed).toAlways(equal(1), until: .seconds(2))
+        expect(player.playbackSpeed).toAlways(equal(1), until: .seconds(2))
     }
 
     func testNoDesiredUpdateIsIgnored() {
@@ -197,9 +197,9 @@ final class SpeedTests: TestCase {
             .value(2),
             .value(2)
         ], from: player.desiredPlaybackSpeedUpdatePublisher()) {
-            player.setDesiredPlaybackSpeed(1)
-            player.setDesiredPlaybackSpeed(2)
-            player.setDesiredPlaybackSpeed(2)
+            player.playbackSpeed = 1
+            player.playbackSpeed = 2
+            player.playbackSpeed = 2
         }
     }
 }


### PR DESCRIPTION
## Description

This PR removes the distinction between desired and effective playback speeds. This distinction is mostly useful when reading test code in which the effective speed obtain does not match the desired one in neighboring lines. It might namely be misleading to have a setter not deliver the expected value when testing the value right after it has been set, because the implementation internally performs some kind of sanitization.

In practice, though, such code never happens, and the distinction between desired speeds, as well as the associated binding, adds unnecessary verbosity to an API that should be simple. Moreover, each API for which the obtained value might be different from the requested value would need to have a similar API for consistency, which is not always the case.

For this reason, this PR proposes to drop this distinction, aligning our API with the one of Castor.

## Changes made

- Merge speed APIs into a single property.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
