### PR TITLE
Simplify download manager constraint type

### DIFF
--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -177,9 +177,6 @@
     "Double tap to toggle controls" : {
 
     },
-    "Download" : {
-
-    },
     "Embeddings" : {
 
     },

--- a/Demo/Sources/Downloads/DemoDownloader~ios.swift
+++ b/Demo/Sources/Downloads/DemoDownloader~ios.swift
@@ -18,7 +18,6 @@ import PillarboxPlayer
 @available(tvOS, unavailable)
 final class DemoDownloader: ObservableObject {
     private let urlDownloader = Downloader(
-        assetLoaderType: URLAssetLoader.self,
         configuration: .background(withIdentifier: "ch.srgssr.pillarbox-demo.url-downloads"),
         store: URLAssetDownloadStore(fileName: "url_downloads.json")
     )

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -41,7 +41,11 @@ struct DownloadCell: View {
             .aspectRatio(16 / 9, contentMode: .fit)
             .frame(height: 32)
             .overlay {
-                LazyImage(source: imageSource) { $0.resizable() }
+                LazyImage(source: imageSource) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
             }
     }
 

--- a/Sources/CoreBusiness/Downloads/URNDownloader.swift
+++ b/Sources/CoreBusiness/Downloads/URNDownloader.swift
@@ -23,11 +23,7 @@ public final class URNDownloader: ObservableObject {
     @Published public private(set) var downloads: [Download] = []
 
     public init(name: String? = nil, configuration: URLSessionConfiguration) throws {
-        let downloader = Downloader(
-            assetLoaderType: URNAssetLoader.self,
-            configuration: configuration,
-            store: try URNAssetDownloadStore(name: name)
-        )
+        let downloader = Downloader(configuration: configuration, store: try URNAssetDownloadStore(name: name))
         self.downloader = downloader
 
         downloader.$downloads

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -49,13 +49,13 @@ public final class Download: ObservableObject {
         properties.fileUrl
     }
 
-    private init<L, S>(
+    private init<S>(
         id: String,
         input: S.Loader.Input,
         creationDate: Date,
         session: DownloadSession,
         store: S
-    ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
+    ) where S: AssetDownloadStore {
         self.id = id
         self.creationDate = creationDate
         self.session = session

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -51,8 +51,7 @@ public final class Download: ObservableObject {
 
     private init<L, S>(
         id: String,
-        assetLoaderType: L.Type,
-        input: L.Input,
+        input: S.Loader.Input,
         creationDate: Date,
         session: DownloadSession,
         store: S
@@ -67,30 +66,27 @@ public final class Download: ObservableObject {
         self.removeRecord = {
             store.removeDownloadRecord(forId: id)
         }
-        configurePropertiesPublisher(assetLoaderType: assetLoaderType, input: input, store: store)
+        configurePropertiesPublisher(input: input, store: store)
     }
 
-    convenience init<L, S>(
-        assetLoaderType: L.Type,
-        input: L.Input,
+    convenience init<S>(
+        input: S.Loader.Input,
         session: DownloadSession,
         store: S
-    ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
+    ) where S: AssetDownloadStore {
         let id = S.id(from: input)
         let creationDate = Date.now
         store.addDownloadRecord(.init(input: input, creationDate: creationDate), forId: id)
-        self.init(id: id, assetLoaderType: assetLoaderType, input: input, creationDate: creationDate, session: session, store: store)
+        self.init(id: id, input: input, creationDate: creationDate, session: session, store: store)
     }
 
-    convenience init<L, S>(
-        assetLoaderType: L.Type,
+    convenience init<S>(
         record: DownloadRecord<S.Loader.Input, S.CustomData>,
         session: DownloadSession,
         store: S
-    ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
+    ) where S: AssetDownloadStore {
         self.init(
             id: S.id(from: record.input),
-            assetLoaderType: assetLoaderType,
             input: record.input,
             creationDate: record.creationDate,
             session: session,
@@ -160,11 +156,10 @@ private extension Download {
         .eraseToAnyPublisher()
     }
 
-    func propertiesPublisher<L, S>(
-        assetLoaderType: L.Type,
-        input: L.Input,
+    func propertiesPublisher<S>(
+        input: S.Loader.Input,
         store: S
-    ) -> AnyPublisher<DownloadProperties<S.CustomData>, Never> where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
+    ) -> AnyPublisher<DownloadProperties<S.CustomData>, Never> where S: AssetDownloadStore {
         // swiftlint:disable:next closure_body_length
         Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: TriggerId.restart)) { [id, trigger, session] in
             let storedProperties = store.downloadProperties(forId: id)
@@ -204,12 +199,11 @@ private extension Download {
         }
     }
 
-    func configurePropertiesPublisher<L, S>(
-        assetLoaderType: L.Type,
-        input: L.Input,
+    func configurePropertiesPublisher<S>(
+        input: S.Loader.Input,
         store: S
-    ) where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
-        propertiesPublisher(assetLoaderType: assetLoaderType, input: input, store: store)
+    ) where S: AssetDownloadStore {
+        propertiesPublisher(input: input, store: store)
             .receiveOnMainThread()
             .handleEvents(
                 receiveOutput: { [id, creationDate] properties in

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -49,13 +49,7 @@ public final class Download: ObservableObject {
         properties.fileUrl
     }
 
-    private init<S>(
-        id: String,
-        input: S.Loader.Input,
-        creationDate: Date,
-        session: DownloadSession,
-        store: S
-    ) where S: AssetDownloadStore {
+    private init<S>(id: String, input: S.Loader.Input, creationDate: Date, session: DownloadSession, store: S) where S: AssetDownloadStore {
         self.id = id
         self.creationDate = creationDate
         self.session = session
@@ -69,29 +63,15 @@ public final class Download: ObservableObject {
         configurePropertiesPublisher(input: input, store: store)
     }
 
-    convenience init<S>(
-        input: S.Loader.Input,
-        session: DownloadSession,
-        store: S
-    ) where S: AssetDownloadStore {
+    convenience init<S>(input: S.Loader.Input, session: DownloadSession, store: S) where S: AssetDownloadStore {
         let id = S.id(from: input)
         let creationDate = Date.now
         store.addDownloadRecord(.init(input: input, creationDate: creationDate), forId: id)
         self.init(id: id, input: input, creationDate: creationDate, session: session, store: store)
     }
 
-    convenience init<S>(
-        record: DownloadRecord<S.Loader.Input, S.CustomData>,
-        session: DownloadSession,
-        store: S
-    ) where S: AssetDownloadStore {
-        self.init(
-            id: S.id(from: record.input),
-            input: record.input,
-            creationDate: record.creationDate,
-            session: session,
-            store: store
-        )
+    convenience init<S>(record: DownloadRecord<S.Loader.Input, S.CustomData>, session: DownloadSession, store: S) where S: AssetDownloadStore {
+        self.init(id: S.id(from: record.input), input: record.input, creationDate: record.creationDate, session: session, store: store)
     }
 
     func remove() {
@@ -156,10 +136,7 @@ private extension Download {
         .eraseToAnyPublisher()
     }
 
-    func propertiesPublisher<S>(
-        input: S.Loader.Input,
-        store: S
-    ) -> AnyPublisher<DownloadProperties<S.CustomData>, Never> where S: AssetDownloadStore {
+    func propertiesPublisher<S>(input: S.Loader.Input, store: S) -> AnyPublisher<DownloadProperties<S.CustomData>, Never> where S: AssetDownloadStore {
         // swiftlint:disable:next closure_body_length
         Publishers.PublishAndRepeat(onOutputFrom: trigger.signal(activatedBy: TriggerId.restart)) { [id, trigger, session] in
             let storedProperties = store.downloadProperties(forId: id)
@@ -199,10 +176,7 @@ private extension Download {
         }
     }
 
-    func configurePropertiesPublisher<S>(
-        input: S.Loader.Input,
-        store: S
-    ) where S: AssetDownloadStore {
+    func configurePropertiesPublisher<S>(input: S.Loader.Input, store: S) where S: AssetDownloadStore {
         propertiesPublisher(input: input, store: store)
             .receiveOnMainThread()
             .handleEvents(

--- a/Sources/Player/Downloads/DownloadManager.swift
+++ b/Sources/Player/Downloads/DownloadManager.swift
@@ -10,17 +10,17 @@ import Combine
 import Foundation
 
 @available(tvOS, unavailable)
-final class DownloadManager<L, S>: DownloadManagement<S> where L: AssetLoader, S: AssetDownloadStore, L == S.Loader {
+final class DownloadManager<S>: DownloadManagement<S> where S: AssetDownloadStore {
     private let store: S
     private let session: any DownloadSession
 
     @Published private(set) var downloads: [Download]
 
-    init(assetLoaderType: L.Type, store: S, session: some DownloadSession) {
+    init(store: S, session: some DownloadSession) {
         self.store = store
         self.session = session
         self.downloads = store.downloadRecords().map { record in
-            Download(assetLoaderType: assetLoaderType, record: record, session: session, store: store)
+            Download(record: record, session: session, store: store)
         }
         session.delegate = self
     }
@@ -31,7 +31,7 @@ final class DownloadManager<L, S>: DownloadManagement<S> where L: AssetLoader, S
             return download
         }
         else {
-            let download = Download(assetLoaderType: L.self, input: input, session: session, store: store)
+            let download = Download(input: input, session: session, store: store)
             downloads.append(download)
             return download
         }

--- a/Sources/Player/Downloads/Downloader.swift
+++ b/Sources/Player/Downloads/Downloader.swift
@@ -18,16 +18,8 @@ public final class Downloader<S>: ObservableObject where S: AssetDownloadStore {
 
     @Published public private(set) var downloads: [Download] = []
 
-    public init<L>(
-        assetLoaderType: L.Type,
-        configuration: URLSessionConfiguration,
-        store: S
-    ) where L: AssetLoader, L == S.Loader {
-        let manager = DownloadManager(
-            assetLoaderType: assetLoaderType,
-            store: store,
-            session: URLDownloadSession(configuration: configuration)
-        )
+    public init<L>(configuration: URLSessionConfiguration, store: S) where L: AssetLoader, L == S.Loader {
+        let manager = DownloadManager(store: store, session: URLDownloadSession(configuration: configuration))
         self.manager = manager
 
         manager.$downloads

--- a/Sources/Player/Downloads/Downloader.swift
+++ b/Sources/Player/Downloads/Downloader.swift
@@ -18,7 +18,7 @@ public final class Downloader<S>: ObservableObject where S: AssetDownloadStore {
 
     @Published public private(set) var downloads: [Download] = []
 
-    public init<L>(configuration: URLSessionConfiguration, store: S) where L: AssetLoader, L == S.Loader {
+    public init(configuration: URLSessionConfiguration, store: S) {
         let manager = DownloadManager(store: store, session: URLDownloadSession(configuration: configuration))
         self.manager = manager
 

--- a/Tests/PlayerTests/Downloads/DownloadManagerTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadManagerTests.swift
@@ -17,7 +17,7 @@ final class DownloadManagerTests: TestCase {
 
     func testEmpty() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         expect(manager.downloads).to(beEmpty())
         expect(store.downloadRecords()).to(beEmpty())
     }
@@ -26,14 +26,14 @@ final class DownloadManagerTests: TestCase {
         let store = AssetDownloadStoreMock(preloadedInputs: [
             .playable(url: Stream.download.url)
         ])
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         expect(manager.downloads).to(haveCount(1))
         expect(store.downloadRecords()).to(haveCount(1))
     }
 
     func testAddSingle() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(manager.downloads).to(equal([download]))
         expect(store.downloadRecords()).to(haveCount(1))
@@ -41,7 +41,7 @@ final class DownloadManagerTests: TestCase {
 
     func testAddDifferent() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download1 = manager.addDownload(for: .playable(url: Stream.download.url))
         let download2 = manager.addDownload(for: .playable(url: Stream.mediumOnDemand.url))
         expect(download1).notTo(equal(download2))
@@ -51,7 +51,7 @@ final class DownloadManagerTests: TestCase {
 
     func testAddIdentical() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download1 = manager.addDownload(for: .playable(url: Stream.download.url))
         let download2 = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download1).to(equal(download2))
@@ -60,20 +60,20 @@ final class DownloadManagerTests: TestCase {
     }
 
     func testDownloadWithMatchingInput() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let input = AssetLoaderMock.Input.playable(url: Stream.download.url)
         let download = manager.addDownload(for: input)
         expect(manager.download(matching: input)).to(equal(download))
     }
 
     func testDownloadWithNonMatchingInput() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         manager.addDownload(for: .playable(url: Stream.download.url))
         expect(manager.download(matching: .playable(url: Stream.mediumOnDemand.url))).to(beNil())
     }
 
     func testRelatedPlayerItem() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).toEventually(equal(.completed))
         let item = manager.playerItem(for: download, trackerAdapters: [])
@@ -81,17 +81,17 @@ final class DownloadManagerTests: TestCase {
     }
 
     func testUnrelatedPlayerItem() {
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager1 = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download1 = manager1.addDownload(for: .playable(url: Stream.download.url))
         expect(download1.state).toEventually(equal(.completed))
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager2 = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         expect(manager2.playerItem(for: download1, trackerAdapters: [])).to(beNil())
     }
 
     func testRemove() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         manager.removeDownload(download)
         expect(manager.downloads).to(beEmpty())
@@ -101,10 +101,10 @@ final class DownloadManagerTests: TestCase {
 
     func testRemoveUnrelated() {
         let store1 = AssetDownloadStoreMock()
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store1, session: session)
+        let manager1 = DownloadManager(store: store1, session: session)
         let download1 = manager1.addDownload(for: .playable(url: Stream.download.url))
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager2 = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         manager2.removeDownload(download1)
         expect(download1.state).to(equal(.running))
         expect(store1.downloadRecords()).to(haveCount(1))
@@ -112,7 +112,7 @@ final class DownloadManagerTests: TestCase {
 
     func testRemoveAll() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download1 = manager.addDownload(for: .playable(url: Stream.download.url))
         let download2 = manager.addDownload(for: .playable(url: Stream.mediumOnDemand.url))
         manager.removeAllDownloads()
@@ -123,7 +123,7 @@ final class DownloadManagerTests: TestCase {
     }
 
     func testDeallocation() {
-        var manager: DownloadManager? = .init(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        var manager: DownloadManager? = .init(store: AssetDownloadStoreMock(), session: session)
         manager?.addDownload(for: .playable(url: Stream.download.url))
 
         weak let weakManager = manager

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -18,14 +18,14 @@ final class DownloadTests: TestCase {
     private let session = DownloadSessionMock(name: "DownloadTests")
 
     func testRunningWithImmediatePreparation() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).to(equal(.running))
         expect(download.progress).to(equal(0))
     }
 
     func testRunningWithAsynchronousPreparation() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, after: 0.1))
         expect(download.state).to(equal(.preparing))
         expect(download.progress).to(equal(0))
@@ -33,7 +33,7 @@ final class DownloadTests: TestCase {
 
     func testCompletion() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, after: 0.1))
         expect(download.state).toEventually(equal(.completed))
         expect(download.progress).to(equal(1))
@@ -44,14 +44,14 @@ final class DownloadTests: TestCase {
     }
 
     func testSuspend() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         download.suspend()
         expect(download.state).toEventually(equal(.suspended))
     }
 
     func testResume() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         download.suspend()
         expect(download.state).toEventually(equal(.suspended))
@@ -61,7 +61,7 @@ final class DownloadTests: TestCase {
     }
 
     func testMetadata() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
         expect(download.metadata.title).to(beNil())
         expect(download.metadata.title).toEventually(equal("Title"))
@@ -69,7 +69,7 @@ final class DownloadTests: TestCase {
     }
 
     func testIgnoreMetadataUpdates() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(
             for: .playable(url: Stream.download.url, metadata: .init(title: "Title1"), updatedWithMetadata: .init(title: "Title2"), interval: 0.1)
         )
@@ -77,7 +77,7 @@ final class DownloadTests: TestCase {
     }
 
     func testMetadataFailure() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .failing(with: MetadataError()))
         expect(download.state).toEventually(equal(.completed))
         expect(download.progress).to(equal(0))
@@ -85,7 +85,7 @@ final class DownloadTests: TestCase {
     }
 
     func testSessionFailure() {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         let download = manager.addDownload(for: .playable(url: Stream.unavailableDownload.url))
         expect(download.state).toEventually(equal(.completed))
         expect(download.progress).to(equal(0))
@@ -95,7 +95,7 @@ final class DownloadTests: TestCase {
 
     func testRemoveWhileInitiallyPreparing() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, after: 0.1))
         expect(download.state).to(equal(.preparing))
 
@@ -109,7 +109,7 @@ final class DownloadTests: TestCase {
 
     func testRemoveWhileInitiallyRunning() {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).to(equal(.running))
 
@@ -123,7 +123,7 @@ final class DownloadTests: TestCase {
 
     func testRemoveWhileDownloadingFile() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         let fileUrl = try pollUnwrap(download.fileUrl)
 
@@ -138,7 +138,7 @@ final class DownloadTests: TestCase {
 
     func testRemoveWhileCompleted() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).toEventually(equal(.completed))
         expect(download.fileUrl).notTo(beNil())
@@ -153,7 +153,7 @@ final class DownloadTests: TestCase {
 
     func testRestartWhileCompleted() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).toEventually(equal(.completed))
         let location1 = try unwrap(download.fileUrl)
@@ -171,7 +171,7 @@ final class DownloadTests: TestCase {
 
     func testRestartImmediately() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url))
         expect(download.state).to(equal(.running))
         download.restart()
@@ -186,7 +186,7 @@ final class DownloadTests: TestCase {
 
     func testRestartKeepsMetadataIfAvailable() throws {
         let store = AssetDownloadStoreMock()
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager = DownloadManager(store: store, session: session)
         let download = manager.addDownload(for: .playable(url: Stream.download.url, metadata: .init(title: "Title"), after: 0.1))
         expect(download.metadata.title).toEventually(equal("Title"))
         download.restart()
@@ -197,13 +197,13 @@ final class DownloadTests: TestCase {
         let store = AssetDownloadStoreMock()
         let input = AssetLoaderMock.Input.playable(url: Stream.download.url)
 
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager1 = DownloadManager(store: store, session: session)
         let download1 = manager1.addDownload(for: input)
         expect(download1.state).toEventually(equal(.completed))
         let location1 = try unwrap(download1.fileUrl)
         try FileManager.default.removeItem(at: location1)
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager2 = DownloadManager(store: store, session: session)
         let download2 = try unwrap(manager2.download(matching: input))
         expect(download2.state).to(equal(.completed))
         expect(download2.progress).to(equal(0))
@@ -215,12 +215,12 @@ final class DownloadTests: TestCase {
         let store = AssetDownloadStoreMock()
         let input = AssetLoaderMock.Input.playable(url: Stream.download.url)
 
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager1 = DownloadManager(store: store, session: session)
         let download1 = manager1.addDownload(for: input)
         expect(download1.state).toEventually(equal(.completed))
         let location1 = try unwrap(download1.fileUrl)
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager2 = DownloadManager(store: store, session: session)
         let download2 = try unwrap(manager2.download(matching: input))
         expect(download2.state).to(equal(.completed))
         expect(download2.fileUrl).to(equal(location1))
@@ -230,13 +230,13 @@ final class DownloadTests: TestCase {
         let store = AssetDownloadStoreMock()
         let input = AssetLoaderMock.Input.failing(with: MetadataError())
 
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager1 = DownloadManager(store: store, session: session)
         let download1 = manager1.addDownload(for: input)
         expect(download1.state).toEventually(equal(.completed))
         let error1 = try unwrap(download1.error)
         expect(download1.fileUrl).to(beNil())
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager2 = DownloadManager(store: store, session: session)
         let download2 = try unwrap(manager2.download(matching: input))
         expect(download2.state).to(equal(.completed))
         let error2 = try unwrap(download2.error)
@@ -248,13 +248,13 @@ final class DownloadTests: TestCase {
         let store = AssetDownloadStoreMock()
         let input = AssetLoaderMock.Input.playable(url: Stream.unavailableDownload.url)
 
-        let manager1 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager1 = DownloadManager(store: store, session: session)
         let download1 = manager1.addDownload(for: input)
         expect(download1.state).toEventually(equal(.completed))
         let error1 = try unwrap(download1.error)
         expect(download1.fileUrl).to(beNil())
 
-        let manager2 = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: store, session: session)
+        let manager2 = DownloadManager(store: store, session: session)
         let download2 = try unwrap(manager2.download(matching: input))
         expect(download2.state).to(equal(.completed))
         let error2 = try unwrap(download2.error)
@@ -263,7 +263,7 @@ final class DownloadTests: TestCase {
     }
 
     func testDeallocationWithManager() throws {
-        var manager: DownloadManager? = .init(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        var manager: DownloadManager? = .init(store: AssetDownloadStoreMock(), session: session)
         weak let weakDownload = try unwrap(manager?.addDownload(for: .playable(url: Stream.download.url)))
         autoreleasepool {
             manager = nil
@@ -272,7 +272,7 @@ final class DownloadTests: TestCase {
     }
 
     func testDeallocationOnRemoval() throws {
-        let manager = DownloadManager(assetLoaderType: AssetLoaderMock.self, store: AssetDownloadStoreMock(), session: session)
+        let manager = DownloadManager(store: AssetDownloadStoreMock(), session: session)
         weak let weakDownload = try unwrap(manager.addDownload(for: .playable(url: Stream.download.url)))
         autoreleasepool {
             if let weakDownload {


### PR DESCRIPTION
## Description

This PR allows us to remove direct asset loader constraint type on the download manager.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
