### PR TITLE
Fix issues when replaying from a failed state

### DIFF
--- a/Sources/Player/ResourceLoading/Resource.swift
+++ b/Sources/Player/ResourceLoading/Resource.swift
@@ -44,6 +44,7 @@ enum Resource {
         case let .custom(url: url, delegate: delegate):
             let asset = asset(for: url, with: configuration)
             asset.resourceLoader.setDelegate(delegate, queue: kResourceLoaderQueue)
+            objc_setAssociatedObject(asset, &kResourceLoaderDelegate, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             return asset
         case let .encrypted(url: url, delegate: delegate):
 #if targetEnvironment(simulator)


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in #1498. If the resource loader delegate is not explicitly retained, subtle memory management timings may lead to error information being lost when replaying from a failed state. This was most notably leading to the following incorrect behaviors:

- Replaying from a failed state might not deliver the same error consistently (provided the error was still expected).
- Triggering a replay when a countdown ends (i.e. when a start date disappears) would lead to playback failure.

Both scenarios are similar and having a UT for the first one would be enough. Sadly, though, the test we wrote was flaky, even though the behavior can be observed to be stable when checked manually. For this reason no UT was added.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
