### PR TITLE
Update Commanders Act to version 5.4.19

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7da825c06af0398383cd3c18b07d055b09f07614d19946179618ca9ce1c33a3b",
+  "originHash" : "951aab17a5d6f34e53bc7633ddcea830377f57a827374cd29428bab43fe997f6",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "a4c2621326b115f254e2193f2fd5a678d48fd8eb",
-        "version" : "5.4.17"
+        "revision" : "3b484abc866976f2cd94f3a499e198ec002f86a9",
+        "version" : "5.4.19"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d26296ad8ff33d563010af5cc8440c4d81d528ef646910a808a384a7797e901f",
+  "originHash" : "4118b830c7259fddc90bd8924198e6e425501fb3d13489ec958e991f73e68bd2",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "a4c2621326b115f254e2193f2fd5a678d48fd8eb",
-        "version" : "5.4.17"
+        "revision" : "3b484abc866976f2cd94f3a499e198ec002f86a9",
+        "version" : "5.4.19"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.16.0")),
-        .package(url: "https://github.com/CommandersAct/iOSV5.git", exact: "5.4.17"),
+        .package(url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMajor(from: "5.4.19")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0"))


### PR DESCRIPTION
## Description

This PR updates Commanders Act to version 5.4.19, which [should fix a crash](https://github.com/CommandersAct/iOSV5/issues/20) affecting version 5.4.18.

This PR reverts #1445.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
