### PR TITLE
Enable offline comScore tracking

### DIFF
--- a/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
+++ b/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
@@ -178,7 +178,7 @@ extension URNAssetDownloadStore: AssetDownloadStore {
     }
 
     static func customData(from metadata: MediaMetadata) -> URNMetadata {
-        .init(analyticsMetadata: metadata.analyticsMetadata)
+        .init(analyticsData: metadata.analyticsData, analyticsMetadata: metadata.analyticsMetadata)
     }
 
     func downloadRecords() -> [DownloadRecord<URNAssetLoader.Input, URNMetadata>] {

--- a/Sources/CoreBusiness/Downloads/URNDownloader.swift
+++ b/Sources/CoreBusiness/Downloads/URNDownloader.swift
@@ -49,6 +49,7 @@ public final class URNDownloader: ObservableObject {
         trackerAdapters: [TrackerAdapter<AssetMetadata<URNMetadata>>] = []
     ) -> PlayerItem? {
         downloader.playerItem(for: download, trackerAdapters: [
+            ComScoreTracker.adapter(mapper: \.customData.analyticsData),
             CommandersActTracker.adapter(configuration: commandersActSource, mapper: \.customData.analyticsMetadata)
         ] + trackerAdapters)
     }

--- a/Sources/CoreBusiness/Downloads/URNMetadata.swift
+++ b/Sources/CoreBusiness/Downloads/URNMetadata.swift
@@ -11,6 +11,7 @@
 @available(tvOS, unavailable)
 @_spi(DownloaderPrivate)
 public struct URNMetadata: Codable {
+    let analyticsData: [String: String]
     let analyticsMetadata: [String: String]
 }
 


### PR DESCRIPTION
## Description

Works without any special configuration. It suffices to persist associated labels and to instantiate an associated tracker for content played locally.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
