### PR TITLE
Stop heartbeats after an error has been encountered

### DIFF
--- a/Sources/Monitoring/Tracker/MetricsTracker.swift
+++ b/Sources/Monitoring/Tracker/MetricsTracker.swift
@@ -68,6 +68,7 @@ public final class MetricsTracker: PlayerItemTracker {
                 session.start()
                 sendEvent(name: .start, data: startData(from: events))
             }
+            stopHeartbeat()
             sendEvent(name: .error, data: errorData(from: error))
             session.stop()
         default:


### PR DESCRIPTION
## Description

This PR fixes an issue leading to tracker heartbeats not stopping after an error has been encountered during playback.

Thanks @jboix for reporting it.

### Remark

Heartbeats were already correctly not started for errors encountered when playback starts.

## Changes made

- Stop tracker heartbeats after errors.
- No tests were written since this issue is difficult to reproduce using a test stream (it can be manually reproduced by playing a DVR stream with a proxy tool, blocking media playlist requests during playback).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
