### PR TITLE
Add language informtion in metrics

### DIFF
--- a/Sources/Monitoring/Tracker/MetricsTracker.swift
+++ b/Sources/Monitoring/Tracker/MetricsTracker.swift
@@ -148,7 +148,8 @@ private extension MetricsTracker {
             player: .init(
                 name: "Pillarbox",
                 platform: "Apple",
-                version: Player.version
+                version: Player.version,
+                language: Self.playerLanguage
             ),
             media: .init(
                 assetUrl: metadata?.assetUrl,
@@ -245,6 +246,7 @@ private extension MetricsTracker {
 private extension MetricsTracker {
     static let applicationId = Bundle.main.bundleIdentifier
     static let applicationVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    static let playerLanguage = Bundle.main.preferredLocalizations.first
 }
 
 private extension MetricsTracker {

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -45,6 +45,7 @@ extension MetricStartData {
         let name: String
         let platform: String
         let version: String
+        let language: String?
     }
 
     struct ExperienceTimings: Encodable {

--- a/Tests/MonitoringTests/MetricsTrackerTests.swift
+++ b/Tests/MonitoringTests/MetricsTrackerTests.swift
@@ -200,6 +200,7 @@ final class MetricsTrackerTests: MonitoringTestCase {
                 let player = data.player
                 expect(player.name).to(equal("Pillarbox"))
                 expect(player.version).to(equal(Player.version))
+                expect(player.language).notTo(beNil())
             },
             heartbeat { payload in
                 expect(payload.version).to(equal(1))


### PR DESCRIPTION
## Description

This PR adds language information (as seen by the player) to our metrics `START` event.

## Changes made

- Use `Bundle.main.preferredLocalizations.first` to reflect the language of the app first.
- Tests have been updated to check for existence (value may differ depending on simulator settings).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
