### PR TITLE
Fix incorrectly wired Control Center skip buttons

### DIFF
--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -323,8 +323,8 @@ private struct SkipButton: View {
 
 private struct ControlsView: View {
     @ObservedObject var player: Player
-    @ObservedObject var progressTracker: ProgressTracker
-    @ObservedObject var skipTracker: SkipTracker
+    let progressTracker: ProgressTracker
+    let skipTracker: SkipTracker
 
     var body: some View {
         HStack(spacing: 30) {
@@ -333,9 +333,7 @@ private struct ControlsView: View {
             SkipForwardButton(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
         }
         .preventsTouchPropagation()
-        ._debugBodyCounter(color: .green)
         .animation(.defaultLinear, value: player.playbackState)
-        .bind(progressTracker, to: player)
     }
 }
 
@@ -356,6 +354,7 @@ private struct SkipBackwardButton: View {
         .animation(.defaultLinear, value: player.canSkipBackward())
         .keyboardShortcut("s", modifiers: [])
         .hoverEffect()
+        ._debugBodyCounter(color: .green)
     }
 
     private func skipBackward() {
@@ -380,6 +379,7 @@ private struct SkipForwardButton: View {
         .animation(.defaultLinear, value: player.canSkipForward())
         .keyboardShortcut("d", modifiers: [])
         .hoverEffect()
+        ._debugBodyCounter(color: .green)
     }
 
     private func skipForward() {

--- a/Demo/Sources/Players/PlaybackView.swift
+++ b/Demo/Sources/Players/PlaybackView.swift
@@ -175,7 +175,7 @@ private struct MainView: View {
                 }
             }
         }
-        .preventsTouchPropagation()
+        .contentShape(.rect)
         .opacity(isUserInterfaceHidden ? 0 : 1)
     }
 
@@ -190,25 +190,34 @@ private struct MainView: View {
 
     private func topBar() -> some View {
         HStack {
-            HStack(spacing: 20) {
-                CloseButton()
-                if supportsPictureInPicture {
-                    PiPButton()
-                }
-                routePickerView()
-            }
-            .opacity(shouldHideInterface ? 0 : 1)
+            topLeadingButtons()
             Spacer()
-            HStack(spacing: 20) {
-                LoadingIndicator(player: player)
-                if !shouldHideInterface {
-                    VolumeButton(player: player)
-                }
-            }
+            topTrailingButtons()
         }
         .topBarStyle()
-        .preventsTouchPropagation()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private func topLeadingButtons() -> some View {
+        HStack(spacing: 20) {
+            CloseButton()
+            if supportsPictureInPicture {
+                PiPButton()
+            }
+            routePickerView()
+        }
+        .opacity(shouldHideInterface ? 0 : 1)
+        .contentShape(.rect)
+    }
+
+    private func topTrailingButtons() -> some View {
+        HStack(spacing: 20) {
+            LoadingIndicator(player: player)
+            if !shouldHideInterface {
+                VolumeButton(player: player)
+            }
+        }
+        .contentShape(.rect)
     }
 
     private func sliderBackground() -> some View {
@@ -332,7 +341,6 @@ private struct ControlsView: View {
             PlaybackButton(player: player)
             SkipForwardButton(player: player, progressTracker: progressTracker, skipTracker: skipTracker)
         }
-        .preventsTouchPropagation()
         .animation(.defaultLinear, value: player.playbackState)
     }
 }

--- a/Demo/Sources/Views/HSlider.swift
+++ b/Demo/Sources/Views/HSlider.swift
@@ -31,7 +31,7 @@ struct HSlider<Value, Content>: View where Value: BinaryFloatingPoint, Value.Str
             content(.init(progress), geometry.size.width)
                 // Use center alignment instead of top leading alignment used by `GeometryReader`.
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .preventsTouchPropagation()
+                .contentShape(.rect)
                 .gesture(dragGesture(in: geometry))
                 .onChange(of: gestureValue) { value in
                     // Gesture cancellation can only be detected via gesture value observation,

--- a/Demo/Sources/Views/Modal.swift
+++ b/Demo/Sources/Views/Modal.swift
@@ -28,7 +28,7 @@ private struct PresentedModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .preventsTouchPropagation()
+            .contentShape(.rect)
             .gesture(
                 DragGesture(minimumDistance: distance)
                     .onEnded { value in

--- a/Demo/Sources/Views/View.swift
+++ b/Demo/Sources/Views/View.swift
@@ -53,11 +53,6 @@ private struct ScaleEffect17: ViewModifier {
 }
 
 extension View {
-    /// Prevents touch propagation to views located below the receiver.
-    func preventsTouchPropagation() -> some View {
-        background(Color(white: 1, opacity: 0.0001))
-    }
-
     func animation<V1, V2>(_ animation: Animation?, values v1: V1, _ v2: V2) -> some View where V1: Equatable, V2: Equatable {
         self.animation(animation, value: v1)
             .animation(animation, value: v2)

--- a/Sources/Player/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player/Player+ControlCenter.swift
@@ -129,7 +129,7 @@ extension Player {
     func nowPlayingPublisher() -> AnyPublisher<NowPlaying, Never> {
         Publishers.CombineLatest(isActivePublisher, queuePublisher)
             .map { [weak self] isActive, queue in
-                guard let self, isActive, !queue.isActive, queue.error == nil else { return Just(NowPlaying.empty).eraseToAnyPublisher() }
+                guard let self, isActive, queue.isActive else { return Just(NowPlaying.empty).eraseToAnyPublisher() }
                 return Publishers.CombineLatest(
                     metadataPublisher,
                     nowPlayingInfoPlaybackPublisher()

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -438,8 +438,8 @@ private extension Player {
             guard let self else { return }
             let areSkipsEnabled = queue.elements.count <= 1 && properties.streamType != .live
             let hasError = queue.error != nil
-            nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled && !hasError && canSkipForward()
-            nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled && !hasError && canSkipBackward()
+            nowPlayingSession.remoteCommandCenter.skipBackwardCommand.isEnabled = areSkipsEnabled && !hasError && canSkipBackward()
+            nowPlayingSession.remoteCommandCenter.skipForwardCommand.isEnabled = areSkipsEnabled && !hasError && canSkipForward()
             nowPlayingSession.remoteCommandCenter.changePlaybackPositionCommand.isEnabled = !hasError
 
             let items = Deque(queue.elements.map(\.item))

--- a/Sources/Player/Types/Queue.swift
+++ b/Sources/Player/Types/Queue.swift
@@ -31,7 +31,7 @@ struct Queue {
     }
 
     var isActive: Bool {
-        playerItem == nil
+        playerItem != nil && error == nil
     }
 
     private var playerItem: AVPlayerItem? {


### PR DESCRIPTION
## Description

This PR fixes incorrectly wired Control Center skip buttons and performs a few additional minor adjustments in the processs.

## Changes made

- Fix Control Center skip buttons.
- Revisit hit testing management (use content shapes rather than almost transparent background trick).
- Improve `isActive` implementation.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
