### PR TITLE
Fix audio leak on first player launch

### DIFF
--- a/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
+++ b/Sources/Player/PictureInPicture/CustomPictureInPicture.swift
@@ -75,7 +75,7 @@ final class CustomPictureInPicture: NSObject {
     func dismantleHostView(_ hostView: PictureInPictureHostView) {
         hostViews.remove(hostView)
         if !isActive && controller?.contentSource == hostView.contentSource {
-            hostView.player = nil
+            controller?.contentSource?.playerLayer?.player = nil
             if let lastHostView = hostViews.last {
                 controller?.contentSource = lastHostView.contentSource ?? .empty
             }


### PR DESCRIPTION
## Description

This PR fixes an audio leak issue (introduced by #1013) on some devices (for example, the iPhone 15 Pro) that occurs only the first time a player is opened.

## Changes made

- The player attached to the content source player layer is manually released.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
