### PR TITLE
Add audiovisual background playback policy to the list of known issues

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -188,3 +188,11 @@ When using an official Lightning-to-HDMI Apple adapter (A1438) to connect a Ligh
 ### Workaround
 
 No workaround is available yet.
+
+## The `.pauses` audiovisual background playback policy is no longer correctly applied on iOS 26.4 (FB22488151)
+
+With the`.automatic` or `.pauses` audiovisual background playback policy enabled, video playback continues instead of being automatically paused by the system when the app moves to the background or the device is locked.
+
+### Workaround
+
+No workaround is available yet.


### PR DESCRIPTION
This PR adds FB22488151 (iOS 26.4 regression: The `.pauses` audiovisual background playback policy does not pause video playback anymore when backgrounding the app) to the list of known issues.

## Description

Self-explanatory.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
