### PR TITLE
Force Commanders Act SDK version to 5.4.17 to avoid crashes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b4b0a25a91438192f3fe15d3b9bf701a972d12c8f8434183af3e5b4a6461ef3",
+  "originHash" : "d26296ad8ff33d563010af5cc8440c4d81d528ef646910a808a384a7797e901f",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "63ef45e6287b86a0b10cdb447dbc9f8a19262482",
-        "version" : "5.4.18"
+        "revision" : "a4c2621326b115f254e2193f2fd5a678d48fd8eb",
+        "version" : "5.4.17"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.16.0")),
-        .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.0")),
+        .package(url: "https://github.com/CommandersAct/iOSV5.git", exact: "5.4.17"),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0"))


### PR DESCRIPTION
## Description

This PR pins the Commanders Act SDK version to 5.4.17 since 5.4.18 seems affected by internal crashes. Until we know more it is therefore safer to stick to a version which did not suffer from these issues.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
