### PR TITLE
Simplify menu labels

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -496,11 +496,8 @@ private struct QualityMenu: View {
             }
             .pickerStyle(.inline)
         } label: {
-            Button(action: {}) {
-                Text("Quality")
-                Text(qualitySetting.name)
-                Image(systemName: "person.and.background.dotted")
-            }
+            Label("Quality", systemImage: "person.and.background.dotted")
+            Text(qualitySetting.name)
         }
     }
 }

--- a/Sources/Player/Player/Player+SettingsMenu.swift
+++ b/Sources/Player/Player/Player+SettingsMenu.swift
@@ -93,11 +93,12 @@ private struct SettingsMenuContent: View {
                 action(.playbackSpeed(speed))
             }
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Playback Speed", bundle: .module, comment: "Playback setting menu title")
-                Text("\(player.playbackSpeed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
+            } icon: {
                 Image(systemName: "speedometer")
             }
+            Text("\(player.playbackSpeed, specifier: "%g×")", bundle: .module, comment: "Speed multiplier")
         }
     }
 
@@ -105,11 +106,12 @@ private struct SettingsMenuContent: View {
         Menu {
             mediaSelectionMenuContent(characteristic: .audible)
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Audio", bundle: .module, comment: "Playback setting menu title")
-                Text(player.selectedMediaOption(for: .audible).displayName)
+            } icon: {
                 Image(systemName: "waveform.circle")
             }
+            Text(player.selectedMediaOption(for: .audible).displayName)
         }
     }
 
@@ -117,11 +119,12 @@ private struct SettingsMenuContent: View {
         Menu {
             mediaSelectionMenuContent(characteristic: .legible)
         } label: {
-            Button(action: {}) {
+            Label {
                 Text("Subtitles", bundle: .module, comment: "Playback setting menu title")
-                Text(player.selectedMediaOption(for: .legible).displayName)
+            } icon: {
                 Image(systemName: "captions.bubble")
             }
+            Text(player.selectedMediaOption(for: .legible).displayName)
         }
     }
 


### PR DESCRIPTION
## Description

This PR simplifies the menu labels.

## Changes made

- A useless button with no action has been removed from all menu labels.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
