### PR TITLE
Add auto-lock issue to known issue list

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -145,3 +145,12 @@ If the app stays in the background for an extended period (around 24 hours) with
 ### Workaround
 
 Instead of using an encrypted `PlayerItem`, create a custom player item and handle key loading via an `AVAssetResourceLoaderDelegate`.
+
+## Device auto-lock may not be prevented during video playback (FB20938762)
+
+On iOS 26 and later, the device screen may dim and eventually auto-lock during video playback, even when `preventsDisplaySleepDuringVideoPlayback` is set to `true` for an `AVPlayer` (the default behavior).
+
+### Workaround
+
+This issue is caused by a Picture in Picture regression introduced in iOS 26.  
+Avoid dynamically changing the value of `VideoView.supportsPictureInPicture(_:)` or `SystemVideoView.supportsPictureInPicture(_:)` while a video view is visible.


### PR DESCRIPTION
## Description

This PR adds FB20938762 (_iOS 26 regression: `AVPlayer.preventsDisplaySleepDuringVideoPlayback` is sometimes ignored after switching between player layers, letting the device incorrectly sleep during video playback_) to the list of known issues.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
