### PR TITLE
Add known memory leak issue on tvOS 26

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -162,3 +162,11 @@ Due to an `AVQueuePlayer` issue, toggling `isMuted` can cause the player to rema
 ### Workaround
 
 No workaround is available yet. Audio is restored when transitioning between items, when the player is paused and resumed, or when a seek operation occurs.
+
+## Memory leaks when using `SystemVideoView` on tvOS 26 (FB21160665)
+
+The standard player user interface leaks memory when playing content that contains chapters on tvOS 26.
+
+### Workaround
+
+No workaround is available yet.


### PR DESCRIPTION
## Description

This PR documents the known tvOS 26 regression described in the linked issue (FB21160665).

### Remark

We could remove navigation markers entirely on another PR is the problem proves blocking for development teams.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
