### PR TITLE
Add support for Play+ endpoints

### DIFF
--- a/Demo/Sources/Model/ServerSetting.swift
+++ b/Demo/Sources/Model/ServerSetting.swift
@@ -12,6 +12,9 @@ enum ServerSetting: Int, CaseIterable {
     case production
     case stage
     case test
+    case playPlusProduction
+    case playPlusIntegration
+    case playPlusDevelopment
 
     var title: String {
         switch self {
@@ -21,6 +24,12 @@ enum ServerSetting: Int, CaseIterable {
             return "Stage"
         case .test:
             return "Test"
+        case .playPlusProduction:
+            return "Play+ Production"
+        case .playPlusIntegration:
+            return "Play+ Integration"
+        case .playPlusDevelopment:
+            return "Play+ Development"
         }
     }
 
@@ -30,11 +39,11 @@ enum ServerSetting: Int, CaseIterable {
 
     private var baseUrl: URL {
         switch self {
-        case .production:
+        case .production, .playPlusProduction:
             return SRGIntegrationLayerProductionServiceURL()
-        case .stage:
+        case .stage, .playPlusIntegration:
             return SRGIntegrationLayerStagingServiceURL()
-        case .test:
+        case .test, .playPlusDevelopment:
             return SRGIntegrationLayerTestServiceURL()
         }
     }
@@ -47,6 +56,12 @@ enum ServerSetting: Int, CaseIterable {
             return .stage
         case .test:
             return .test
+        case .playPlusProduction:
+            return .playPlusProduction
+        case .playPlusIntegration:
+            return .playPlusIntegration
+        case .playPlusDevelopment:
+            return .playPlusDevelopment
         }
     }
 }

--- a/Sources/CoreBusiness/DataProvider/DataProvider.swift
+++ b/Sources/CoreBusiness/DataProvider/DataProvider.swift
@@ -24,8 +24,8 @@ final class DataProvider {
         return decoder
     }
 
-    func mediaCompositionPublisher(forUrn urn: String) -> AnyPublisher<MediaCompositionResponse, Error> {
-        session.dataTaskPublisher(for: server.mediaCompositionRequest(forUrn: urn))
+    func mediaCompositionPublisher(forUrn urn: String, httpHeaders: [String: String]) -> AnyPublisher<MediaCompositionResponse, Error> {
+        session.dataTaskPublisher(for: server.mediaCompositionRequest(forUrn: urn, httpHeaders: httpHeaders))
             .mapHttpErrors()
             .tryMap { data, response in
                 MediaCompositionResponse(

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -66,7 +66,7 @@ public enum Server: Codable {
         }
     }
 
-    func mediaCompositionRequest(forUrn urn: String) -> URLRequest {
+    func mediaCompositionRequest(forUrn urn: String, httpHeaders: [String: String]) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return .init(url: url)
@@ -75,7 +75,9 @@ public enum Server: Codable {
             URLQueryItem(name: "onlyChapters", value: "true"),
             URLQueryItem(name: "vector", value: Self.vector)
         ]
-        return .init(url: components.url ?? url)
+        var request = URLRequest(url: components.url ?? url)
+        request.allHTTPHeaderFields = httpHeaders
+        return request
     }
 
     func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -49,7 +49,7 @@ public enum Server: Codable {
         }
     }
 
-    var baseUrl: URL {
+    private var baseUrl: URL {
         switch self {
         case .production:
             URL(string: "https://il.srgssr.ch")!
@@ -63,6 +63,17 @@ public enum Server: Codable {
             URL(string: "https://api.int.playplus.ch")!
         case .playPlusDevelopment:
             URL(string: "https://api.dev.playplus.ch")!
+        }
+    }
+
+    private var resizedImageBaseUrl: URL {
+        switch self {
+        case .production, .playPlusProduction:
+            URL(string: "https://il.srgssr.ch")!
+        case .stage, .playPlusIntegration:
+            URL(string: "https://il-stage.srgssr.ch")!
+        case .test, .playPlusDevelopment:
+            URL(string: "https://il-test.srgssr.ch")!
         }
     }
 
@@ -80,7 +91,7 @@ public enum Server: Codable {
 
     func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
         guard var components = URLComponents(
-            url: baseUrl.appending(path: "images/"),
+            url: resizedImageBaseUrl.appending(path: "images/"),
             resolvingAgainstBaseURL: false
         ) else {
             return url

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -17,6 +17,15 @@ public enum Server: Codable {
     /// Test.
     case test
 
+    /// Play+ production.
+    case playPlusProduction
+
+    /// Play+ integration.
+    case playPlusIntegration
+
+    /// Play+ development.
+    case playPlusDevelopment
+
 #if os(iOS)
     private static let vector = "appplay"
 #else
@@ -31,6 +40,12 @@ public enum Server: Codable {
             return "stage"
         case .test:
             return "test"
+        case .playPlusProduction:
+            return "playPlusProduction"
+        case .playPlusIntegration:
+            return "playPlusIntegration"
+        case .playPlusDevelopment:
+            return "playPlusDevelopment"
         }
     }
 
@@ -42,6 +57,12 @@ public enum Server: Codable {
             URL(string: "https://il-stage.srgssr.ch")!
         case .test:
             URL(string: "https://il-test.srgssr.ch")!
+        case .playPlusProduction:
+            URL(string: "https://api.playplus.ch")!
+        case .playPlusIntegration:
+            URL(string: "https://api.int.playplus.ch")!
+        case .playPlusDevelopment:
+            URL(string: "https://api.dev.playplus.ch")!
         }
     }
 

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -66,17 +66,6 @@ public enum Server: Codable {
         }
     }
 
-    private var resizedImageBaseUrl: URL {
-        switch self {
-        case .production, .playPlusProduction:
-            URL(string: "https://il.srgssr.ch")!
-        case .stage, .playPlusIntegration:
-            URL(string: "https://il-stage.srgssr.ch")!
-        case .test, .playPlusDevelopment:
-            URL(string: "https://il-test.srgssr.ch")!
-        }
-    }
-
     func mediaCompositionRequest(forUrn urn: String) -> URLRequest {
         let url = baseUrl.appending(path: "integrationlayer/2.1/mediaComposition/byUrn/\(urn)")
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
@@ -90,22 +79,26 @@ public enum Server: Codable {
     }
 
     func resizedImageUrl(_ url: URL, width: ImageWidth) -> URL {
-        guard var components = URLComponents(
-            url: resizedImageBaseUrl.appending(path: "images/"),
-            resolvingAgainstBaseURL: false
-        ) else {
-            return url
-        }
-        components.queryItems = [
-            URLQueryItem(name: "imageUrl", value: url.absoluteString),
-            URLQueryItem(name: "format", value: "jpg"),
-            URLQueryItem(name: "width", value: String(width.rawValue))
-        ]
-        if let scaledUrl = components.url {
-            return scaledUrl
-        }
-        else {
-            return url
+        switch self {
+        case .production, .stage, .test:
+            guard var components = URLComponents(url: baseUrl.appending(path: "images/"), resolvingAgainstBaseURL: false) else {
+                return url
+            }
+            components.queryItems = [
+                URLQueryItem(name: "imageUrl", value: url.absoluteString),
+                URLQueryItem(name: "format", value: "jpg"),
+                URLQueryItem(name: "width", value: String(width.rawValue))
+            ]
+            return components.url ?? url
+        case .playPlusProduction, .playPlusIntegration, .playPlusDevelopment:
+            guard var components = URLComponents(url: URL(string: "https://img.playplus.ch")!, resolvingAgainstBaseURL: false) else {
+                return url
+            }
+            components.queryItems = [
+                URLQueryItem(name: "src", value: url.absoluteString),
+                URLQueryItem(name: "imwidth", value: String(width.rawValue))
+            ]
+            return components.url ?? url
         }
     }
 }

--- a/Sources/CoreBusiness/Downloads/URNDownloader.swift
+++ b/Sources/CoreBusiness/Downloads/URNDownloader.swift
@@ -35,12 +35,12 @@ public final class URNDownloader: ObservableObject {
     }
 
     @discardableResult
-    public func addDownload(urn: String, server: Server = .production) -> Download {
-        downloader.addDownload(for: .init(urn: urn, server: server))
+    public func addDownload(urn: String, server: Server = .production, httpHeaders: [String: String] = [:]) -> Download {
+        downloader.addDownload(for: .init(urn: urn, server: server, httpHeaders: httpHeaders))
     }
 
     public func download(urn: String, server: Server) -> Download? {
-        downloader.download(matching: .init(urn: urn, server: server))
+        downloader.download(matching: .init(urn: urn, server: server, httpHeaders: [:]))
     }
 
     public func playerItem(

--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -19,6 +19,7 @@ public extension PlayerItem {
     /// - Parameters:
     ///   - urn: The URN to play.
     ///   - server: The server which the URN is played from.
+    ///   - httpHeaders: HTTP headers to set when requesting the content.
     ///   - trackerAdapters: An array of `TrackerAdapter` instances to use for tracking playback events.
     ///   - commandersActSource: The source of events sent to Commanders Act.
     ///
@@ -27,12 +28,13 @@ public extension PlayerItem {
     static func urn(
         _ urn: String,
         server: Server = .production,
+        httpHeaders: [String: String] = [:],
         trackerAdapters: [TrackerAdapter<MediaMetadata>] = [],
         commandersActSource: CommandersActSource? = nil
     ) -> Self {
         self.init(
             assetLoaderType: URNAssetLoader.self,
-            input: .init(urn: urn, server: server),
+            input: .init(urn: urn, server: server, httpHeaders: httpHeaders),
             trackerAdapters: [
                 ComScoreTracker.adapter { $0.analyticsData },
                 CommandersActTracker.adapter(configuration: commandersActSource) { $0.analyticsMetadata },

--- a/Sources/CoreBusiness/Model/ImageWidth.swift
+++ b/Sources/CoreBusiness/Model/ImageWidth.swift
@@ -4,11 +4,10 @@
 //  License information is available from the LICENSE file.
 //
 
+/// Image widths supported by all image services.
 enum ImageWidth: Int {
-    case width240 = 240
     case width320 = 320
     case width480 = 480
     case width720 = 720
-    case width960 = 960
     case width1920 = 1920
 }

--- a/Sources/CoreBusiness/Types/URNAssetLoader.swift
+++ b/Sources/CoreBusiness/Types/URNAssetLoader.swift
@@ -13,6 +13,7 @@ enum URNAssetLoader: AssetLoader {
     struct Input: Codable {
         let urn: String
         let server: Server
+        let httpHeaders: [String: String]
 
         var id: String {
             "\(urn)-\(server.id)"
@@ -21,7 +22,7 @@ enum URNAssetLoader: AssetLoader {
 
     static func metadataPublisher(for input: Input) -> AnyPublisher<MediaMetadata, any Error> {
         let dataProvider = DataProvider(server: input.server)
-        return dataProvider.mediaCompositionPublisher(forUrn: input.urn)
+        return dataProvider.mediaCompositionPublisher(forUrn: input.urn, httpHeaders: input.httpHeaders)
             .tryMap { response in
                 try MediaMetadata(mediaCompositionResponse: response, dataProvider: dataProvider)
             }

--- a/Tests/CoreBusinessTests/DataProviderTests.swift
+++ b/Tests/CoreBusinessTests/DataProviderTests.swift
@@ -15,14 +15,14 @@ import XCTest
 final class DataProviderTests: XCTestCase {
     func testExistingMediaMetadata() {
         expectSuccess(
-            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:6820736")
+            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:6820736", httpHeaders: [:])
         )
     }
 
     func testNonExistingMediaMetadata() {
         expectFailure(
             HttpError(statusCode: 404),
-            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:unknown")
+            from: DataProvider().mediaCompositionPublisher(forUrn: "urn:rts:video:unknown", httpHeaders: [:])
         )
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for Play+ endpoints and HTTP headers for URN-based content.

The new endpoints can be considered official endpoints and deserve to be added to Core Business, as they are ultimately retrieved from the Integration Layer / SAM, only localizing labels in the process, based on the `Accept-Language` header.

Custom headers can be useful to convey additional information, e.g. a user identity.

## Changes made

- Add support for Play+ production, integration and development API endpoints.
- Perform image scaling for Play+ content with the Play+ image scaling service.
- Update the demo to support playback from the new endpoints. Content is still delivered by the Integration Layer.
- Add support for HTTP headers when requesting URN-based content. Headers have been added both when playing a remote item or when downloading a URN, but are not persisted in offline storage.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
