### PR TITLE
Fix MP3 audio duration when running as iPad app on macOS

### DIFF
--- a/Demo/Sources/Showcase/ShowcaseView.swift
+++ b/Demo/Sources/Showcase/ShowcaseView.swift
@@ -228,6 +228,7 @@ struct ShowcaseView: View {
     }
 
     private func systemPlayerSection() -> some View {
+        // swiftlint:disable:next closure_body_length
         CustomSection("System player (using Pillarbox)") {
             cell(
                 title: "Apple Basic 16:9",
@@ -252,6 +253,10 @@ struct ShowcaseView: View {
             cell(
                 title: "Video URN - Livestream with DRM",
                 destination: .systemPlayer(media: URNMedia.dvrVideo)
+            )
+            cell(
+                title: "AOD - MP3",
+                destination: .systemPlayer(media: URLMedia.onDemandAudioMP3)
             )
             cell(
                 title: "Unknown",
@@ -417,6 +422,10 @@ struct ShowcaseView: View {
             cell(
                 title: "VOD - MP4",
                 destination: .vanillaPlayer(item: URLMedia.onDemandVideoMP4.playerItem()!)
+            )
+            cell(
+                title: "AOD - MP3",
+                destination: .vanillaPlayer(item: URLMedia.onDemandAudioMP3.playerItem()!)
             )
             cell(
                 title: "Unknown",

--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -34,13 +34,15 @@ enum Resource {
     }
 
     func playerItem(configuration: PlayerConfiguration) -> AVPlayerItem {
+        let automaticallyLoadedAssetKeys = ["duration"]
         switch self {
         case let .simple(url: url):
-            return AVPlayerItem(asset: asset(for: url, with: configuration))
+            return AVPlayerItem(asset: asset(for: url, with: configuration), automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
         case let .custom(url: url, delegate: delegate):
             return ResourceLoadedPlayerItem(
                 asset: asset(for: url, with: configuration),
-                resourceLoaderDelegate: delegate
+                resourceLoaderDelegate: delegate,
+                automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys
             )
         case let .encrypted(url: url, delegate: delegate):
 #if targetEnvironment(simulator)
@@ -50,7 +52,7 @@ enum Resource {
             let asset = asset(for: url, with: configuration)
             kContentKeySession.setDelegate(delegate, queue: kContentKeySessionQueue)
             kContentKeySession.addContentKeyRecipient(asset)
-            return AVPlayerItem(asset: asset)
+            return AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
 #endif
         }
     }

--- a/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
+++ b/Sources/Player/ResourceLoading/ResourceLoadedPlayerItem.swift
@@ -13,10 +13,11 @@ final class ResourceLoadedPlayerItem: AVPlayerItem {
     // swiftlint:disable:next weak_delegate
     private let resourceLoaderDelegate: AVAssetResourceLoaderDelegate
 
-    init(asset: AVURLAsset, resourceLoaderDelegate: AVAssetResourceLoaderDelegate) {
+    // swiftlint:disable:next discouraged_optional_collection
+    init(asset: AVURLAsset, resourceLoaderDelegate: AVAssetResourceLoaderDelegate, automaticallyLoadedAssetKeys: [String]?) {
         self.resourceLoaderDelegate = resourceLoaderDelegate
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: kResourceLoaderQueue)
         // Provide same key as for a standard asset, see `AVPlayerItem.init(asset:)` documentation.
-        super.init(asset: asset, automaticallyLoadedAssetKeys: ["duration"])
+        super.init(asset: asset, automaticallyLoadedAssetKeys: automaticallyLoadedAssetKeys)
     }
 }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -65,14 +65,6 @@ The media type can be `.unknown` if an AirPlay session was established before pl
 
 No workaround is available yet.
 
-## Audio duration is zero in Mac applications "Designed for iPad" (FB12765347)
-
-Pillarbox can be used in iPad applications run on Silicon Macs (_Designed for iPad_ destination) but audios played will have a reported duration of zero. As a result progress reported by `ProgressTracker` also remains stuck at zero.
-
-### Workaround
-
-No workaround is available yet.
-
 ## AirPlay does not work in Mac applications "Designed for iPad" (FB15343579)
 
 Pillarbox can be used in iPad applications run on Silicon Macs (_Designed for iPad_ destination) but AirPlay does not work. Playback fails.


### PR DESCRIPTION
## Description

This PR fixes missing audio duration on macOS by ensuring the _duration_ key is always consistently loaded by an item. This in turn ensures that seekable time ranges are correct.

This change does not negatively impact performance (keys are loaded asynchronously and we observe changes reactively).

### Remark

Vanilla examples (`VideoPlayer` with `AVPlayer`) have been updated as well but in this case default keys are still loaded, which means seeking is still not possible for an MP3. This might change in the future if Apple updates the behavior in response to FB12765347.

## Changes made

- Load the default set of keys (only _duration_ according to `AVPlayerItem`'s documentation) for all items created by a `Player`.
- Add AOD MP3 examples played with the system player UI.
- Remove FB12765347 from known issues.
- Update [FB12765347](https://github.com/SRGSSR/apple-bug-reports/blob/main/FB12765347/Report.md).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
