### PR TITLE
Update Commanders Act to version 5.5.0 available from the official SPM repository

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "f5cbbb9439ead05e8db71a471a4272b4ad0cd185a46d175c19deae4fac939c55",
+  "originHash" : "533746a712bc76ec6633fdbf559af6a73b95d8f92df4058b35b43fab239270ee",
   "pins" : [
-    {
-      "identity" : "commanders-act-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SRGSSR/commanders-act-apple.git",
-      "state" : {
-        "revision" : "bed2a1fb87885bc535a2c8a7de891b8f2ae820ed",
-        "version" : "5.4.19"
-      }
-    },
     {
       "identity" : "comscore-swift-package-manager",
       "kind" : "remoteSourceControl",
@@ -44,6 +35,15 @@
       "state" : {
         "revision" : "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
         "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "iosv5-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CommandersAct/iOSV5-spm.git",
+      "state" : {
+        "revision" : "39eb694d2df118f435dc82900cb864a568972a7c",
+        "version" : "5.5.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "f11afc707ae186ec29b599a5b1fdd92d1864d067",
-        "version" : "19.0.10"
+        "revision" : "d438354131bd2b144e917cae7139bae1b86e8d10",
+        "version" : "19.0.12"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srglogger-apple.git",
       "state" : {
-        "revision" : "dd98468422044b53e283d970809b8502e1ef5b8d",
-        "version" : "3.1.0"
+        "revision" : "2e2aeaeb4277f762dfdc66b78bf396a5cc935215",
+        "version" : "3.1.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgnetwork-apple.git",
       "state" : {
-        "revision" : "153a2544391c1aaccae2d38d8b113fd0a03421b8",
-        "version" : "3.1.0"
+        "revision" : "26643d930bb10b4749e8723e88dbebb305dd27cd",
+        "version" : "3.1.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "30e57fd2ab52f9dbc09240ea62dbd41bdbae0674313067bd94f08126a7ac7101",
+  "originHash" : "b00e9f6f2dcc79d30330aef09d0e11c39c8ef2821f8b8173fd048bba7e990a7a",
   "pins" : [
-    {
-      "identity" : "commanders-act-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SRGSSR/commanders-act-apple.git",
-      "state" : {
-        "revision" : "bed2a1fb87885bc535a2c8a7de891b8f2ae820ed",
-        "version" : "5.4.19"
-      }
-    },
     {
       "identity" : "comscore-swift-package-manager",
       "kind" : "remoteSourceControl",
@@ -47,6 +38,15 @@
       }
     },
     {
+      "identity" : "iosv5-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CommandersAct/iOSV5-spm.git",
+      "state" : {
+        "revision" : "39eb694d2df118f435dc82900cb864a568972a7c",
+        "version" : "5.5.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.16.0")),
-        .package(url: "https://github.com/SRGSSR/commanders-act-apple.git", .upToNextMajor(from: "5.4.19")),
+        .package(url: "https://github.com/CommandersAct/iOSV5-spm.git", .upToNextMajor(from: "5.5.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0"))
@@ -51,8 +51,8 @@ let package = Package(
             dependencies: [
                 .target(name: "PillarboxPlayer"),
                 .product(name: "ComScore", package: "Comscore-Swift-Package-Manager"),
-                .product(name: "TCCore", package: "commanders-act-apple"),
-                .product(name: "TCServerSide", package: "commanders-act-apple")
+                .product(name: "TCCore", package: "iOSV5-spm"),
+                .product(name: "TCServerSide", package: "iOSV5-spm")
             ],
             path: "Sources/Analytics",
             resources: [


### PR DESCRIPTION
## Description

The CommandersAct V5 SDK for Apple platforms was recently improved to address two issues we reported:

- https://github.com/CommandersAct/iOSV5/issues/19
- https://github.com/CommandersAct/iOSV5/issues/17

## Changes made

- Update SPM package URL to point at the new official Commanders Act lightweight repository.
- Update to version 5.5.0 of the SDK.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
