### PR TITLE
Remove FB22488151 from known issues

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -175,14 +175,6 @@ When using an official Lightning-to-HDMI Apple adapter (A1438) to connect a Ligh
 
 No workaround is available yet.
 
-## The `.pauses` audiovisual background playback policy is no longer correctly applied on iOS 26.4 (FB22488151)
-
-With the`.automatic` or `.pauses` audiovisual background playback policy enabled, video playback continues instead of being automatically paused by the system when the app moves to the background or the device is locked.
-
-### Workaround
-
-No workaround is available yet.
-
 ## Negative metrics after audio track switch (FB22519249)
 
 Some increments reported in `Metrics` may contain negative values immediately following an audio track switch.


### PR DESCRIPTION
## Description

The audiovisual background policy regression introduced in i(Pad)OS 26.4 has been fixed in 26.6. Since this only affects minor versions, we can remove it from known issues, since a simple OS update suffices to fix it.

I closed the FB22488151 as well.

## Changes made

- Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
