### PR TITLE
Add `media_google_cast` to media events

### DIFF
--- a/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
@@ -10,6 +10,7 @@
 public struct CommandersActLabels: Decodable {
     private let _media_airplay_on: String?
     private let _media_audiodescription_on: String?
+    private let _media_google_cast: String?
     private let _media_position: String?
     private let _media_subtitles_on: String?
     private let _media_timeshift: String?
@@ -105,6 +106,12 @@ public struct CommandersActLabels: Decodable {
         extract(\._media_audiodescription_on)
     }
 
+    /// The value of `media_google_cast`.
+    public var media_google_cast: Bool? {
+        // swiftlint:disable:previous discouraged_optional_boolean
+        extract(\._media_google_cast)
+    }
+
     /// The value of `media_player_display`.
     public let media_player_display: String?
 
@@ -169,6 +176,7 @@ private extension CommandersActLabels {
     enum CodingKeys: String, CodingKey {
         case _media_airplay_on = "media_airplay_on"
         case _media_audiodescription_on = "media_audiodescription_on"
+        case _media_google_cast = "media_google_cast"
         case _media_position = "media_position"
         case _media_subtitles_on = "media_subtitles_on"
         case _media_timeshift = "media_timeshift"

--- a/Sources/Analytics/CommandersAct/CommandersActTracker.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActTracker.swift
@@ -120,6 +120,7 @@ private extension CommandersActTracker {
         labels["media_subtitles_on"] = subtitleOn(from: properties)
         labels["media_subtitle_selection"] = subtitleSelection(from: properties)
         labels["media_airplay_on"] = externalPlaybackActive(from: properties)
+        labels["media_google_cast"] = "false"
 
         switch properties.streamType {
         case .onDemand:

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActTrackerTests.swift
@@ -219,6 +219,23 @@ final class CommandersActTrackerTests: CommandersActTestCase {
         }
     }
 
+    func testCommonLabels() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            trackerAdapters: [
+                CommandersActTracker.adapter(configuration: nil) { _ in .test }
+            ]
+        ))
+        expectAtLeastHits(
+            play { labels in
+                expect(labels.media_player_display).to(equal("Pillarbox"))
+                expect(labels.media_google_cast).to(beFalse())
+            }
+        ) {
+            player.play()
+        }
+    }
+
     func testSourceLabels() {
         let player = Player(item: .simple(
             url: Stream.onDemand.url,


### PR DESCRIPTION
## Description

This PR adds the `media_google_cast` to fulfill requirements described in the linked issue.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
