### PR TITLE
Document custom Info view tab recommendations

### DIFF
--- a/Sources/Player/UserInterface/ChapterList.swift
+++ b/Sources/Player/UserInterface/ChapterList.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ChapterList: View {
     @ObservedObject var player: Player
     @StateObject private var progressTracker = ProgressTracker(interval: .init(value: 1, timescale: 1))
+    @Environment(\.dismiss) private var dismiss
 
     private var chapters: [Chapter] {
         player.metadata.chapters
@@ -25,6 +26,7 @@ struct ChapterList: View {
                 ForEach(chapters, id: \.timeRange) { chapter in
                     ChapterCell(chapter: chapter, isHighlighted: chapter == currentChapter) {
                         player.seek(to: chapter)
+                        dismiss()
                     }
                 }
             }

--- a/Sources/Player/UserInterface/SystemVideoView.swift
+++ b/Sources/Player/UserInterface/SystemVideoView.swift
@@ -212,6 +212,10 @@ public extension SystemVideoView {
     /// Apply the ``SwiftUICore/View/infoViewTabPanel()`` modifier to use a background that mimics the standard tvOS
     /// Info view appearance.
     ///
+    /// > Important: The system does not always refresh Info views while they are displayed. As a result, if an action in a
+    ///   custom Info view tab changes the current item, you should dismiss the panel manually to force a refresh. In SwiftUI,
+    ///   you can do this by retrieving and calling the [dismiss action](https://developer.apple.com/documentation/swiftui/environmentvalues/dismiss).
+    ///
     /// @Image(source: info-view-tabs, alt: "A screenshot of info view tabs")
     func infoViewTabs(@InfoViewTabsContentBuilder content: () -> InfoViewTabsContent) -> Self {
         var view = self


### PR DESCRIPTION
## Description

Custom Info view actions automatically dismiss the Info view panel (see #1359).

There is no such mechanism for custom Info view tabs, though. Since the tvOS Info view panel is not updated while displayed, it is therefore recommended to dismiss the Info view panel, should some action in a custom info view tab change the current item. Otherwise data displayed in the panel might not reflect the new item being played, especially when looking under the standard Info tab.

### Remark

Standard dismissal APIs can be used to dismiss the panel. Though it would have been possible to access the underlying `playerViewController` to create a dismissal API, there is really no need to.

## Changes made

- Document recommendations.
- Update custom tvOS 26 chapter list so that the panel is dismissed when selecting a chapter. This is namely how the standard tvOS player UI is supposed to work.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
