### PR TITLE
Enable prefer_self_in_static_references SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -116,6 +116,7 @@ opt_in_rules:
   - period_spacing
   - prefer_key_path
   - prefer_nimble
+  - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init
   - prefixed_toplevel_constant

--- a/Demo/Sources/Settings/UserDefaults.swift
+++ b/Demo/Sources/Settings/UserDefaults.swift
@@ -66,7 +66,7 @@ extension UserDefaults {
     }
 
     private static func registerDefaultDemoSettings() {
-        UserDefaults.standard.register(defaults: [
+        standard.register(defaults: [
             DemoSettingKey.presenterModeEnabled.rawValue: false,
             DemoSettingKey.smartNavigationEnabled.rawValue: true,
             DemoSettingKey.seekBehaviorSetting.rawValue: SeekBehaviorSetting.optimal.rawValue,

--- a/Sources/Player/Extensions/CMTimeRange.swift
+++ b/Sources/Player/Extensions/CMTimeRange.swift
@@ -8,7 +8,7 @@ import CoreMedia
 
 extension CMTimeRange {
     static func flatten(_ timeRanges: [CMTimeRange]) -> [CMTimeRange] {
-        timeRanges.sorted { $0.start < $1.start }.reduce(into: [CMTimeRange]()) { result, timeRange in
+        timeRanges.sorted { $0.start < $1.start }.reduce(into: []) { result, timeRange in
             if let lastTimeRange = result.last {
                 if timeRange.containsTime(lastTimeRange.end) {
                     result[result.count - 1] = lastTimeRange.union(timeRange)

--- a/Sources/Player/Publishers/AVPlayerItemPublishers.swift
+++ b/Sources/Player/Publishers/AVPlayerItemPublishers.swift
@@ -119,13 +119,13 @@ extension AVPlayerItem {
     }
 
     private func endTimeNotificationPublisher() -> AnyPublisher<Bool, Never> {
-        NotificationCenter.default.weakPublisher(for: AVPlayerItem.didPlayToEndTimeNotification, object: self)
+        NotificationCenter.default.weakPublisher(for: Self.didPlayToEndTimeNotification, object: self)
             .map { _ in true }
             .eraseToAnyPublisher()
     }
 
     private func timeJumpedNotificationPublisher() -> AnyPublisher<Bool, Never> {
-        NotificationCenter.default.weakPublisher(for: AVPlayerItem.timeJumpedNotification, object: self)
+        NotificationCenter.default.weakPublisher(for: Self.timeJumpedNotification, object: self)
             .map { _ in false }
             .eraseToAnyPublisher()
     }
@@ -134,7 +134,7 @@ extension AVPlayerItem {
 extension AVPlayerItem {
     func isStalledPublisher() -> AnyPublisher<Bool, Never> {
         Publishers.Merge(
-            NotificationCenter.default.weakPublisher(for: AVPlayerItem.playbackStalledNotification, object: self)
+            NotificationCenter.default.weakPublisher(for: Self.playbackStalledNotification, object: self)
                 .map { _ in true },
             publisher(for: \.isPlaybackLikelyToKeepUp)
                 .compactMap { $0 ? false : nil }
@@ -165,7 +165,7 @@ extension AVPlayerItem {
     }
 
     private func playbackErrorPublisher() -> AnyPublisher<Error, Never> {
-        NotificationCenter.default.weakPublisher(for: AVPlayerItem.failedToPlayToEndTimeNotification, object: self)
+        NotificationCenter.default.weakPublisher(for: Self.failedToPlayToEndTimeNotification, object: self)
             .compactMap { $0.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error }
             .eraseToAnyPublisher()
     }
@@ -210,7 +210,7 @@ extension AVPlayerItem {
     }
 
     func warningMetricEventPublisher() -> AnyPublisher<MetricEvent, Never> {
-        NotificationCenter.default.weakPublisher(for: AVPlayerItem.newErrorLogEntryNotification, object: self)
+        NotificationCenter.default.weakPublisher(for: Self.newErrorLogEntryNotification, object: self)
             .compactMap { notification -> Error? in
                 guard let lastErrorEvent = (notification.object as? AVPlayerItem)?.errorLog()?.events.last else { return nil }
                 return NSError(

--- a/Sources/Player/Types/AssetMetadata.swift
+++ b/Sources/Player/Types/AssetMetadata.swift
@@ -26,7 +26,7 @@ public struct AssetMetadata<CustomData> {
             playerMetadata.playerMetadataPublisher(),
             Just(customData)
         )
-        .map { AssetMetadata(playerMetadata: $0, customData: $1) }
+        .map { .init(playerMetadata: $0, customData: $1) }
         .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## Description

This PR restores the `prefer_self_in_static_references` SwiftLint rule. The most recent [SwiftLint versions](https://github.com/realm/SwiftLint/releases/tag/0.65.0) namely fixed the false positives we encountered.

## Changes made

- Restore `prefer_self_in_static_references`.
- Fix associated linter warnings.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
