### PR TITLE
Update comScore to version 6.17.0

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "533746a712bc76ec6633fdbf559af6a73b95d8f92df4058b35b43fab239270ee",
+  "originHash" : "6972ec39f36ac227022d7b100fddbbf691a22bdbe5ba6d42b1119e19689e46a0",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
       "state" : {
-        "revision" : "f123be6aae5864c4eb7def5e9f1be9710fe1d782",
-        "version" : "6.16.0"
+        "revision" : "966992952a84510ac3a086d745f1681302b5cb26",
+        "version" : "6.17.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b00e9f6f2dcc79d30330aef09d0e11c39c8ef2821f8b8173fd048bba7e990a7a",
+  "originHash" : "b49ca76806b797b94e0c794deb46c10af344fb8e17cb6ab90da36ee3d8f861a2",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
       "state" : {
-        "revision" : "f123be6aae5864c4eb7def5e9f1be9710fe1d782",
-        "version" : "6.16.0"
+        "revision" : "966992952a84510ac3a086d745f1681302b5cb26",
+        "version" : "6.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.16.0")),
+        .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMajor(from: "6.17.0")),
         .package(url: "https://github.com/CommandersAct/iOSV5-spm.git", .upToNextMajor(from: "5.5.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", exact: "1.0.1"),


### PR DESCRIPTION
## Description

Self-explanatory. Note that this version **does not** fix offline measurements (which should work out-of-the-box according to comScore).

## Changes made

- Loosen allowed updates (incorrectly stuck on minor versions).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
