### PR TITLE
Avoid chapter artwork leak on tvOS 26

### DIFF
--- a/Demo/Sources/Players/PlayerView~ios.swift
+++ b/Demo/Sources/Players/PlayerView~ios.swift
@@ -141,11 +141,7 @@ private struct ChapterCell: View {
         }
         .animation(.defaultLinear, value: chapter.imageSource)
         .overlay {
-            LinearGradient(
-                colors: [.black.opacity(0.7), .clear],
-                startPoint: .bottom,
-                endPoint: .top
-            )
+            LinearGradient(colors: [.black.opacity(0.7), .clear], startPoint: .bottom, endPoint: .top)
         }
         .overlay(alignment: .topTrailing) {
             durationLabel()

--- a/Demo/Sources/Players/PlayerView~ios.swift
+++ b/Demo/Sources/Players/PlayerView~ios.swift
@@ -142,7 +142,7 @@ private struct ChapterCell: View {
         .animation(.defaultLinear, value: chapter.imageSource)
         .overlay {
             LinearGradient(
-                gradient: Gradient(colors: [.black.opacity(0.7), .clear]),
+                colors: [.black.opacity(0.7), .clear],
                 startPoint: .bottom,
                 endPoint: .top
             )

--- a/Demo/Sources/Showcase/Playlist/PlaylistView~tvos.swift
+++ b/Demo/Sources/Showcase/Playlist/PlaylistView~tvos.swift
@@ -52,7 +52,7 @@ struct PlaylistView: View {
     @InfoViewTabsContentBuilder
     func infoViewTabsContent() -> InfoViewTabsContent {
         if model.entries.count > 1 {
-            Tab(title: "Playlist") {
+            Tab("Playlist") {
                 _PlaylistView(model: model)
                     .frame(height: 400)
             }

--- a/Demo/Sources/Views/MediaCardView~tvos.swift
+++ b/Demo/Sources/Views/MediaCardView~tvos.swift
@@ -85,11 +85,7 @@ struct MediaCardView: View {
                 }
             }
             .overlay {
-                LinearGradient(
-                    colors: [.black, .clear],
-                    startPoint: .bottom,
-                    endPoint: .top
-                )
+                LinearGradient(colors: [.black, .clear], startPoint: .bottom, endPoint: .top)
             }
             .frame(width: size.width, height: size.height, alignment: .center)
 

--- a/Demo/Sources/Views/MediaCardView~tvos.swift
+++ b/Demo/Sources/Views/MediaCardView~tvos.swift
@@ -85,7 +85,11 @@ struct MediaCardView: View {
                 }
             }
             .overlay {
-                LinearGradient(gradient: Gradient(colors: [Color.clear, Color.black]), startPoint: .top, endPoint: .bottom)
+                LinearGradient(
+                    colors: [.black, .clear],
+                    startPoint: .bottom,
+                    endPoint: .top
+                )
             }
             .frame(width: size.width, height: size.height, alignment: .center)
 

--- a/Sources/Player/Extensions/AVPlayerItem.swift
+++ b/Sources/Player/Extensions/AVPlayerItem.swift
@@ -180,9 +180,11 @@ extension AVPlayerItem {
         interstitialTimeRanges = content.metadata.blockedTimeRanges.map { timeRange in
             .init(timeRange: timeRange)
         }
-        navigationMarkerGroups = [
-            AVNavigationMarkersGroup(title: "chapters", timedNavigationMarkers: content.metadata.timedNavigationMarkers)
-        ]
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion != 26 {
+            navigationMarkerGroups = [
+                AVNavigationMarkersGroup(title: "chapters", timedNavigationMarkers: content.metadata.timedNavigationMarkers)
+            ]
+        }
 #endif
         return self
     }

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -106,6 +106,17 @@
         }
       }
     },
+    "Chapters" : {
+      "comment" : "Chapters info panel tab title",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapters"
+          }
+        }
+      }
+    },
     "E%lld" : {
       "comment" : "Short episode information",
       "localizations" : {
@@ -352,7 +363,15 @@
       }
     },
     "Watching" : {
-
+      "comment" : "Marker text for the current chapter",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watching"
+          }
+        }
+      }
     },
     "Zoom" : {
       "comment" : "Playback setting menu title",

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -351,6 +351,9 @@
         }
       }
     },
+    "Watching" : {
+
+    },
     "Zoom" : {
       "comment" : "Playback setting menu title",
       "localizations" : {

--- a/Sources/Player/Resources/Localizable.xcstrings
+++ b/Sources/Player/Resources/Localizable.xcstrings
@@ -109,10 +109,34 @@
     "Chapters" : {
       "comment" : "Chapters info panel tab title",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapitel"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chapters"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapitres"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capitoli"
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapitels"
           }
         }
       }
@@ -365,10 +389,34 @@
     "Watching" : {
       "comment" : "Marker text for the current chapter",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird angeschaut"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Watching"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cours"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In riproduzione"
+          }
+        },
+        "rm" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
           }
         }
       }

--- a/Sources/Player/UserInterface/BasicSystemVideoView.swift
+++ b/Sources/Player/UserInterface/BasicSystemVideoView.swift
@@ -34,7 +34,7 @@ struct BasicSystemVideoView<VideoOverlay>: UIViewControllerRepresentable where V
         uiViewController.updateTransportBarCustomMenuItemsIfNeeded(with: transportBarContent.toMenuElements())
         uiViewController.updateContextualActionsIfNeeded(with: contextualActionsContent.toActions())
         uiViewController.updateInfoViewActionsIfNeeded(with: infoViewActionsContent.toActions(dismissing: uiViewController))
-        uiViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(reusing: uiViewController.customInfoViewControllers)
+        uiViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(reusing: uiViewController.customInfoViewControllers, for: player)
 #endif
     }
 }

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -9,18 +9,90 @@ import SwiftUI
 // TODO: Remove once tvOS 26 is not supported anymore.
 @available(iOS, unavailable)
 struct ChapterCell: View {
+    private static let aspectRatio: CGFloat = 16 / 9
+
+    private static let width: CGFloat = 320
+    private static let heightExtension: CGFloat = 48
+
+    private static var height = width / aspectRatio + heightExtension
+
     let chapter: Chapter
+    let isHighlighted: Bool
     let action: () -> Void
 
     var body: some View {
         SwiftUI.Button(action: action) {
-            LazyImage(source: chapter.imageSource) { image in
-                image
-                    .resizable()
-                    .aspectRatio(16/9, contentMode: .fit)
-                    .frame(width: 320, height: 228, alignment: .top)
+            ZStack {
+                artwork()
+                description()
             }
+            .background(Color(white: 0.1))
         }
+        .frame(width: Self.width, height: Self.height)
         .buttonStyle(.card)
+    }
+
+    @ViewBuilder
+    private func artwork() -> some View {
+        LazyImage(source: chapter.imageSource) { image in
+            image
+                .resizable()
+                .aspectRatio(Self.aspectRatio, contentMode: .fit)
+                .backgroundExtension(spacing: Self.heightExtension)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(
+            LinearGradient(
+                colors: [.black, .clear],
+                startPoint: .bottom,
+                endPoint: .center
+            )
+        )
+    }
+
+    private func description() -> some View {
+        VStack(alignment: .leading) {
+            subtitle()
+            title()
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private func subtitle() -> some View {
+        if isHighlighted {
+            Text("Watching")
+                .textCase(.uppercase)
+                .font(.system(size: 18))
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func title() -> some View {
+        if let title = chapter.title {
+            Text(title)
+                .font(.system(size: 24))
+                .fontWeight(.medium)
+                .lineLimit(1)
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func backgroundExtension(spacing: CGFloat) -> some View {
+        if #available(tvOS 26, *) {
+            backgroundExtensionEffect()
+                .safeAreaInset(edge: .bottom, spacing: spacing) {
+                    Color.clear
+                        .frame(height: 0)
+                }
+        }
+        else {
+            self
+        }
     }
 }

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -62,7 +62,7 @@ struct ChapterCell: View {
     @ViewBuilder
     private func subtitle() -> some View {
         if isHighlighted {
-            Text("Watching")
+            Text("Watching", bundle: .module, comment: "Marker text for the current chapter")
                 .textCase(.uppercase)
                 .font(.system(size: 18))
                 .fontWeight(.medium)

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -85,6 +85,7 @@ private extension View {
     @ViewBuilder
     func backgroundExtension(spacing: CGFloat) -> some View {
         if #available(tvOS 26, *) {
+            // Trick, see https://nilcoalescing.com/blog/BackgroundExtensionEffectInSwiftUI/
             backgroundExtensionEffect()
                 .safeAreaInset(edge: .bottom, spacing: spacing) {
                     Color.clear

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -47,13 +47,9 @@ struct ChapterCell: View {
                 .backgroundExtension(spacing: Self.heightExtension)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .overlay(
-            LinearGradient(
-                colors: [.black, .clear],
-                startPoint: .bottom,
-                endPoint: .center
-            )
-        )
+        .overlay {
+            LinearGradient(colors: [.black, .clear], startPoint: .bottom, endPoint: .center)
+        }
     }
 
     private func description() -> some View {

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -57,7 +57,7 @@ struct ChapterCell: View {
             title()
         }
         .padding(10)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }
 
     @ViewBuilder

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -19,6 +19,10 @@ struct ChapterCell: View {
     let isHighlighted: Bool
     let action: () -> Void
 
+    private var accessibilityTraits: AccessibilityTraits {
+        isHighlighted ? [.isSelected] : []
+    }
+
     var body: some View {
         SwiftUI.Button(action: action) {
             ZStack {
@@ -31,6 +35,7 @@ struct ChapterCell: View {
 #if os(tvOS)
         .buttonStyle(.card)
 #endif
+        .accessibilityAddTraits(accessibilityTraits)
     }
 
     @ViewBuilder

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 
 // TODO: Remove once tvOS 26 is not supported anymore.
-@available(iOS, unavailable)
 struct ChapterCell: View {
     private static let aspectRatio: CGFloat = 16 / 9
 
@@ -29,7 +28,9 @@ struct ChapterCell: View {
             .background(Color(white: 0.1))
         }
         .frame(width: Self.width, height: Self.height)
+#if os(tvOS)
         .buttonStyle(.card)
+#endif
     }
 
     @ViewBuilder
@@ -84,7 +85,7 @@ struct ChapterCell: View {
 private extension View {
     @ViewBuilder
     func backgroundExtension(spacing: CGFloat) -> some View {
-        if #available(tvOS 26, *) {
+        if #available(iOS 26, tvOS 26, *) {
             // Trick, see https://nilcoalescing.com/blog/BackgroundExtensionEffectInSwiftUI/
             backgroundExtensionEffect()
                 .safeAreaInset(edge: .bottom, spacing: spacing) {

--- a/Sources/Player/UserInterface/ChapterCell.swift
+++ b/Sources/Player/UserInterface/ChapterCell.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+// TODO: Remove once tvOS 26 is not supported anymore.
+@available(iOS, unavailable)
+struct ChapterCell: View {
+    let chapter: Chapter
+    let action: () -> Void
+
+    var body: some View {
+        SwiftUI.Button(action: action) {
+            LazyImage(source: chapter.imageSource) { image in
+                image
+                    .resizable()
+                    .aspectRatio(16/9, contentMode: .fit)
+                    .frame(width: 320, height: 228, alignment: .top)
+            }
+        }
+        .buttonStyle(.card)
+    }
+}

--- a/Sources/Player/UserInterface/ChapterList.swift
+++ b/Sources/Player/UserInterface/ChapterList.swift
@@ -10,18 +10,28 @@ import SwiftUI
 @available(iOS, unavailable)
 struct ChapterList: View {
     @ObservedObject var player: Player
+    @StateObject private var progressTracker = ProgressTracker(interval: .init(value: 1, timescale: 1))
+
+    private var chapters: [Chapter] {
+        player.metadata.chapters
+    }
+
+    private var currentChapter: Chapter? {
+        chapters.first { $0.timeRange.containsTime(progressTracker.time) }
+    }
 
     var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 40) {
-                ForEach(player.metadata.chapters, id: \.timeRange) { chapter in
-                    ChapterCell(chapter: chapter) {
+                ForEach(chapters, id: \.timeRange) { chapter in
+                    ChapterCell(chapter: chapter, isHighlighted: chapter == currentChapter) {
                         player.seek(to: chapter)
                     }
                 }
             }
         }
         .scrollClipDisabled_tvOS26()
+        .bind(progressTracker, to: player)
     }
 }
 

--- a/Sources/Player/UserInterface/ChapterList.swift
+++ b/Sources/Player/UserInterface/ChapterList.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 
 // TODO: Remove once tvOS 26 is not supported anymore.
-@available(iOS, unavailable)
 struct ChapterList: View {
     @ObservedObject var player: Player
     @StateObject private var progressTracker = ProgressTracker(interval: .init(value: 1, timescale: 1))
@@ -30,14 +29,14 @@ struct ChapterList: View {
                 }
             }
         }
-        .scrollClipDisabled_tvOS26()
+        .scrollClipDisabled26()
         .bind(progressTracker, to: player)
     }
 }
 
 private extension View {
-    func scrollClipDisabled_tvOS26() -> some View {
-        if #available(tvOS 26, *) {
+    func scrollClipDisabled26() -> some View {
+        if #available(iOS 26, tvOS 26, *) {
             return scrollClipDisabled()
         }
         else {

--- a/Sources/Player/UserInterface/ChapterList.swift
+++ b/Sources/Player/UserInterface/ChapterList.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+// TODO: Remove once tvOS 26 is not supported anymore.
+@available(iOS, unavailable)
+struct ChapterList: View {
+    @ObservedObject var player: Player
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 40) {
+                ForEach(player.metadata.chapters, id: \.timeRange) { chapter in
+                    ChapterCell(chapter: chapter) {
+                        player.seek(to: chapter)
+                    }
+                }
+            }
+        }
+        .scrollClipDisabled_tvOS26()
+    }
+}
+
+private extension View {
+    func scrollClipDisabled_tvOS26() -> some View {
+        if #available(tvOS 26, *) {
+            return scrollClipDisabled()
+        }
+        else {
+            return self
+        }
+    }
+}

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/InfoViewTabs/InfoViewTabsContent.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/InfoViewTabs/InfoViewTabsContent.swift
@@ -28,7 +28,10 @@ public struct InfoViewTabsContent {
             return []
         }
         return [
-            Tab(title: "Chapters", identifier: "pillarbox-tvos26-chapters") {
+            Tab(
+                String(localized: "Chapters", bundle: .module, comment: "Chapters info panel tab title"),
+                identifier: "pillarbox-tvos26-chapters"
+            ) {
                 ChapterList(player: player)
             }
         ].map { $0.viewController(reusing: viewControllers) }

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/InfoViewTabs/InfoViewTabsContent.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/InfoViewTabs/InfoViewTabsContent.swift
@@ -17,4 +17,20 @@ public struct InfoViewTabsContent {
     func viewControllers(reusing viewControllers: [UIViewController]) -> [UIViewController] {
         elements.map { $0.viewController(reusing: viewControllers) }
     }
+
+    // TODO: Remove when tvOS 26 fix is not needed anymore. Use `viewControllers(reusing:)` directly.
+    func viewControllers(reusing viewControllers: [UIViewController], for player: Player) -> [UIViewController] {
+        builtInViewControllers(reusing: viewControllers, for: player) + self.viewControllers(reusing: viewControllers)
+    }
+
+    private func builtInViewControllers(reusing viewControllers: [UIViewController], for player: Player) -> [UIViewController] {
+        guard ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 26, !player.metadata.chapters.isEmpty else {
+            return []
+        }
+        return [
+            Tab(title: "Chapters", identifier: "pillarbox-tvos26-chapters") {
+                ChapterList(player: player)
+            }
+        ].map { $0.viewController(reusing: viewControllers) }
+    }
 }

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/Tab.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/Tab.swift
@@ -27,6 +27,34 @@ public struct Tab<Content> where Content: View {
     }
 }
 
+public extension Tab {
+    /// Creates a tab.
+    ///
+    /// - Parameters:
+    ///   - title: The tab title.
+    ///   - identifier: A unique tab identifier. If omitted `title` is used instead.
+    ///   - content: The tab content
+    ///
+    /// For optimal behavior you should ensure that each tab is assigned a unique stable identifier.
+    @_disfavoredOverload
+    init<S>(_ title: S, identifier: String? = nil, @ViewBuilder _ content: () -> Content) where S: StringProtocol {
+        self.init(String(title), identifier: identifier, content)
+    }
+
+    /// Creates a tab.
+    ///
+    /// - Parameters:
+    ///   - title: The tab title.
+    ///   - identifier: A unique tab identifier. If omitted `title` is used instead.
+    ///   - content: The tab content
+    ///
+    /// For optimal behavior you should ensure that each tab is assigned a unique stable identifier.
+    @_disfavoredOverload
+    init(_ title: LocalizedStringResource, identifier: String? = nil, @ViewBuilder _ content: () -> Content) {
+        self.init(String(localized: title), identifier: identifier, content)
+    }
+}
+
 // MARK: Info view tabs embedding
 
 extension Tab: InfoViewTabsElement {

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/Tab.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewTabs/Tab.swift
@@ -20,26 +20,12 @@ public struct Tab<Content> where Content: View {
     ///   - content: The tab content
     ///
     /// For optimal behavior you should ensure that each tab is assigned a unique stable identifier.
-    public init(title: String, identifier: String? = nil, @ViewBuilder _ content: () -> Content) {
-        self.title = title
-        self.identifier = identifier ?? title
+    @_disfavoredOverload
+    public init<S>(_ title: S, identifier: String? = nil, @ViewBuilder _ content: () -> Content) where S: StringProtocol {
+        self.title = String(title)
+        self.identifier = identifier ?? String(title)
         self.content = content()
     }
-}
-
-public extension Tab {
-    /// Creates a tab.
-    ///
-    /// - Parameters:
-    ///   - title: The tab title.
-    ///   - identifier: A unique tab identifier. If omitted `title` is used instead.
-    ///   - content: The tab content
-    ///
-    /// For optimal behavior you should ensure that each tab is assigned a unique stable identifier.
-    @_disfavoredOverload
-    init<S>(_ title: S, identifier: String? = nil, @ViewBuilder _ content: () -> Content) where S: StringProtocol {
-        self.init(String(title), identifier: identifier, content)
-    }
 
     /// Creates a tab.
     ///
@@ -50,7 +36,7 @@ public extension Tab {
     ///
     /// For optimal behavior you should ensure that each tab is assigned a unique stable identifier.
     @_disfavoredOverload
-    init(_ title: LocalizedStringResource, identifier: String? = nil, @ViewBuilder _ content: () -> Content) {
+    public init(_ title: LocalizedStringResource, identifier: String? = nil, @ViewBuilder _ content: () -> Content) {
         self.init(String(localized: title), identifier: identifier, content)
     }
 }

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -35,7 +35,10 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
             playerViewController.updateTransportBarCustomMenuItemsIfNeeded(with: transportBarContent.toMenuElements())
             playerViewController.updateContextualActionsIfNeeded(with: contextualActionsContent.toActions())
             playerViewController.updateInfoViewActionsIfNeeded(with: infoViewActionsContent.toActions(dismissing: playerViewController))
-            playerViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(reusing: playerViewController.customInfoViewControllers, for: player)
+            playerViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(
+                reusing: playerViewController.customInfoViewControllers,
+                for: player
+            )
 #endif
         }
     }

--- a/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
+++ b/Sources/Player/UserInterface/PictureInPictureSupportingSystemVideoView.swift
@@ -35,7 +35,7 @@ struct PictureInPictureSupportingSystemVideoView<VideoOverlay>: UIViewController
             playerViewController.updateTransportBarCustomMenuItemsIfNeeded(with: transportBarContent.toMenuElements())
             playerViewController.updateContextualActionsIfNeeded(with: contextualActionsContent.toActions())
             playerViewController.updateInfoViewActionsIfNeeded(with: infoViewActionsContent.toActions(dismissing: playerViewController))
-            playerViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(reusing: playerViewController.customInfoViewControllers)
+            playerViewController.customInfoViewControllers = infoViewTabsContent.viewControllers(reusing: playerViewController.customInfoViewControllers, for: player)
 #endif
         }
     }

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -215,7 +215,7 @@ public extension SystemVideoView {
     /// @Image(source: info-view-tabs, alt: "A screenshot of info view tabs")
     func infoViewTabs(@InfoViewTabsContentBuilder content: () -> InfoViewTabsContent) -> Self {
         var view = self
-        view.infoViewTabsContent = .init(elements: content().elements)
+        view.infoViewTabsContent = content()
         return view
     }
 }

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -209,8 +209,8 @@ public extension SystemVideoView {
     ///    }
     /// ```
     ///
-    /// Apply the ``SwiftUICore/View/infoViewTabPanel()`` modifier to use a background
-    /// that mimics the standard tvOS Info view appearance.
+    /// Apply the ``SwiftUICore/View/infoViewTabPanel()`` modifier to use a background that mimics the standard tvOS
+    /// Info view appearance.
     ///
     /// @Image(source: info-view-tabs, alt: "A screenshot of info view tabs")
     func infoViewTabs(@InfoViewTabsContentBuilder content: () -> InfoViewTabsContent) -> Self {

--- a/Tests/PlayerTests/UserInterface/DSL/Builders/InfoViewTabsContentBuilderDSLChecks.swift
+++ b/Tests/PlayerTests/UserInterface/DSL/Builders/InfoViewTabsContentBuilderDSLChecks.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 private enum InfoViewTabsContentBuilderDSLChecks {
     private static func tab() -> InfoViewTabsElement {
-        Tab(title: "Title") {
+        Tab("Title") {
             SwiftUI.Button("") {}
         }
     }

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -159,14 +159,6 @@ Due to an `AVQueuePlayer` issue, toggling `isMuted` can cause the player to rema
 
 No workaround is available yet. Audio is restored when transitioning between items, when the player is paused and resumed, or when a seek operation occurs.
 
-## Memory leaks when using `SystemVideoView` on tvOS 26 (FB21160665)
-
-The standard player user interface leaks memory when playing content that contains chapters on tvOS 26.
-
-### Workaround
-
-No workaround is available yet.
-
 ## Playback incorrectly jumps to the live edge when resuming a DVR video livestream after an interruption (e.g. alarm) (FB21701670)
 
 When playing a video livestream that offers a DVR window, the player incorrectly resumes at the live edge after an interruption instead of resuming from the previous playback position.


### PR DESCRIPTION
## Description

This PR offers a workaround for the tvOS chapter artwork leak described in #1379. It implements a completely custom chapters panel that mimics the system one on tvOS 26, with a few minor differences:

- Selecting a chapter does not close the info panel automatically.
- There is no marquee effect on chapter titles. This effect is tricky to implement and probably too much work for what is a temporary workaround anyway. A nice [library](https://github.com/GRimAce11/MarqueeKit) exist but this would add a dependency for a very specific need.

<img width="1500" height="844" alt="result" src="https://github.com/user-attachments/assets/424224b5-1bca-49a0-b576-0e220c03a54e" />

Note that the workaround has been applied on tvOS 26 only since tvOS 27 will likely fix the leak. We were namely informed of a change in beta 1 and can confirm that the leak has been reduce, though not entirely eliminated yet.

Also note that the tvOS panel APIs have never been marked as tvOS-specific. For this reason the new chapter UI types have not been marked as unavailable on iOS.

### Remark

Accessibility is not perfect, as tab titles are appended for some reason to be determined. I have created a dedicated task since this likely affects all custom info panels.

## Changes made

- Disable navigation markers on tvOS 26.
- Implement chapters tab replacement for tvOS 26, based on the design for this version (the design was updated in tvOS 27). The blurry image extension was obtained using the new background extension effect introduced in tvOS 26.
- Improve `Tab` initializers for localization. The `title` parameter was removed to match usual SwiftUI tab creation.
- Remove associated known issue.
- Translate all required strings. Those have been borrowed from tvOS directly (except for the Romansh one) and are updated on Crowdin.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
