### PR TITLE
Avoid pulling conflicting dependencies in the same environment

### DIFF
--- a/Scripts/private/deliver-demo.sh
+++ b/Scripts/private/deliver-demo.sh
@@ -12,7 +12,7 @@ function usage {
 function install_tools {
     curl -Ssf https://pkgx.sh | sh &> /dev/null
     set -a
-    eval "$(pkgx +ruby@3.3.0 +bundle +rsvg-convert +magick)"
+    eval "$(pkgx +ruby@3.3.0 +bundle +magick)"
     set +a
 }
 
@@ -43,5 +43,5 @@ install_tools
 echo -e "Delivering demo $CONFIGURATION build for $PLATFORM..."
 bundle config set path '.bundle'
 bundle install
-bundle exec fastlane "deliver_demo_${CONFIGURATION}_${PLATFORM}"
+pkgx +rsvg-convert bundle exec fastlane "deliver_demo_${CONFIGURATION}_${PLATFORM}"
 echo "... done."


### PR DESCRIPTION
## Description

This PR fixes a pkgx CI dependency conflict. Inspired by this [comment](https://github.com/pkgxdev/pantry/issues/11724#issuecomment-3836161025), it avoids pulling both conflicting `convert` and `rsvg-convert` commands into the same environment at the same time.

## Changes made

- Remove `rsvg-convert` from tools.
- Use it explicitly when calling fastlane for delivery and badging.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
