### PR TITLE
Fix MIME type ordering

### DIFF
--- a/Sources/CoreBusiness/DataProvider/Server.swift
+++ b/Sources/CoreBusiness/DataProvider/Server.swift
@@ -33,11 +33,11 @@ public enum Server: Codable {
 #endif
 
     private static let supportedMimeTypes = [
-        "audio/mp4; codecs=\"mp4a.40.2\"",
+        "application/x-mpegURL",
+        "video/mpeg",
         "video/mp4",
         "audio/mpeg",
-        "video/mpeg",
-        "application/x-mpegURL"
+        "audio/mp4; codecs=\"mp4a.40.2\""
     ]
 
     var id: String {


### PR DESCRIPTION
## Description

This PR fixes MIME type ordering when requesting IL content, from the most to the least desirable option.

### Remark

There is still a server issue that prevented #1537 from working, due to `"audio/mp4; codecs=\"mp4a.40.2\""` appearing first. As a result no content was playable.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
