### PR TITLE
Preserve metadata when restarting a download

### DIFF
--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -90,10 +90,8 @@ struct DownloadCell: View {
     @ViewBuilder
     private func completedButton() -> some View {
         if download.error != nil {
-            button(systemImage: "arrow.counterclockwise.circle") {
-                download.restart(keepsMetadata: true)
-            }
-            .tint(.red)
+            button(systemImage: "arrow.counterclockwise.circle", action: download.restart)
+                .tint(.red)
         }
         else {
             Image(systemName: "checkmark")

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -90,8 +90,10 @@ struct DownloadCell: View {
     @ViewBuilder
     private func completedButton() -> some View {
         if download.error != nil {
-            button(systemImage: "arrow.counterclockwise.circle", action: download.restart)
-                .tint(.red)
+            button(systemImage: "arrow.counterclockwise.circle") {
+                download.restart(keepsMetadata: true)
+            }
+            .tint(.red)
         }
         else {
             Image(systemName: "checkmark")

--- a/Demo/Sources/Downloads/DownloadsView~ios.swift
+++ b/Demo/Sources/Downloads/DownloadsView~ios.swift
@@ -77,7 +77,7 @@ struct DownloadsView: View {
 
     private func media(from download: Download) -> Media? {
         guard let item = downloader.playerItem(for: download) else { return nil }
-        return .init(title: download.metadata.title ?? "Untitled", type: .item(item))
+        return .init(title: download.metadata.title ?? "Untitled", subtitle: download.metadata.subtitle, type: .item(item))
     }
 
     private func openPlaylist() {

--- a/Demo/Sources/Downloads/DownloadsView~ios.swift
+++ b/Demo/Sources/Downloads/DownloadsView~ios.swift
@@ -43,8 +43,8 @@ struct DownloadsView: View {
                     }
                 }
                 .swipeActions {
-                    button(systemImage: "arrow.counterclockwise", action: download.restart)
                     button(systemImage: "trash", color: .red) { downloader.removeDownload(download) }
+                    button(systemImage: "arrow.counterclockwise", action: download.restart)
                 }
             }
         }

--- a/Demo/Sources/Downloads/DownloadsView~ios.swift
+++ b/Demo/Sources/Downloads/DownloadsView~ios.swift
@@ -38,8 +38,8 @@ struct DownloadsView: View {
         List {
             ForEach(downloader.downloads, id: \.self) { download in
                 DownloadCell(download: download) {
-                    if let item = downloader.playerItem(for: download) {
-                        router.presented = .player(media: .init(title: download.metadata.title ?? "Untitled", type: .item(item)))
+                    if let media = media(from: download) {
+                        router.presented = .player(media: media)
                     }
                 }
                 .swipeActions {
@@ -68,7 +68,20 @@ struct DownloadsView: View {
             } label: {
                 Image(systemName: "trash")
             }
+            Button(action: openPlaylist) {
+                Image(systemName: "rectangle.stack.badge.play")
+            }
+            .accessibilityLabel("Open as playlist")
         }
+    }
+
+    private func media(from download: Download) -> Media? {
+        guard let item = downloader.playerItem(for: download) else { return nil }
+        return .init(title: download.metadata.title ?? "Untitled", type: .item(item))
+    }
+
+    private func openPlaylist() {
+        router.presented = .playlist(medias: downloader.downloads.compactMap(media(from:)))
     }
 
     private func button(systemImage: String, color: Color? = nil, action: @escaping () -> Void) -> some View {

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -203,14 +203,7 @@ private extension Download {
                 }
                 .switchToLatest()
                 .fail(onOutputFrom: trigger.signal(activatedBy: TriggerId.cancel), with: URLError(.cancelled))
-                .catch { error in
-                    Just(DownloadProperties(
-                        progress: .estimate(0),
-                        assetMetadata: storedProperties.assetMetadata,
-                        fileUrl: storedProperties.fileUrl,
-                        error: error
-                    ))
-                }
+                .catch { Just(store.downloadProperties(forId: id).withError($0)) }
                 .prepend(storedProperties)
         }
     }

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -24,7 +24,7 @@ public final class Download: ObservableObject {
     private let trigger = Trigger()
     private let session: any DownloadSession
 
-    private let resetRecord: (Bool) -> Void
+    private let resetRecord: () -> Void
     private let removeRecord: () -> Void
 
     public let creationDate: Date
@@ -60,9 +60,9 @@ public final class Download: ObservableObject {
         self.id = id
         self.creationDate = creationDate
         self.session = session
-        self.resetRecord = { keepsMetadata in
+        self.resetRecord = {
             guard let record = store.downloadRecord(forId: id) else { return }
-            store.updateDownloadRecord(record.reset(keepsMetadata: keepsMetadata), forId: id)
+            store.updateDownloadRecord(record.reset(), forId: id)
         }
         self.removeRecord = {
             store.removeDownloadRecord(forId: id)
@@ -123,13 +123,9 @@ public extension Download {
     }
 
     func restart() {
-        restart(keepsMetadata: false)
-    }
-
-    func restart(keepsMetadata: Bool) {
         removeFile()
         cancelOperations()
-        resetRecord(keepsMetadata)
+        resetRecord()
         trigger.activate(for: TriggerId.restart)
     }
 

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -24,7 +24,7 @@ public final class Download: ObservableObject {
     private let trigger = Trigger()
     private let session: any DownloadSession
 
-    private let addRecord: () -> Void
+    private let resetRecord: (Bool) -> Void
     private let removeRecord: () -> Void
 
     public let creationDate: Date
@@ -60,8 +60,9 @@ public final class Download: ObservableObject {
         self.id = id
         self.creationDate = creationDate
         self.session = session
-        self.addRecord = {
-            store.addDownloadRecord(.init(input: input, creationDate: creationDate), forId: id)
+        self.resetRecord = { keepsMetadata in
+            guard let record = store.downloadRecord(forId: id) else { return }
+            store.updateDownloadRecord(record.reset(keepsMetadata: keepsMetadata), forId: id)
         }
         self.removeRecord = {
             store.removeDownloadRecord(forId: id)
@@ -122,8 +123,13 @@ public extension Download {
     }
 
     func restart() {
-        remove()
-        addRecord()
+        restart(keepsMetadata: false)
+    }
+
+    func restart(keepsMetadata: Bool) {
+        removeFile()
+        cancelOperations()
+        resetRecord(keepsMetadata)
         trigger.activate(for: TriggerId.restart)
     }
 

--- a/Sources/Player/Downloads/DownloadProperties.swift
+++ b/Sources/Player/Downloads/DownloadProperties.swift
@@ -102,6 +102,10 @@ struct DownloadProperties<CustomData> {
     func suspend() {
         task?.suspend()
     }
+
+    func withError(_ error: Error) -> Self {
+        .init(progress: progress, assetMetadata: assetMetadata, fileUrl: fileUrl, error: error)
+    }
 }
 
 #endif

--- a/Sources/Player/Downloads/DownloadRecord.swift
+++ b/Sources/Player/Downloads/DownloadRecord.swift
@@ -33,8 +33,8 @@ public struct DownloadRecord<Input, CustomData> {
         self.creationDate = creationDate
     }
 
-    func reset(keepsMetadata: Bool) -> Self {
-        .init(input: input, metadata: keepsMetadata ? metadata : nil, bookmarkData: nil, progress: 0, error: nil, creationDate: creationDate)
+    func reset() -> Self {
+        .init(input: input, metadata: metadata, bookmarkData: nil, progress: 0, error: nil, creationDate: creationDate)
     }
 }
 

--- a/Sources/Player/Downloads/DownloadRecord.swift
+++ b/Sources/Player/Downloads/DownloadRecord.swift
@@ -32,6 +32,10 @@ public struct DownloadRecord<Input, CustomData> {
         self.error = error
         self.creationDate = creationDate
     }
+
+    func reset(keepsMetadata: Bool) -> Self {
+        .init(input: input, metadata: keepsMetadata ? metadata : nil, bookmarkData: nil, progress: 0, error: nil, creationDate: creationDate)
+    }
 }
 
 #endif

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -183,6 +183,25 @@ final class DownloadTests: TestCase {
         expect(store.downloadRecord(forId: download.id)).notTo(beNil())
     }
 
+    func testRestartDiscardingMetadata() throws {
+        let store = AssetDownloadStoreMock()
+        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
+        expect(download.metadata.title).toEventually(equal("Title"))
+        download.restart()
+        expect(download.metadata.title).to(beNil())
+        expect(download.metadata.title).toEventually(equal("Title"))
+    }
+
+    func testRestartKeepingMetadata() throws {
+        let store = AssetDownloadStoreMock()
+        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
+        expect(download.metadata.title).toEventually(equal("Title"))
+        download.restart(keepsMetadata: true)
+        expect(download.metadata.title).toEventually(beNil())
+    }
+
     func testRestoreRunningWithMissingFile() throws {
         let store = AssetDownloadStoreMock()
         let input = AssetLoaderMock.Input.playable(url: Stream.download.url)

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -184,22 +184,12 @@ final class DownloadTests: TestCase {
         expect(store.downloadRecord(forId: download.id)).notTo(beNil())
     }
 
-    func testRestartDiscardingMetadata() throws {
+    func testRestartKeepsMetadataIfAvailable() throws {
         let store = AssetDownloadStoreMock()
         let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
         expect(download.metadata.title).toEventually(equal("Title"))
         download.restart()
-        expect(download.metadata.title).to(beNil())
-        expect(download.metadata.title).toEventually(equal("Title"))
-    }
-
-    func testRestartKeepingMetadata() throws {
-        let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
-        let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
-        expect(download.metadata.title).toEventually(equal("Title"))
-        download.restart(keepsMetadata: true)
         expect(download.metadata.title).toNever(beNil(), until: .milliseconds(100))
     }
 

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -166,6 +166,7 @@ final class DownloadTests: TestCase {
         let location2 = try unwrap(download.fileUrl)
         expect(location1).notTo(equal(location2))
         expect(store.downloadRecord(forId: download.id)).notTo(beNil())
+        expect(FileManager.default.fileExists(atPath: location1.path())).toEventually(beFalse())
     }
 
     func testRestartImmediately() throws {
@@ -199,7 +200,7 @@ final class DownloadTests: TestCase {
         let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
         expect(download.metadata.title).toEventually(equal("Title"))
         download.restart(keepsMetadata: true)
-        expect(download.metadata.title).toEventually(beNil())
+        expect(download.metadata.title).toNever(beNil(), until: .milliseconds(100))
     }
 
     func testRestoreRunningWithMissingFile() throws {


### PR DESCRIPTION
## Description

This PR allows us to keep the metadata previously retrieved when restarting a download.

## Changes made

- A `resetRecord` closure  has been added to update a download record without removing its previously retrieved metadata.
- The `downloadPropertiesPublisher` has been updated to prepend the previous metadata and also using it when catching an error.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
