### PR TITLE
Fix macOS Design for iPad crash on older than iOS 18

### DIFF
--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -322,7 +322,7 @@ private extension Player {
 
     func configureControlCenterPublishers() {
         if ProcessInfo.processInfo.isiOSAppOnMac {
-            guard #available(iOS 26, *) else { return }
+            guard #available(iOS 18, *) else { return }
         }
         configureControlCenterMetadataUpdatePublisher()
         configureControlCenterRemoteCommandUpdatePublisher()

--- a/Sources/Player/Player/Player.swift
+++ b/Sources/Player/Player/Player.swift
@@ -321,6 +321,9 @@ private extension Player {
     }
 
     func configureControlCenterPublishers() {
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            guard #available(iOS 26, *) else { return }
+        }
         configureControlCenterMetadataUpdatePublisher()
         configureControlCenterRemoteCommandUpdatePublisher()
     }


### PR DESCRIPTION
## Description

This PR fixes a regression introduced by PR #1419. Indeed, removing the guard to enable the Control Center on iOS 26.0 caused a crash on earlier versions of iOS (< 18).

## Changes made

- The Control Center for older versions than iOS 18 has been disabled.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
