### PR TITLE
Improve download cell UI

### DIFF
--- a/Demo/Sources/Downloads/DownloadButton~ios.swift
+++ b/Demo/Sources/Downloads/DownloadButton~ios.swift
@@ -1,0 +1,81 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+#if DEBUG
+
+@_spi(DownloaderPrivate)
+import PillarboxPlayer
+
+import SwiftUI
+
+private struct DownloadIcon: View {
+    enum State {
+        case running(Double)
+        case suspended(Double)
+        case completed
+        case failed
+    }
+
+    let state: State
+    let side: CGFloat
+
+    var body: some View {
+        switch state {
+        case let .running(progress):
+            CircularProgressIcon(progress: progress, icon: "pause.fill", side: side)
+        case let .suspended(progress):
+            CircularProgressIcon(progress: progress, icon: "play.fill", side: side)
+        case .completed:
+            CircularProgressIcon(progress: 1, icon: "checkmark", color: .green, side: side)
+        case .failed:
+            CircularProgressIcon(progress: 1, icon: "arrow.counterclockwise", color: .red, side: side)
+        }
+    }
+}
+
+struct DownloadButton: View {
+    @ObservedObject var download: Download
+    let side: CGFloat
+
+    var body: some View {
+        ZStack {
+            if download.error != nil {
+                Button(action: download.restart) {
+                    DownloadIcon(state: .failed, side: side)
+                }
+            }
+            else {
+                switch download.state {
+                case .preparing:
+                    ProgressView()
+                        .frame(width: side, height: side)
+                case .running:
+                    Button(action: download.suspend) {
+                        DownloadIcon(state: .running(download.progress), side: side)
+                    }
+                case .suspended:
+                    Button(action: download.resume) {
+                        DownloadIcon(state: .suspended(download.progress), side: side)
+                    }
+                case .completed:
+                    DownloadIcon(state: .completed, side: side)
+                }
+            }
+        }
+        .animation(.default, value: download.progress)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        DownloadIcon(state: .completed, side: 100)
+        DownloadIcon(state: .failed, side: 100)
+        DownloadIcon(state: .running(0.3), side: 100)
+        DownloadIcon(state: .suspended(0.5), side: 100)
+    }
+}
+
+#endif

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -30,9 +30,8 @@ struct DownloadCell: View {
 
     var body: some View {
         HStack {
-            artworkView()
             infoView()
-            statusButton()
+            DownloadButton(download: download, side: 32)
         }
     }
 
@@ -42,18 +41,14 @@ struct DownloadCell: View {
             .aspectRatio(16 / 9, contentMode: .fit)
             .frame(height: 32)
             .overlay {
-                LazyImage(source: imageSource) { image in
-                    image
-                        .resizable()
-                }
+                LazyImage(source: imageSource) { $0.resizable() }
             }
     }
 
     private func infoView() -> some View {
-        VStack(alignment: .leading, spacing: 20) {
+        HStack {
+            artworkView()
             descriptionView()
-            progressBar()
-            errorMessage()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(.rect)
@@ -64,64 +59,13 @@ struct DownloadCell: View {
     private func descriptionView() -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
+                .lineLimit(1)
             if let subtitle {
                 Text(subtitle)
+                    .lineLimit(2)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
-        }
-    }
-
-    private func progressBar() -> some View {
-        ProgressView(value: download.progress) {
-            Text(download.progress, format: .percent.precision(.fractionLength(0)))
-                .contentTransition(.numericText())
-        }
-        .animation(.linear, value: download.progress)
-    }
-
-    @ViewBuilder
-    private func errorMessage() -> some View {
-        if let error = download.error {
-            Text(error.localizedDescription)
-                .foregroundStyle(.red)
-        }
-    }
-
-    private func statusButton() -> some View {
-        ZStack {
-            switch download.state {
-            case .preparing:
-                ProgressView()
-            case .running:
-                button(systemImage: "pause.circle", action: download.suspend)
-            case .suspended:
-                button(systemImage: "play.circle", action: download.resume)
-            case .completed:
-                completedButton()
-            }
-        }
-        .frame(width: 30, height: 30)
-        .padding()
-    }
-
-    @ViewBuilder
-    private func completedButton() -> some View {
-        if download.error != nil {
-            button(systemImage: "arrow.counterclockwise.circle", action: download.restart)
-                .tint(.red)
-        }
-        else {
-            Image(systemName: "checkmark")
-                .resizable()
-                .foregroundStyle(.green)
-        }
-    }
-
-    private func button(systemImage: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .resizable()
         }
     }
 }

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -24,11 +24,29 @@ struct DownloadCell: View {
         download.metadata.subtitle
     }
 
+    private var imageSource: ImageSource {
+        download.metadata.imageSource
+    }
+
     var body: some View {
         HStack {
+            artworkView()
             infoView()
             statusButton()
         }
+    }
+
+    private func artworkView() -> some View {
+        Rectangle()
+            .foregroundStyle(.quaternary)
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .frame(height: 32)
+            .overlay {
+                LazyImage(source: imageSource) { image in
+                    image
+                        .resizable()
+                }
+            }
     }
 
     private func infoView() -> some View {

--- a/Demo/Sources/Views/CircularProgressButton.swift
+++ b/Demo/Sources/Views/CircularProgressButton.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SwiftUI
+
+private struct CircularProgressStyle: ProgressViewStyle {
+    let color: Color
+    let width: Double
+
+    func makeBody(configuration: Configuration) -> some View {
+        ZStack {
+            Circle()
+                .stroke(color.opacity(0.5), lineWidth: width)
+
+            Circle()
+                .trim(from: 0, to: configuration.fractionCompleted ?? 0)
+                .stroke(color, style: StrokeStyle(lineWidth: width, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+    }
+}
+
+/*
+ TODO: Starting with iOS 26, should be replaced by something like:
+ ```swift
+ Button {} label: {
+     Image(systemName: "play.circle", variableValue: 0.5)
+         .symbolVariableValueMode(.draw)
+ ```
+ }
+ */
+struct CircularProgressButton: View {
+    let progress: Double
+    let icon: String
+    let color: Color
+    let side: Double
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ProgressView(value: progress)
+                .progressViewStyle(CircularProgressStyle(color: color, width: side * 0.1))
+                .overlay {
+                    Image(systemName: icon)
+                        .font(.system(size: side / 2))
+                        .tint(color)
+                }
+        }
+        .frame(width: side, height: side)
+    }
+
+    init(progress: Double, icon: String, color: Color = .accentColor, side: Double, action: @escaping () -> Void) {
+        self.progress = progress
+        self.icon = icon
+        self.color = color
+        self.side = side
+        self.action = action
+    }
+}
+
+#Preview {
+    VStack(spacing: 50) {
+        CircularProgressButton(progress: 0.7, icon: "play.fill", side: 100) {}
+        CircularProgressButton(progress: 0.3, icon: "pause.fill", color: .green, side: 100) {}
+    }
+}

--- a/Demo/Sources/Views/CircularProgressIcon.swift
+++ b/Demo/Sources/Views/CircularProgressIcon.swift
@@ -32,38 +32,35 @@ private struct CircularProgressStyle: ProgressViewStyle {
  ```
  }
  */
-struct CircularProgressButton: View {
+struct CircularProgressIcon: View {
     let progress: Double
     let icon: String
     let color: Color
-    let side: Double
-    let action: () -> Void
+    let side: CGFloat
 
     var body: some View {
-        Button(action: action) {
-            ProgressView(value: progress)
-                .progressViewStyle(CircularProgressStyle(color: color, width: side * 0.1))
-                .overlay {
-                    Image(systemName: icon)
-                        .font(.system(size: side / 2))
-                        .tint(color)
-                }
-        }
-        .frame(width: side, height: side)
+        ProgressView(value: progress)
+            .progressViewStyle(CircularProgressStyle(color: color, width: side * 0.1))
+            .overlay {
+                Image(systemName: icon)
+                    .font(.system(size: side / 2))
+                    .foregroundStyle(color)
+                    .bold()
+            }
+            .frame(width: side, height: side)
     }
 
-    init(progress: Double, icon: String, color: Color = .accentColor, side: Double, action: @escaping () -> Void) {
+    init(progress: Double, icon: String, color: Color = .accentColor, side: CGFloat) {
         self.progress = progress
         self.icon = icon
         self.color = color
         self.side = side
-        self.action = action
     }
 }
 
 #Preview {
     VStack(spacing: 50) {
-        CircularProgressButton(progress: 0.7, icon: "play.fill", side: 100) {}
-        CircularProgressButton(progress: 0.3, icon: "pause.fill", color: .green, side: 100) {}
+        CircularProgressIcon(progress: 0.7, icon: "play.fill", side: 100)
+        CircularProgressIcon(progress: 0.3, icon: "pause.fill", color: .green, side: 100)
     }
 }

--- a/Demo/Sources/Views/CircularProgressIcon.swift
+++ b/Demo/Sources/Views/CircularProgressIcon.swift
@@ -40,7 +40,7 @@ struct CircularProgressIcon: View {
 
     var body: some View {
         ProgressView(value: progress)
-            .progressViewStyle(CircularProgressStyle(color: color, width: side * 0.1))
+            .progressViewStyle(.circular(color: color, width: side * 0.1))
             .overlay {
                 Image(systemName: icon)
                     .font(.system(size: side / 2))
@@ -62,5 +62,11 @@ struct CircularProgressIcon: View {
     VStack(spacing: 50) {
         CircularProgressIcon(progress: 0.7, icon: "play.fill", side: 100)
         CircularProgressIcon(progress: 0.3, icon: "pause.fill", color: .green, side: 100)
+    }
+}
+
+private extension ProgressViewStyle where Self == CircularProgressStyle {
+    static func circular(color: Color, width: CGFloat) -> CircularProgressStyle {
+        .init(color: color, width: width)
     }
 }


### PR DESCRIPTION
## Description

This PR allows us to provide a more polished and compact UI for download cells.

## Changes made

- A new circular progress icon component has been added.
- The download control logic has been abstracted into a dedicated component.
- The progress bar and error text have been replaced with the new `DownloadButton`.
- An `artworkView` has been added to display the image source.

## Illustration

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/41a71b0a-3b4a-4597-ac4c-5caa36471f5b" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/9fb703b4-b0f7-4e79-b254-424a6ec879d6" /> | 

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
