### PR TITLE
Provide player capabilities when fetching a URN

### DIFF
--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -52,7 +52,9 @@ public enum Server: Codable {
         }
         components.queryItems = [
             URLQueryItem(name: "onlyChapters", value: "true"),
-            URLQueryItem(name: "vector", value: Self.vector)
+            URLQueryItem(name: "vector", value: Self.vector),
+            URLQueryItem(name: "streamPlayerCapabilities", value: "application/x-mpegURL,audio/mpeg"),
+            URLQueryItem(name: "drmPlayerCapabilities", value: "com.apple.fps")
         ]
         return .init(url: components.url ?? url)
     }

--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -23,6 +23,14 @@ public enum Server: Codable {
     private static let vector = "tvplay"
 #endif
 
+    private static let supportedMimeTypes = [
+        "audio/mp4; codecs=\"mp4a.40.2\"",
+        "video/mp4",
+        "audio/mpeg",
+        "video/mpeg",
+        "application/x-mpegURL"
+    ]
+
     var id: String {
         switch self {
         case .production:
@@ -53,7 +61,7 @@ public enum Server: Codable {
         components.queryItems = [
             URLQueryItem(name: "onlyChapters", value: "true"),
             URLQueryItem(name: "vector", value: Self.vector),
-            URLQueryItem(name: "streamPlayerCapabilities", value: "application/x-mpegURL,audio/mpeg"),
+            URLQueryItem(name: "streamPlayerCapabilities", value: Self.supportedMimeTypes.joined(separator: ",")),
             URLQueryItem(name: "drmPlayerCapabilities", value: "com.apple.fps")
         ]
         return .init(url: components.url ?? url)


### PR DESCRIPTION
## Description

This PR provides device capabilities when retrieving metadata associated with an SRG SSR URN.

## Changes made

- Declare support for M3U and MP3.
- Declare support for FairPlay

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
