### PR TITLE
Fix list animations

### DIFF
--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -152,7 +152,7 @@ struct ContentListView: View {
                 }
             }
         }
-        .animation(.defaultLinear, value: model.state)
+        .animation(.defaultLinear, value: model.animationValue)
         .onAppear { model.configuration = configuration }
 #if os(iOS)
         .navigationTitle(configuration.list.name)

--- a/Demo/Sources/ContentLists/ContentListViewModel.swift
+++ b/Demo/Sources/ContentLists/ContentListViewModel.swift
@@ -13,6 +13,17 @@ final class ContentListViewModel: ObservableObject, Refreshable {
     @Published var configuration: ContentList.Configuration?
     private let trigger = Trigger()
 
+    var animationValue: String {
+        switch state {
+        case .loading:
+            return "loading"
+        case .loaded:
+            return "loaded"
+        case .failed:
+            return "failed"
+        }
+    }
+
     init() {
         $configuration
             .removeDuplicates()
@@ -135,23 +146,10 @@ final class ContentListViewModel: ObservableObject, Refreshable {
 }
 
 extension ContentListViewModel {
-    enum State: Equatable {
+    enum State {
         case loading
         case loaded(contents: [Content])
         case failed(Error)
-
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.loading, .loading):
-                return true
-            case let (.loaded(contents: lhsContents), .loaded(contents: rhsContents)):
-                return lhsContents == rhsContents
-            case let (.failed(lhsError), .failed(rhsError)):
-                return lhsError as NSError == rhsError as NSError
-            default:
-                return false
-            }
-        }
     }
 
     enum TriggerId {

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -26,6 +26,14 @@ struct SearchView: View {
             case .loading:
                 ProgressView()
                     .accessibilityHidden(true)
+            case let .loaded(medias: medias) where medias.isEmpty:
+                UnavailableModelView(model: model) {
+                    Label {
+                        Text("No results.")
+                    } icon: {
+                        Image(systemName: "circle.slash")
+                    }
+                }
             case let .loaded(medias: medias):
                 loadedView(medias)
             case let .failed(error):
@@ -53,46 +61,35 @@ struct SearchView: View {
 
     @ViewBuilder
     private func loadedView(_ medias: [SRGMedia]) -> some View {
-        if !medias.isEmpty {
-            CustomList(data: medias) { media in
-                if let media {
-                    Cell(
-                        size: .init(width: 520, height: 300),
-                        title: constant(iOS: MediaDescription.title(for: media), tvOS: media.show?.title),
-                        subtitle: constant(iOS: MediaDescription.subtitle(for: media), tvOS: media.title),
-                        imageUrl: SRGDataProvider.current!.url(for: media.image, size: .large),
-                        type: MediaDescription.systemImage(for: media),
-                        duration: MediaDescription.duration(for: media),
-                        date: MediaDescription.date(for: media),
-                        style: MediaDescription.style(for: media)
-                    ) {
-                        let media = Media(title: media.title, type: .urn(media.urn))
-                        router.presented = .player(media: media)
+        CustomList(data: medias) { media in
+            if let media {
+                Cell(
+                    size: .init(width: 520, height: 300),
+                    title: constant(iOS: MediaDescription.title(for: media), tvOS: media.show?.title),
+                    subtitle: constant(iOS: MediaDescription.subtitle(for: media), tvOS: media.title),
+                    imageUrl: SRGDataProvider.current!.url(for: media.image, size: .large),
+                    type: MediaDescription.systemImage(for: media),
+                    duration: MediaDescription.duration(for: media),
+                    date: MediaDescription.date(for: media),
+                    style: MediaDescription.style(for: media)
+                ) {
+                    let media = Media(title: media.title, type: .urn(media.urn))
+                    router.presented = .player(media: media)
+                }
+                .onAppear {
+                    if let index = medias.firstIndex(of: media), medias.count - index < kPageSize {
+                        model.loadMore()
                     }
-                    .onAppear {
-                        if let index = medias.firstIndex(of: media), medias.count - index < kPageSize {
-                            model.loadMore()
-                        }
-                    }
+                }
 #if os(iOS)
-                    .swipeActions { CopyActions(text: media.urn) }
-                    .refreshable { await model.refresh() }
+                .swipeActions { CopyActions(text: media.urn) }
+                .refreshable { await model.refresh() }
 #else
-                    .ignoresSafeArea(.all, edges: .horizontal)
+                .ignoresSafeArea(.all, edges: .horizontal)
 #endif
-                }
-            }
-            .scrollDismissesKeyboard(.immediately)
-        }
-        else {
-            UnavailableModelView(model: model) {
-                Label {
-                    Text("No results.")
-                } icon: {
-                    Image(systemName: "circle.slash")
-                }
             }
         }
+        .scrollDismissesKeyboard(.immediately)
     }
 }
 

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -16,34 +16,16 @@ struct SearchView: View {
         ZStack {
             switch model.state {
             case .empty:
-                UnavailableView {
-                    Label {
-                        Text("Enter something to search.")
-                    } icon: {
-                        Image(systemName: "magnifyingglass")
-                    }
-                }
+                emptyView()
             case .loading:
                 ProgressView()
                     .accessibilityHidden(true)
             case let .loaded(medias: medias) where medias.isEmpty:
-                UnavailableModelView(model: model) {
-                    Label {
-                        Text("No results.")
-                    } icon: {
-                        Image(systemName: "circle.slash")
-                    }
-                }
+                unavailableModelView(title: "No results.", icon: "circle.slash")
             case let .loaded(medias: medias):
                 loadedView(medias)
             case let .failed(error):
-                UnavailableModelView(model: model) {
-                    Label {
-                        Text(error.localizedDescription)
-                    } icon: {
-                        Image(systemName: "exclamationmark.bubble")
-                    }
-                }
+                unavailableModelView(title: error.localizedDescription, icon: "exclamationmark.bubble")
             }
         }
         .animation(.defaultLinear, value: model.animationValue)
@@ -90,6 +72,30 @@ struct SearchView: View {
             }
         }
         .scrollDismissesKeyboard(.immediately)
+    }
+
+    private func emptyView() -> some View {
+        UnavailableView {
+            Label {
+                Text("Enter something to search.")
+            } icon: {
+                Image(systemName: "magnifyingglass")
+            }
+        }
+    }
+
+    private func unavailableModelView(title: String, icon: String) -> some View {
+        UnavailableModelView(model: model) {
+            Label {
+                Text(title)
+            } icon: {
+                Image(systemName: icon)
+            }
+        }
+    }
+
+    private func unavailableModelView(title: LocalizedStringResource, icon: String) -> some View {
+        unavailableModelView(title: String(localized: title), icon: icon)
     }
 }
 

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -38,7 +38,7 @@ struct SearchView: View {
                 }
             }
         }
-        .animation(.defaultLinear, value: model.state)
+        .animation(.defaultLinear, value: model.animationValue)
         .tracked(name: "search")
         .searchable(text: $model.text)
 #if os(iOS)

--- a/Demo/Sources/Search/SearchViewModel.swift
+++ b/Demo/Sources/Search/SearchViewModel.swift
@@ -11,24 +11,11 @@ import SRGDataProviderCombine
 import SRGDataProviderModel
 
 final class SearchViewModel: ObservableObject, Refreshable {
-    enum State: Equatable {
+    enum State {
         case empty
         case loading
         case loaded(medias: [SRGMedia])
         case failed(Error)
-
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            switch (lhs, rhs) {
-            case (.empty, .empty), (.loading, .loading):
-                return true
-            case let (.loaded(medias: lhsMedias), .loaded(medias: rhsMedias)):
-                return lhsMedias == rhsMedias
-            case let (.failed(lhsError), .failed(rhsError)):
-                return lhsError as NSError == rhsError as NSError
-            default:
-                return false
-            }
-        }
     }
 
     enum TriggerId {
@@ -47,6 +34,19 @@ final class SearchViewModel: ObservableObject, Refreshable {
     @Published var vendor: SRGVendor = .RTS
 
     private let trigger = Trigger()
+
+    var animationValue: String {
+        switch state {
+        case .empty:
+            return "empty"
+        case .loading:
+            return "loading"
+        case.loaded:
+            return "loaded"
+        case .failed:
+            return "failed"
+        }
+    }
 
     init() {
         Publishers.CombineLatest($text, $vendor)


### PR DESCRIPTION
## Description

This PR avoids animations when loading more content in scrollable lists. Such animations namely give the false impression that content pages are incorrectly loaded.

## Changes made

- Update content list and search views to only animate between different states, ignoring associated values.
- Refactor search view implementation to separate view states more cleanly.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
