### PR TITLE
Revisit label priorities / Add Commanders Act platform and vector identifiers

### DIFF
--- a/Demo/Sources/Application/AppDelegate.swift
+++ b/Demo/Sources/Application/AppDelegate.swift
@@ -47,7 +47,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         let configuration = Analytics.Configuration(
             vendor: .SRG,
             sourceKey: .development,
-            appSiteName: "pillarbox-demo-apple"
+            appSiteName: "pillarbox-demo-apple",
+            platformIdentifier: "pillarboxdemoapp"
         )
         try? Analytics.shared.start(with: configuration, dataSource: self, delegate: self)
     }

--- a/Sources/Analytics/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics/Analytics.swift
@@ -24,6 +24,7 @@ public class Analytics {
         let vendor: Vendor
         let sourceKey: SourceKey
         let appSiteName: String
+        let platformIdentifier: String
 
         /// Creates an analytics configuration.
         ///
@@ -33,10 +34,12 @@ public class Analytics {
         ///   - vendor: The vendor which the application belongs to.
         ///   - sourceKey: The source key.
         ///   - appSiteName: The app/site name.
-        public init(vendor: Vendor, sourceKey: SourceKey, appSiteName: String) {
+        ///   - platformIdentifier: The [platform identifier](https://srgssr-ch.atlassian.net/wiki/spaces/RN/pages/2655846518/Reference+tables#Platform_id).
+        public init(vendor: Vendor, sourceKey: SourceKey, appSiteName: String, platformIdentifier: String) {
             self.vendor = vendor
             self.sourceKey = sourceKey
             self.appSiteName = appSiteName
+            self.platformIdentifier = platformIdentifier
         }
     }
 

--- a/Sources/Analytics/ComScore/ComScoreTracker.swift
+++ b/Sources/Analytics/ComScore/ComScoreTracker.swift
@@ -82,7 +82,7 @@ private extension ComScoreTracker {
     func setMetadata(_ metadata: [String: String]) {
         let builder = SCORStreamingContentMetadataBuilder()
         if let globals = Analytics.shared.comScoreGlobals {
-            builder.setCustomLabels(metadata.merging(globals.labels) { _, new in new })
+            builder.setCustomLabels(globals.labels.merging(metadata) { _, new in new })
         }
         else {
             builder.setCustomLabels(metadata)

--- a/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
@@ -36,6 +36,9 @@ public struct CommandersActLabels: Decodable {
     /// The value of `navigation_device`.
     public let navigation_device: String?
 
+    /// The value of `vector_id`.
+    public let vector_id: String?
+
     /// The value of `consent_services`.
     public let consent_services: String?
 
@@ -214,10 +217,11 @@ private extension CommandersActLabels {
         case media_player_display
         case media_player_version
         case media_subtitle_selection
-        case user
         case page_id
         case page_version
         case section_id
         case section_version
+        case user
+        case vector_id
     }
 }

--- a/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
+++ b/Sources/Analytics/CommandersAct/Capture/CommandersActLabels.swift
@@ -30,6 +30,9 @@ public struct CommandersActLabels: Decodable {
     /// The value of `navigation_app_site_name`.
     public let navigation_app_site_name: String?
 
+    /// The value of `platform_id`.
+    public let platform_id: String?
+
     /// The value of `navigation_device`.
     public let navigation_device: String?
 
@@ -191,6 +194,7 @@ private extension CommandersActLabels {
         case navigation_app_site_name
         case navigation_device
         case consent_services
+        case platform_id
         case profile_id
         case navigation_property_type
         case content_bu_owner

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -32,9 +32,11 @@ public struct CommandersActEvent {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = globals.labels
-            .merging(labels) { _, new in new }
-            .merging(source?.labels ?? [:]) { _, new in new }
-        return .init(name: name, labels: labels)
+        let labels = globals.labels.merging(labels) { _, new in new }
+        return .init(name: name, source: source, labels: labels)
+    }
+
+    func allLabels() -> [String: String] {
+        labels.merging(source?.labels ?? [:]) { _, new in new }
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActEvent.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActEvent.swift
@@ -32,9 +32,9 @@ public struct CommandersActEvent {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = labels
+        let labels = globals.labels
+            .merging(labels) { _, new in new }
             .merging(source?.labels ?? [:]) { _, new in new }
-            .merging(globals.labels) { _, new in new }
         return .init(name: name, labels: labels)
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -43,9 +43,11 @@ public struct CommandersActPageView {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = globals.labels
-            .merging(labels) { _, new in new }
-            .merging(source?.labels ?? [:]) { _, new in new }
+        let labels = globals.labels.merging(labels) { _, new in new }
         return .init(name: name, type: type, levels: levels, source: source, labels: labels)
+    }
+
+    func allLabels() -> [String: String] {
+        labels.merging(source?.labels ?? [:]) { _, new in new }
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActPageView.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActPageView.swift
@@ -43,9 +43,9 @@ public struct CommandersActPageView {
 
     func merging(globals: CommandersActGlobals?) -> Self {
         guard let globals else { return self }
-        let labels = labels
+        let labels = globals.labels
+            .merging(labels) { _, new in new }
             .merging(source?.labels ?? [:]) { _, new in new }
-            .merging(globals.labels) { _, new in new }
         return .init(name: name, type: type, levels: levels, source: source, labels: labels)
     }
 }

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -18,6 +18,7 @@ private final class UnprotectedCommandersActService {
         if let serverSide = ServerSide(siteID: 3666, andSourceKey: configuration.sourceKey.rawValue) {
             serverSide.addPermanentData("app_library_version", withValue: Analytics.version)
             serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
+            serverSide.addPermanentData("platform_id", withValue: configuration.platformIdentifier)
             serverSide.addPermanentData("navigation_device", withValue: Self.device)
             serverSide.enableRunningInBackground()
             serverSide.waitForUserAgent()

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -31,7 +31,7 @@ private final class UnprotectedCommandersActService {
 
     func trackPageView(_ pageView: CommandersActPageView) {
         guard let serverSide, let event = TCPageViewEvent(type: pageView.type) else { return }
-        pageView.labels.forEach { key, value in
+        pageView.allLabels().forEach { key, value in
             event.addAdditionalProperty(key, withStringValue: value)
         }
         event.pageName = pageView.name
@@ -47,7 +47,7 @@ private final class UnprotectedCommandersActService {
 
     func sendEvent(_ event: CommandersActEvent) {
         guard let serverSide, let customEvent = TCCustomEvent(name: event.name) else { return }
-        event.labels.forEach { key, value in
+        event.allLabels().forEach { key, value in
             customEvent.addNonBlankAdditionalProperty(key, withStringValue: value)
         }
         AnalyticsListener.capture(customEvent)

--- a/Sources/Analytics/CommandersAct/CommandersActService.swift
+++ b/Sources/Analytics/CommandersAct/CommandersActService.swift
@@ -20,6 +20,7 @@ private final class UnprotectedCommandersActService {
             serverSide.addPermanentData("navigation_app_site_name", withValue: configuration.appSiteName)
             serverSide.addPermanentData("platform_id", withValue: configuration.platformIdentifier)
             serverSide.addPermanentData("navigation_device", withValue: Self.device)
+            serverSide.addPermanentData("vector_id", withValue: Self.vectorIdentifier)
             serverSide.enableRunningInBackground()
             serverSide.waitForUserAgent()
             self.serverSide = serverSide
@@ -90,6 +91,16 @@ private extension UnprotectedCommandersActService {
             return "tvbox"
         default:
             return "phone"
+        }
+    }()
+
+    static let vectorIdentifier = {
+        guard !ProcessInfo.processInfo.isRunningOnMac else { return "desktop.macos" }
+        switch UIDevice.current.userInterfaceIdiom {
+        case .tv:
+            return "tv.tvos"
+        default:
+            return "mobile.ios"
         }
     }()
 }

--- a/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
+++ b/Tests/AnalyticsTests/ComScore/ComScoreTrackerTests.swift
@@ -39,6 +39,26 @@ final class ComScoreTrackerTests: ComScoreTestCase {
         }
     }
 
+    func testLabelsMerging() {
+        let player = Player(item: .simple(
+            url: Stream.onDemand.url,
+            trackerAdapters: [
+                ComScoreTracker.adapter { _ in
+                    ["cs_ucfr": "tracker"]
+                }
+            ]
+        ))
+        expectAtLeastHits(
+            play { labels in
+                expect(labels.ns_st_mp).to(equal("Pillarbox"))
+                expect(labels.ns_st_mv).to(equal(PackageInfo.version))
+                expect(labels.cs_ucfr).to(equal("tracker"))
+            }
+        ) {
+            player.play()
+        }
+    }
+
     func testInitiallyPlaying() {
         let player = Player(item: .simple(
             url: Stream.onDemand.url,

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -12,12 +12,14 @@ import TCServerSide
 import XCTest
 
 final class CommandersActEventTests: CommandersActTestCase {
-    func testMergingWithGlobals() {
+    func testLabelsMerging() {
         let event = CommandersActEvent(
             name: "name",
+            source: .init(page: .init(identifier: "event-source")),
             labels: [
                 "event-label": "event",
-                "common-label": "event"
+                "common-label": "event",
+                "page_id": "event"
             ]
         )
         let globals = CommandersActGlobals(
@@ -25,7 +27,8 @@ final class CommandersActEventTests: CommandersActTestCase {
             profileIdentifier: "profile",
             labels: [
                 "globals-label": "globals",
-                "common-label": "globals"
+                "common-label": "globals",
+                "page_id": "globals"
             ]
         )
 
@@ -34,7 +37,8 @@ final class CommandersActEventTests: CommandersActTestCase {
             "profile_id": "profile",
             "globals-label": "globals",
             "event-label": "event",
-            "common-label": "globals"
+            "common-label": "event",
+            "page_id": "event-source"
         ]))
     }
 
@@ -98,27 +102,6 @@ final class CommandersActEventTests: CommandersActTestCase {
             }
         ) {
             Analytics.shared.sendEvent(commandersAct: .init(name: "name"))
-        }
-    }
-
-    func testCustomLabelsForbiddenOverrides() {
-        expectAtLeastHits(
-            custom(name: "name") { labels in
-                expect(labels.profile_id).to(equal("profile"))
-                expect(labels.consent_services).to(equal("service1,service2,service3"))
-                expect(labels.page_id).to(equal("page"))
-            }
-        ) {
-            Analytics.shared.sendEvent(commandersAct: .init(
-                name: "name",
-                source: .init(page: .init(identifier: "page")),
-                labels: [
-                    "event_name": "overridden_name",
-                    "profile_id": "profile42",
-                    "consent_services": "service42",
-                    "page_id": "page42"
-                ]
-            ))
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActEventTests.swift
@@ -32,7 +32,7 @@ final class CommandersActEventTests: CommandersActTestCase {
             ]
         )
 
-        expect(event.merging(globals: globals).labels).to(equal([
+        expect(event.merging(globals: globals).allLabels()).to(equal([
             "consent_services": "service1,service2,service3",
             "profile_id": "profile",
             "globals-label": "globals",

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -58,6 +58,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(labels.navigation_level_8).to(equal("level_8"))
                 expect(labels.navigation_level_9).to(beNil())
                 expect(["phone", "tablet", "tvbox", "phone"]).to(contain([labels.navigation_device]))
+                expect(["mobile.ios", "tv.tvos", "desktop.macos"]).to(contain([labels.vector_id]))
                 expect(labels.app_library_version).to(equal(Analytics.version))
                 expect(labels.navigation_app_site_name).to(equal("site"))
                 expect(labels.platform_id).to(equal("platform"))

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -11,13 +11,15 @@ import PillarboxCircumspect
 import XCTest
 
 final class CommandersActPageViewTests: CommandersActTestCase {
-    func testMergingWithGlobals() {
+    func testLabelsMerging() {
         let pageView = CommandersActPageView(
             name: "name",
             type: "type",
+            source: .init(page: .init(identifier: "pageview-source")),
             labels: [
                 "pageview-label": "pageview",
-                "common-label": "pageview"
+                "common-label": "pageview",
+                "page_id": "pageview"
             ]
         )
         let globals = CommandersActGlobals(
@@ -25,7 +27,8 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             profileIdentifier: "profile",
             labels: [
                 "globals-label": "globals",
-                "common-label": "globals"
+                "common-label": "globals",
+                "page_id": "globals"
             ]
         )
 
@@ -34,7 +37,8 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             "profile_id": "profile",
             "globals-label": "globals",
             "pageview-label": "pageview",
-            "common-label": "globals"
+            "common-label": "pageview",
+            "page_id": "pageview-source"
         ]))
     }
 
@@ -154,29 +158,6 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             }
         ) {
             Analytics.shared.trackPageView(commandersAct: .init(name: "name", type: "type"))
-        }
-    }
-
-    func testLabelsForbiddenOverrides() {
-        expectAtLeastHits(
-            page_view { labels in
-                expect(labels.page_name).to(equal("name"))
-                expect(labels.consent_services).to(equal("service1,service2,service3"))
-                expect(labels.page_id).to(equal("page"))
-            }
-        ) {
-            Analytics.shared.trackPageView(
-                commandersAct: .init(
-                    name: "name",
-                    type: "type",
-                    source: .init(page: .init(identifier: "page")),
-                    labels: [
-                        "page_name": "overridden_title",
-                        "consent_services": "service42",
-                        "page_id": "page42"
-                    ]
-                )
-            )
         }
     }
 }

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -60,6 +60,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
                 expect(["phone", "tablet", "tvbox", "phone"]).to(contain([labels.navigation_device]))
                 expect(labels.app_library_version).to(equal(Analytics.version))
                 expect(labels.navigation_app_site_name).to(equal("site"))
+                expect(labels.platform_id).to(equal("platform"))
                 expect(labels.navigation_property_type).to(equal("app"))
                 expect(labels.content_bu_owner).to(equal("SRG"))
                 expect(labels.consent_services).to(equal("service1,service2,service3"))

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActPageViewTests.swift
@@ -32,7 +32,7 @@ final class CommandersActPageViewTests: CommandersActTestCase {
             ]
         )
 
-        expect(pageView.merging(globals: globals).labels).to(equal([
+        expect(pageView.merging(globals: globals).allLabels()).to(equal([
             "consent_services": "service1,service2,service3",
             "profile_id": "profile",
             "globals-label": "globals",

--- a/Tests/AnalyticsTests/CommandersAct/CommandersActSourceTests.swift
+++ b/Tests/AnalyticsTests/CommandersAct/CommandersActSourceTests.swift
@@ -9,12 +9,13 @@
 import Nimble
 
 final class CommandersActSourceTests: CommandersActTestCase {
-    func testLabels() {
+    func testLabelsMerging() {
         let source = CommandersActSource(
             page: .init(identifier: "page", version: "p", position: 3),
             section: .init(identifier: "section", version: "s", position: 4),
             labels: [
-                "custom-label": "value"
+                "custom-label": "source",
+                "page_id": "source"
             ]
         )
         expect(source.labels).to(equal([
@@ -24,30 +25,7 @@ final class CommandersActSourceTests: CommandersActTestCase {
             "section_id": "section",
             "section_version": "s",
             "item_position_in_section": "4",
-            "custom-label": "value"
-        ]))
-    }
-
-    func testCustomLabelsForbiddenOverrides() {
-        let source = CommandersActSource(
-            page: .init(identifier: "page", version: "p", position: 3),
-            section: .init(identifier: "section", version: "s", position: 4),
-            labels: [
-                "page_id": "page42",
-                "page_version": "p42",
-                "section_position_in_page": "42",
-                "section_id": "section42",
-                "section_version": "s42",
-                "item_position_in_section": "42"
-            ]
-        )
-        expect(source.labels).to(equal([
-            "page_id": "page",
-            "page_version": "p",
-            "section_position_in_page": "3",
-            "section_id": "section",
-            "section_version": "s",
-            "item_position_in_section": "4"
+            "custom-label": "source"
         ]))
     }
 }

--- a/Tests/AnalyticsTests/TestCase.swift
+++ b/Tests/AnalyticsTests/TestCase.swift
@@ -27,7 +27,7 @@ class TestCase: XCTestCase {
         PollingDefaults.timeout = .seconds(20)
         PollingDefaults.pollInterval = .milliseconds(100)
         try? Analytics.shared.start(
-            with: .init(vendor: .SRG, sourceKey: .development, appSiteName: "site"),
+            with: .init(vendor: .SRG, sourceKey: .development, appSiteName: "site", platformIdentifier: "platform"),
             dataSource: dataSource
         )
     }


### PR DESCRIPTION
## Description

Global labels introduced in #561 have higher precedence over other labels. But after giving some thought we decided to prioritize labels as follows:

- Global labels: These labels are the default and should have lower precedence.
- Custom labels: These are labels defined in a narrow context. They should have higher precedence than globals.
- Labels backed by official types (e.g. `CommandersActSource`): If custom labels can be provided alongside labels backed by official types, they should really be provided via official types directly. Therefore these official labels should have higher precedence than custom labels.

Work related to #1557 was accidentally pushed to this branch and merged. This PR therefore also adds platform and vector identifiers to Commanders Act analytics.

## Changes made

- Merge tests checking label precedence.
- Revisit precedence.
- Add platform and vector identifiers.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
