### PR TITLE
Support content replay from the Control Center

### DIFF
--- a/Sources/Player/Player/Player+ControlCenter.swift
+++ b/Sources/Player/Player/Player+ControlCenter.swift
@@ -46,7 +46,13 @@ private extension Player {
 
     func playRegistration() -> some RemoteCommandRegistrable {
         nowPlayingSession.remoteCommandCenter.register(command: \.playCommand) { [weak self] _ in
-            self?.play()
+            guard let self else { return .commandFailed }
+            if canReplay() {
+                replay()
+            }
+            else {
+                play()
+            }
             return .success
         }
     }


### PR DESCRIPTION
## Description

The play Control Center button was not useful at the end of playback (not doing anything). With improvements made in #1467 we can further improve the end of playback Control Center experience.

We decided to align the Control Center behavior on Apple Music:

- The play button is equivalent to a replay button after playback ended.
- Previous/next buttons never make paused playback resume (including when smartly seeking to the beginning instead of navigating to the previous item).

Custom play/pause, previous and next buttons (e.g. those in the playlist demo view) can be implemented as desired by a product, based on state information available from `Player`.

If a product needs more flexibility in the future we might consider adding more options, but for the moment this seems meaningful behavior.

## Alternatives considered

Spotify resumes playback when navigating the playlist (but not when returning to the beginning of the current item, strangely).

## Changes made

- Make the Control Center play button replay content at the end of playback.
- No other changes were required to align our behavior on Apple Music.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
