### PR TITLE
Add creation date to downloads

### DIFF
--- a/Demo/Sources/Downloads/DemoDownloader~ios.swift
+++ b/Demo/Sources/Downloads/DemoDownloader~ios.swift
@@ -33,7 +33,11 @@ final class DemoDownloader: ObservableObject {
         _urnDownloader as! URNDownloader
     }
 
-    @Published private(set) var downloads: [Download] = []
+    @Published private var _downloads: [Download] = []
+
+    var downloads: [Download] {
+        _downloads.sorted { $0.creationDate > $1.creationDate }
+    }
 
     init() {
         if #available(iOS 17, *) {
@@ -42,11 +46,11 @@ final class DemoDownloader: ObservableObject {
                 urnDownloader.$downloads
             )
             .map { $0 + $1 }
-            .assign(to: &$downloads)
+            .assign(to: &$_downloads)
         }
         else {
             urlDownloader.$downloads
-                .assign(to: &$downloads)
+                .assign(to: &$_downloads)
         }
     }
 

--- a/Demo/Sources/Downloads/URLAssetDownloadStore~ios.swift
+++ b/Demo/Sources/Downloads/URLAssetDownloadStore~ios.swift
@@ -28,6 +28,7 @@ final class URLAssetDownloadStore {
         let bookmarkData: Data?
         let progress: Double
         let errorDescription: String?
+        let creationDate: Date
 
         private init(
             id: String,
@@ -35,7 +36,8 @@ final class URLAssetDownloadStore {
             metadata: PlayerMetadata,
             bookmarkData: Data?,
             progress: Double,
-            errorDescription: String?
+            errorDescription: String?,
+            creationDate: Date
         ) {
             self.id = id
             self.url = url
@@ -43,17 +45,7 @@ final class URLAssetDownloadStore {
             self.bookmarkData = bookmarkData
             self.progress = progress
             self.errorDescription = errorDescription
-        }
-
-        init(id: String, input: URLAssetLoader.Input) {
-            self.init(
-                id: id,
-                url: input.url,
-                metadata: input.metadata,
-                bookmarkData: nil,
-                progress: 0,
-                errorDescription: nil
-            )
+            self.creationDate = creationDate
         }
 
         init(id: String, record: DownloadRecord<URLAssetLoader.Input, Void>) {
@@ -63,7 +55,8 @@ final class URLAssetDownloadStore {
                 metadata: record.metadata?.playerMetadata ?? record.input.metadata,
                 bookmarkData: record.bookmarkData,
                 progress: record.progress,
-                errorDescription: record.error?.localizedDescription
+                errorDescription: record.error?.localizedDescription,
+                creationDate: record.creationDate
             )
         }
 
@@ -73,7 +66,8 @@ final class URLAssetDownloadStore {
                 metadata: .init(playerMetadata: metadata, customData: ()),
                 bookmarkData: bookmarkData,
                 progress: progress,
-                error: DownloadError(errorDescription: errorDescription)
+                error: DownloadError(errorDescription: errorDescription),
+                creationDate: creationDate
             )
         }
     }
@@ -106,8 +100,8 @@ extension URLAssetDownloadStore: AssetDownloadStore {
         fileEntries.map { $0.toDownloadRecord() }
     }
 
-    func addDownloadRecord(using input: URLAssetLoader.Input, forId id: String) {
-        fileEntries.append(FileEntry(id: id, input: input))
+    func addDownloadRecord(_ record: DownloadRecord<URLAssetLoader.Input, Void>, forId id: String) {
+        fileEntries.append(FileEntry(id: id, record: record))
         save()
     }
 

--- a/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
+++ b/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
@@ -127,21 +127,16 @@ private extension URNAssetDownloadStore {
         private var bookmarkData: Data?
         private var progress: Double
         private var errorDescription: String?
+        private var creationDate: Date
 
-        init(
-            id: String,
-            input: URNAssetLoader.Input,
-            metadata: EntryAssetMetadata? = nil,
-            bookmarkData: Data? = nil,
-            progress: Double,
-            errorDescription: String? = nil
-        ) {
+        init(id: String, record: DownloadRecord<URNAssetLoader.Input, URNMetadata>) {
             self.id = id
-            self.input = input
-            self.metadata = metadata
-            self.bookmarkData = bookmarkData
-            self.progress = progress
-            self.errorDescription = errorDescription
+            self.input = record.input
+            self.metadata = .init(assetMetadata: record.metadata)
+            self.bookmarkData = record.bookmarkData
+            self.progress = record.progress
+            self.errorDescription = record.error?.localizedDescription
+            self.creationDate = record.creationDate
         }
 
         static func predicate(for id: String) -> Predicate<Entry> {
@@ -156,7 +151,8 @@ private extension URNAssetDownloadStore {
                 metadata: metadata?.assetMetadata(),
                 bookmarkData: bookmarkData,
                 progress: progress,
-                error: DownloadError(errorDescription: errorDescription)
+                error: DownloadError(errorDescription: errorDescription),
+                creationDate: creationDate
             )
         }
 
@@ -166,6 +162,7 @@ private extension URNAssetDownloadStore {
             self.bookmarkData = record.bookmarkData
             self.progress = record.progress
             self.errorDescription = record.error?.localizedDescription
+            self.creationDate = record.creationDate
         }
     }
 }
@@ -189,8 +186,8 @@ extension URNAssetDownloadStore: AssetDownloadStore {
         return entries.map { $0.toRecord() }
     }
 
-    func addDownloadRecord(using input: URNAssetLoader.Input, forId id: String) {
-        context.insert(Entry(id: id, input: input, progress: 0))
+    func addDownloadRecord(_ record: DownloadRecord<URNAssetLoader.Input, URNMetadata>, forId id: String) {
+        context.insert(Entry(id: id, record: record))
     }
 
     func removeDownloadRecord(forId id: String) {

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -63,7 +63,7 @@ public final class Download: ObservableObject {
         self.id = id
         self.creationDate = creationDate
         self.addRecord = {
-            store.addDownloadRecord(.init(input: input, creationDate: .now), forId: id)
+            store.addDownloadRecord(.init(input: input, creationDate: creationDate), forId: id)
         }
         self.removeRecord = {
             store.removeDownloadRecord(forId: id)

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -29,6 +29,8 @@ public final class Download: ObservableObject {
     private let addRecord: () -> Void
     private let removeRecord: () -> Void
 
+    public let creationDate: Date
+
     public var progress: Double {
         properties.progress
     }
@@ -54,12 +56,14 @@ public final class Download: ObservableObject {
         id: String,
         assetLoaderType: L.Type,
         input: L.Input,
+        creationDate: Date,
         session: DownloadSession,
         store: S
     ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
         self.id = id
+        self.creationDate = creationDate
         self.addRecord = {
-            store.addDownloadRecord(using: input, forId: id)
+            store.addDownloadRecord(.init(input: input, creationDate: .now), forId: id)
         }
         self.removeRecord = {
             store.removeDownloadRecord(forId: id)
@@ -74,8 +78,9 @@ public final class Download: ObservableObject {
         store: S
     ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
         let id = type(of: store).id(from: input)
-        store.addDownloadRecord(using: input, forId: id)
-        self.init(id: id, assetLoaderType: assetLoaderType, input: input, session: session, store: store)
+        let creationDate = Date.now
+        store.addDownloadRecord(.init(input: input, creationDate: creationDate), forId: id)
+        self.init(id: id, assetLoaderType: assetLoaderType, input: input, creationDate: creationDate, session: session, store: store)
     }
 
     convenience init<L, S>(
@@ -88,6 +93,7 @@ public final class Download: ObservableObject {
             id: type(of: store).id(from: record.input),
             assetLoaderType: assetLoaderType,
             input: record.input,
+            creationDate: record.creationDate,
             session: session,
             store: store
         )
@@ -199,13 +205,14 @@ extension Download {
         downloadPropertiesPublisher(assetLoaderType: assetLoaderType, id: id, input: input, session: session, store: store)
             .receiveOnMainThread()
             .handleEvents(
-                receiveOutput: { [id] properties in
+                receiveOutput: { [id, creationDate] properties in
                     let record = DownloadRecord(
                         input: input,
                         metadata: properties.source.metadata,
                         bookmarkData: properties.bookmarkData(),
                         progress: properties.progress,
-                        error: properties.error
+                        error: properties.error,
+                        creationDate: creationDate
                     )
                     store.updateDownloadRecord(record, forId: id)
                 },

--- a/Sources/Player/Downloads/DownloadRecord.swift
+++ b/Sources/Player/Downloads/DownloadRecord.swift
@@ -18,13 +18,19 @@ public struct DownloadRecord<Input, CustomData> {
     public let bookmarkData: Data?
     public let progress: Double
     public let error: Error?
+    public let creationDate: Date
 
-    public init(input: Input, metadata: AssetMetadata<CustomData>?, bookmarkData: Data?, progress: Double, error: Error?) {
+    init(input: Input, creationDate: Date) {
+        self.init(input: input, metadata: nil, bookmarkData: nil, progress: 0, error: nil, creationDate: creationDate)
+    }
+
+    public init(input: Input, metadata: AssetMetadata<CustomData>?, bookmarkData: Data?, progress: Double, error: Error?, creationDate: Date) {
         self.input = input
         self.metadata = metadata
         self.bookmarkData = bookmarkData
         self.progress = progress
         self.error = error
+        self.creationDate = creationDate
     }
 }
 

--- a/Sources/Player/Interfaces/AssetDownloadStore.swift
+++ b/Sources/Player/Interfaces/AssetDownloadStore.swift
@@ -26,7 +26,7 @@ public protocol AssetDownloadStore: AnyObject {
 
     func downloadRecords() -> [DownloadRecord<Loader.Input, CustomData>]
 
-    func addDownloadRecord(using input: Loader.Input, forId id: String)
+    func addDownloadRecord(_ record: DownloadRecord<Loader.Input, CustomData>, forId id: String)
     func removeDownloadRecord(forId id: String)
 
     func downloadRecord(forId id: String) -> DownloadRecord<Loader.Input, CustomData>?

--- a/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
+++ b/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(DownloaderPrivate)
-import PillarboxPlayer
+@testable import PillarboxPlayer
 
 import Foundation
 import OrderedCollections
@@ -16,7 +16,7 @@ final class AssetDownloadStoreMock {
 
     init(preloadedInputs: [AssetLoaderMock.Input] = []) {
         records = preloadedInputs.reduce(into: [:]) { records, input in
-            records.updateValue(Self.record(from: input), forKey: Self.id(from: input))
+            records.updateValue(.init(input: input, creationDate: .now), forKey: Self.id(from: input))
         }
     }
 }
@@ -31,24 +31,14 @@ extension AssetDownloadStoreMock: AssetDownloadStore {
 
     static func customData(from metadata: PlayerMetadata) {}
 
-    static func record(from input: AssetLoaderMock.Input) -> DownloadRecord<AssetLoaderMock.Input, Void> {
-        .init(
-            input: input,
-            metadata: .init(playerMetadata: input.metadata, customData: ()),
-            bookmarkData: nil,
-            progress: 0,
-            error: nil
-        )
-    }
-
     func downloadRecords() -> [DownloadRecord<AssetLoaderMock.Input, Void>] {
         assert(Thread.isMainThread)
         return Array(records.values)
     }
 
-    func addDownloadRecord(using input: AssetLoaderMock.Input, forId id: String) {
+    func addDownloadRecord(_ record: DownloadRecord<AssetLoaderMock.Input, Void>, forId id: String) {
         assert(Thread.isMainThread)
-        records[id] = Self.record(from: input)
+        records[id] = record
     }
 
     func removeDownloadRecord(forId id: String) {


### PR DESCRIPTION
## Description

This PR adds a creation date for every download, so that we can combine downloads from different downloaders into a consolidated list.

## Changes made

- A `creationDate` has been added to a download.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
