### PR TITLE
Add download button for manually entered content

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -177,6 +177,9 @@
     "Double tap to toggle controls" : {
 
     },
+    "Download" : {
+
+    },
     "Embeddings" : {
 
     },

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -59,7 +59,7 @@ private struct MediaEntryView: View {
     @State private var certificateUrlString = ""
     @EnvironmentObject private var router: Router
 
-#if os(iOS)
+#if DEBUG && os(iOS)
     @EnvironmentObject private var downloader: DemoDownloader
 #endif
 
@@ -152,7 +152,7 @@ private struct MediaEntryView: View {
                 Text("Play")
                     .frame(maxWidth: .infinity)
             }
-#if os(iOS)
+#if DEBUG && os(iOS)
             Button(action: download) {
                 Text("Download")
                     .frame(maxWidth: .infinity)
@@ -166,7 +166,7 @@ private struct MediaEntryView: View {
         router.presented = .player(media: media)
     }
 
-#if os(iOS)
+#if DEBUG && os(iOS)
     private func download() {
         downloader.addDownload(media: media)
     }

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -57,9 +57,11 @@ private struct MediaEntryView: View {
     @State private var kind: Kind = .url
     @State private var text = ""
     @State private var certificateUrlString = ""
-
     @EnvironmentObject private var router: Router
+
+#if os(iOS)
     @EnvironmentObject private var downloader: DemoDownloader
+#endif
 
     private var media: Media {
         switch kind {
@@ -150,10 +152,12 @@ private struct MediaEntryView: View {
                 Text("Play")
                     .frame(maxWidth: .infinity)
             }
+#if os(iOS)
             Button(action: download) {
                 Text("Download")
                     .frame(maxWidth: .infinity)
             }
+#endif
         }
         .foregroundColor(Color.accentColor)
     }
@@ -162,9 +166,11 @@ private struct MediaEntryView: View {
         router.presented = .player(media: media)
     }
 
+#if os(iOS)
     private func download() {
         downloader.addDownload(media: media)
     }
+#endif
 }
 
 struct ExamplesView: View {

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -57,7 +57,9 @@ private struct MediaEntryView: View {
     @State private var kind: Kind = .url
     @State private var text = ""
     @State private var certificateUrlString = ""
+
     @EnvironmentObject private var router: Router
+    @EnvironmentObject private var downloader: DemoDownloader
 
     private var media: Media {
         switch kind {
@@ -119,10 +121,7 @@ private struct MediaEntryView: View {
                 TextFieldView("Certificate URL", text: $certificateUrlString)
             }
             if isValid {
-                Button(action: play) {
-                    Text("Play")
-                }
-                .foregroundColor(Color.accentColor)
+                actionButtons()
             }
         }
         .transaction { $0.animation = nil }
@@ -145,8 +144,24 @@ private struct MediaEntryView: View {
 #endif
     }
 
+    private func actionButtons() -> some View {
+        HStack {
+            Button(action: play) {
+                Text("Play")
+            }
+            Button(action: download) {
+                Text("Download")
+            }
+        }
+        .foregroundColor(Color.accentColor)
+    }
+
     private func play() {
         router.presented = .player(media: media)
+    }
+
+    private func download() {
+        downloader.addDownload(media: media)
     }
 }
 

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -65,13 +65,13 @@ private struct MediaEntryView: View {
         switch kind {
         case .url:
             guard let url else { return URLMedia.unknown }
-            return .init(title: "URL", type: .url(url))
+            return .init(title: "URL", subtitle: url.absoluteString, type: .url(url))
         case .tokenProtected:
             guard let url else { return URLMedia.unknown }
-            return .init(title: "Token-protected", type: .tokenProtectedUrl(url))
+            return .init(title: "Token-protected", subtitle: url.absoluteString, type: .tokenProtectedUrl(url))
         case .encrypted:
             guard let url, let certificateUrl else { return URLMedia.unknown }
-            return .init(title: "Encrypted", type: .encryptedUrl(url, certificateUrl: certificateUrl))
+            return .init(title: "Encrypted", subtitle: url.absoluteString, type: .encryptedUrl(url, certificateUrl: certificateUrl))
         case .productionUrn:
             return .init(title: trimmedText, type: .urn(trimmedText, serverSetting: .production))
         case .stageUrn:
@@ -148,9 +148,11 @@ private struct MediaEntryView: View {
         HStack {
             Button(action: play) {
                 Text("Play")
+                    .frame(maxWidth: .infinity)
             }
             Button(action: download) {
                 Text("Download")
+                    .frame(maxWidth: .infinity)
             }
         }
         .foregroundColor(Color.accentColor)


### PR DESCRIPTION
## Description

This PR adds a download button next to the play button displayed when content has been manually entered. The user experience is minimal (no feedback is provided yet), as the feature is mostly intended for tests purposes. We'll likely do better if we split the player demo in the future.

<img width="600" height="1208" alt="result" src="https://github.com/user-attachments/assets/78bca461-86cc-4004-a5ea-875c32aa6d07" />

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
