### PR TITLE
Ignore Nimble updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,4 @@ updates:
           - "*"
     ignore:
       - dependency-name: "github.com/krzysztofzablocki/difference"
+      - dependency-name: "nimble"


### PR DESCRIPTION
## Description

This PR updates the **Dependabot** configuration to ignore updates for the **Nimble** dependency. Upgrading to **Nimble** `14.0.0` appears to be tricky, and we also plan to migrate to **Swift Testing** in the near future.

## Changes made

- The dependabot file has been updated. 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
