### PR TITLE
Fix Swift 6.2 compilation warnings

### DIFF
--- a/Tests/CircumspectTests/ObservableObjectTests.swift
+++ b/Tests/CircumspectTests/ObservableObjectTests.swift
@@ -61,7 +61,7 @@ final class ObservableObjectTests: XCTestCase {
     func testDeallocation() {
         var object: TestObservableObject? = TestObservableObject()
         _ = object?.changePublisher(at: \.nonPublishedProperty)
-        weak var weakObject = object
+        weak let weakObject = object
         autoreleasepool {
             object = nil
         }

--- a/Tests/CoreTests/NotificationPublisherTests.swift
+++ b/Tests/CoreTests/NotificationPublisherTests.swift
@@ -32,7 +32,7 @@ final class NotificationPublisherTests: XCTestCase {
         var object: TestObject? = TestObject()
         let publisher = notificationCenter.weakPublisher(for: .testNotification, object: object).first()
 
-        weak var weakObject = object
+        weak let weakObject = object
         autoreleasepool {
             object = nil
         }

--- a/Tests/CoreTests/WeakCapturePublisherTests.swift
+++ b/Tests/CoreTests/WeakCapturePublisherTests.swift
@@ -16,7 +16,7 @@ final class WeakCapturePublisherTests: XCTestCase {
         let publisher = Just("output")
             .weakCapture(object)
 
-        weak var weakObject = object
+        weak let weakObject = object
         autoreleasepool {
             object = nil
         }

--- a/Tests/PlayerTests/Publishers/AVPlayerBoundaryTimePublisherTests.swift
+++ b/Tests/PlayerTests/Publishers/AVPlayerBoundaryTimePublisherTests.swift
@@ -65,7 +65,7 @@ final class AVPlayerBoundaryTimePublisherTests: TestCase {
             ]
         )
 
-        weak var weakPlayer = player
+        weak let weakPlayer = player
         autoreleasepool {
             player = nil
         }


### PR DESCRIPTION
## Description

This PR fixes Swift 6.2 compilation warnings appeared with the new `weak let` support.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
