### PR TITLE
Avoid undesired tvOS refreshes

### DIFF
--- a/Sources/Player/Extensions/UIAction.swift
+++ b/Sources/Player/Extensions/UIAction.swift
@@ -7,12 +7,25 @@
 import UIKit
 
 extension UIAction {
-    static func identifiedAction(title: String, image: UIImage? = nil, state: UIMenuElement.State = .off, handler: @escaping UIActionHandler) -> UIAction {
+    static func identifiedAction(
+        title: String,
+        subtitle: String? = nil,
+        image: UIImage? = nil,
+        state: UIMenuElement.State = .off,
+        handler: @escaping UIActionHandler
+    ) -> UIAction {
         if let image {
-            return UIAction(title: title, image: image, identifier: .init(rawValue: "\(title)-\(image.hash)"), state: state, handler: handler)
+            return UIAction(
+                title: title,
+                subtitle: subtitle,
+                image: image,
+                identifier: .init(rawValue: "\(title)-\(image.hash)"),
+                state: state,
+                handler: handler
+            )
         }
         else {
-            return UIAction(title: title, image: image, identifier: .init(rawValue: title), state: state, handler: handler)
+            return UIAction(title: title, subtitle: subtitle, image: image, identifier: .init(rawValue: title), state: state, handler: handler)
         }
     }
 }

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Button.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Button.swift
@@ -108,7 +108,7 @@ public struct ButtonInInfoViewActions: InfoViewActionsBody {
 
     // swiftlint:disable:next missing_docs
     public func toAction(dismissing viewController: UIViewController) -> UIAction {
-        UIAction(title: title, image: image) { [weak viewController] _ in
+        UIAction.identifiedAction(title: title, image: image) { [weak viewController] _ in
             action()
             viewController?.dismiss(animated: true)
         }
@@ -213,7 +213,7 @@ public struct ButtonInMenu: MenuBody {
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement() -> UIMenuElement? {
-        UIAction(title: title, subtitle: subtitle, image: image) { _ in action() }
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image) { _ in action() }
     }
 }
 
@@ -341,7 +341,7 @@ public struct ButtonInSection: SectionBody {
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement() -> UIMenuElement? {
-        UIAction(title: title, subtitle: subtitle, image: image) { _ in action() }
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image) { _ in action() }
     }
 }
 

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Option.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Option.swift
@@ -72,7 +72,7 @@ public struct OptionInInlinePicker<Value>: InlinePickerBody where Value: Equatab
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement(updating selection: Binding<Value>) -> UIMenuElement {
-        UIAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
             selection.wrappedValue = value
             action.state = state(selection: selection)
             handler(value)
@@ -195,7 +195,7 @@ public struct OptionInPicker<Value>: PickerBody where Value: Equatable {
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement(updating selection: Binding<Value>) -> UIMenuElement? {
-        UIAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
             selection.wrappedValue = value
             action.state = state(selection: selection)
             handler(value)
@@ -298,7 +298,7 @@ public struct OptionInPickerSection<Value>: PickerSectionBody where Value: Equat
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement(updating selection: Binding<Value>) -> UIMenuElement? {
-        UIAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image, state: state(selection: selection)) { action in
             selection.wrappedValue = value
             action.state = state(selection: selection)
             handler(value)

--- a/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Toggle.swift
+++ b/Sources/Player/UserInterface/DSL/SystemVideoViewControls/Toggle.swift
@@ -93,7 +93,7 @@ public struct ToggleInMenu: MenuBody {
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement() -> UIMenuElement? {
-        UIAction(title: title, subtitle: subtitle, image: image, state: state(isOn: isOn)) { action in
+        UIAction.identifiedAction(title: title, subtitle: subtitle, image: image, state: state(isOn: isOn)) { action in
             isOn.wrappedValue.toggle()
             action.state = state(isOn: isOn)
             handler(isOn.wrappedValue)
@@ -232,7 +232,7 @@ public struct ToggleInSection: SectionBody {
 
     // swiftlint:disable:next missing_docs
     public func toMenuElement() -> UIMenuElement? {
-        let action = UIAction(title: title, subtitle: subtitle, image: image) { action in
+        let action = UIAction.identifiedAction(title: title, subtitle: subtitle, image: image) { action in
             isOn.wrappedValue.toggle()
             action.state = isOn.wrappedValue ? .on : .off
             handler(isOn.wrappedValue)


### PR DESCRIPTION
## Description

This PR allows us to fix some undesired UI refreshes on tvOS.

## Changes made

- `UIAction` used on tvOS have been given an identifier.

## Overview

| Issue | Fix |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/cfab06a1-e5a8-4b3a-879b-bcb256ccfbe4" /> |  <video src="https://github.com/user-attachments/assets/ded4317c-07ac-4db0-86a0-3fe568e05ac0" />  |

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
