### PR TITLE
Hide downloads behind preview trait

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>github</string>
@@ -15,6 +13,11 @@
 	</dict>
 	<key>TestFlightApplicationIdentifier</key>
 	<string>$(TEST_FLIGHT_APPLICATION_IDENTIFIER)</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
@@ -24,10 +27,5 @@
 		<key>UIImageName</key>
 		<string>LaunchScreen_image</string>
 	</dict>
-    <key>UIApplicationSceneManifest</key>
-    <dict>
-        <key>UIApplicationSupportsMultipleScenes</key>
-        <true/>
-    </dict>
 </dict>
 </plist>

--- a/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
+++ b/Demo/Pillarbox-demo.xcodeproj/project.pbxproj
@@ -3,13 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 71;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */ = {isa = PBXBuildFile; productRef = 0EF42CB529AE513400553165 /* SRGDataProviderCombine */; };
 		6F09A2922B48744000700365 /* PillarboxCoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6F09A2912B48744000700365 /* PillarboxCoreBusiness */; };
 		6F9B5BC928CF8C530074B9E0 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 6F9B5BC828CF8C530074B9E0 /* OrderedCollections */; };
+		6FA9092730399BF300FCEA3B /* PillarboxCoreBusiness in Frameworks */ = {isa = PBXBuildFile; productRef = 6FA9092630399BF300FCEA3B /* PillarboxCoreBusiness */; };
 		6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */ = {isa = PBXBuildFile; productRef = 6FCA4746292CBEC7008C2812 /* ShowTime */; };
 		6FEDBA6B2FE56EA800DB3970 /* SwiftData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FEDBA6A2FE56EA800DB3970 /* SwiftData.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
@@ -22,24 +23,39 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		6FD6C9F92CD8B61A00ED6B32 /* Preview Content */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Preview Content"; sourceTree = "<group>"; };
-		6FD6CA0E2CD8B61A00ED6B32 /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Resources; sourceTree = "<group>"; };
-		6FD6CA7E2CD8B61A00ED6B32 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
-		6FD6CADF2CD8B61A00ED6B32 /* Xcode */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Xcode; sourceTree = "<group>"; };
+		6FD6C9F92CD8B61A00ED6B32 /* Preview Content */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		6FD6CA0E2CD8B61A00ED6B32 /* Resources */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		6FD6CA7E2CD8B61A00ED6B32 /* Sources */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		6FD6CADF2CD8B61A00ED6B32 /* Xcode */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Xcode;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		6F05B8D22887E934005D75E3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				6FEDBA6B2FE56EA800DB3970 /* SwiftData.framework in Frameworks */,
 				6FCA4747292CBEC7008C2812 /* ShowTime in Frameworks */,
 				0EF42CB629AE513400553165 /* SRGDataProviderCombine in Frameworks */,
+				6FA9092730399BF300FCEA3B /* PillarboxCoreBusiness in Frameworks */,
 				6F9B5BC928CF8C530074B9E0 /* OrderedCollections in Frameworks */,
 				6F09A2922B48744000700365 /* PillarboxCoreBusiness in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -95,8 +111,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			fileSystemSynchronizedGroups = (
 				6FD6C9F92CD8B61A00ED6B32 /* Preview Content */,
 				6FD6CA0E2CD8B61A00ED6B32 /* Resources */,
@@ -108,6 +122,7 @@
 				6FCA4746292CBEC7008C2812 /* ShowTime */,
 				0EF42CB529AE513400553165 /* SRGDataProviderCombine */,
 				6F09A2912B48744000700365 /* PillarboxCoreBusiness */,
+				6FA9092630399BF300FCEA3B /* PillarboxCoreBusiness */,
 			);
 			productName = PillarboxDemo;
 			productReference = 6F05B8D52887E934005D75E3 /* Pillarbox-demo.app */;
@@ -129,7 +144,6 @@
 				};
 			};
 			buildConfigurationList = 6F05B8D02887E934005D75E3 /* Build configuration list for PBXProject "Pillarbox-demo" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -145,7 +159,9 @@
 				6F9B5BC728CF8C530074B9E0 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				6FCA4745292CBEC7008C2812 /* XCRemoteSwiftPackageReference "ShowTime" */,
 				0EF42CB429AE513400553165 /* XCRemoteSwiftPackageReference "srgdataprovider-apple" */,
+				6FA9092530399BF300FCEA3B /* XCLocalSwiftPackageReference "../../pillarbox-apple" */,
 			);
+			preferredProjectObjectVersion = 100;
 			productRefGroup = 6F05B8D62887E934005D75E3 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -158,25 +174,21 @@
 /* Begin PBXResourcesBuildPhase section */
 		6F05B8D32887E934005D75E3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6F05B8D12887E934005D75E3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		6F05B8E12887E935005D75E3 /* Debug */ = {
+		6F05B8E12887E935005D75E3 /* Debug configuration for PBXProject "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -239,7 +251,7 @@
 			};
 			name = Debug;
 		};
-		6F05B8E22887E935005D75E3 /* Release */ = {
+		6F05B8E22887E935005D75E3 /* Release configuration for PBXProject "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -297,7 +309,7 @@
 			};
 			name = Release;
 		};
-		6F05B8E42887E935005D75E3 /* Debug */ = {
+		6F05B8E42887E935005D75E3 /* Debug configuration for PBXNativeTarget "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 6FD6CADF2CD8B61A00ED6B32 /* Xcode */;
 			baseConfigurationReferenceRelativePath = Application.xcconfig;
@@ -326,6 +338,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DownloadDemoPreview;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
@@ -333,7 +346,7 @@
 			};
 			name = Debug;
 		};
-		6F05B8E52887E935005D75E3 /* Release */ = {
+		6F05B8E52887E935005D75E3 /* Release configuration for PBXNativeTarget "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 6FD6CADF2CD8B61A00ED6B32 /* Xcode */;
 			baseConfigurationReferenceRelativePath = Application.xcconfig;
@@ -369,7 +382,7 @@
 			};
 			name = Release;
 		};
-		6F45DB8C2893B717008ACCE6 /* Nightly */ = {
+		6F45DB8C2893B717008ACCE6 /* Nightly configuration for PBXProject "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -427,7 +440,7 @@
 			};
 			name = Nightly;
 		};
-		6F45DB8D2893B717008ACCE6 /* Nightly */ = {
+		6F45DB8D2893B717008ACCE6 /* Nightly configuration for PBXNativeTarget "Pillarbox-demo" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 6FD6CADF2CD8B61A00ED6B32 /* Xcode */;
 			baseConfigurationReferenceRelativePath = Application.xcconfig;
@@ -456,6 +469,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DownloadDemoPreview;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
@@ -469,24 +483,32 @@
 		6F05B8D02887E934005D75E3 /* Build configuration list for PBXProject "Pillarbox-demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6F05B8E12887E935005D75E3 /* Debug */,
-				6F05B8E22887E935005D75E3 /* Release */,
-				6F45DB8C2893B717008ACCE6 /* Nightly */,
+				6F05B8E12887E935005D75E3 /* Debug configuration for PBXProject "Pillarbox-demo" */,
+				6F05B8E22887E935005D75E3 /* Release configuration for PBXProject "Pillarbox-demo" */,
+				6F45DB8C2893B717008ACCE6 /* Nightly configuration for PBXProject "Pillarbox-demo" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		6F05B8E32887E935005D75E3 /* Build configuration list for PBXNativeTarget "Pillarbox-demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6F05B8E42887E935005D75E3 /* Debug */,
-				6F05B8E52887E935005D75E3 /* Release */,
-				6F45DB8D2893B717008ACCE6 /* Nightly */,
+				6F05B8E42887E935005D75E3 /* Debug configuration for PBXNativeTarget "Pillarbox-demo" */,
+				6F05B8E52887E935005D75E3 /* Release configuration for PBXNativeTarget "Pillarbox-demo" */,
+				6F45DB8D2893B717008ACCE6 /* Nightly configuration for PBXNativeTarget "Pillarbox-demo" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		6FA9092530399BF300FCEA3B /* XCLocalSwiftPackageReference "../../pillarbox-apple" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../pillarbox-apple";
+			traits = (
+				DownloadPreview,
+			);
+		};
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		0EF42CB429AE513400553165 /* XCRemoteSwiftPackageReference "srgdataprovider-apple" */ = {
@@ -529,6 +551,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6F9B5BC728CF8C530074B9E0 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
+		};
+		6FA9092630399BF300FCEA3B /* PillarboxCoreBusiness */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PillarboxCoreBusiness;
 		};
 		6FCA4746292CBEC7008C2812 /* ShowTime */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Demo/Resources/Localizable.xcstrings
+++ b/Demo/Resources/Localizable.xcstrings
@@ -177,6 +177,12 @@
     "Double tap to toggle controls" : {
 
     },
+    "Download" : {
+
+    },
+    "Downloads" : {
+
+    },
     "Embeddings" : {
 
     },
@@ -310,6 +316,9 @@
 
     },
     "No content" : {
+
+    },
+    "No downloads." : {
 
     },
     "No items" : {

--- a/Demo/Sources/Application/DemoApp.swift
+++ b/Demo/Sources/Application/DemoApp.swift
@@ -12,7 +12,7 @@ struct DemoApp: App {
 
     @StateObject private var router = Router()
 
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
     @State private var downloader = DemoDownloader()
 #endif
 
@@ -23,7 +23,7 @@ struct DemoApp: App {
                 showcaseTab()
                 contentListsTab()
                 searchTab()
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
                 downloadsTab()
 #endif
                 settingsTab()
@@ -33,7 +33,7 @@ struct DemoApp: App {
             }
             // TODO: Starting with iOS 17 this can be moved on the window group.
             .environmentObject(router)
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
             .environmentObject(downloader)
 #endif
         }
@@ -75,7 +75,7 @@ struct DemoApp: App {
         }
     }
 
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
     private func downloadsTab() -> some View {
         RoutedNavigationStack(keyPath: \.downloadsPath) {
             DownloadsView()

--- a/Demo/Sources/ContentLists/ContentListView.swift
+++ b/Demo/Sources/ContentLists/ContentListView.swift
@@ -106,7 +106,7 @@ private struct ContentCell: View {
 #if os(iOS)
             .swipeActions {
                 CopyActions(text: srgMedia.urn)
-#if DEBUG
+#if DownloadDemoPreview
                 DownloadAction(media: media)
 #endif
             }

--- a/Demo/Sources/Downloads/DemoDownloader~ios.swift
+++ b/Demo/Sources/Downloads/DemoDownloader~ios.swift
@@ -4,15 +4,11 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
 import Combine
 import Foundation
-
-@_spi(DownloaderPrivate)
 import PillarboxCoreBusiness
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
 
 @available(tvOS, unavailable)

--- a/Demo/Sources/Downloads/DownloadAction~ios.swift
+++ b/Demo/Sources/Downloads/DownloadAction~ios.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
 import SwiftUI
 

--- a/Demo/Sources/Downloads/DownloadButton~ios.swift
+++ b/Demo/Sources/Downloads/DownloadButton~ios.swift
@@ -4,11 +4,9 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
-
 import SwiftUI
 
 private struct DownloadIcon: View {

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -4,11 +4,9 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
-
 import SwiftUI
 
 struct DownloadCell: View {

--- a/Demo/Sources/Downloads/DownloadCell~ios.swift
+++ b/Demo/Sources/Downloads/DownloadCell~ios.swift
@@ -42,7 +42,7 @@ struct DownloadCell: View {
                 LazyImage(source: imageSource) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                 }
             }
     }

--- a/Demo/Sources/Downloads/DownloadsView~ios.swift
+++ b/Demo/Sources/Downloads/DownloadsView~ios.swift
@@ -4,14 +4,10 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
-@_spi(DownloaderPrivate)
 import PillarboxCoreBusiness
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
-
 import SwiftUI
 
 struct DownloadsView: View {

--- a/Demo/Sources/Downloads/URLAssetDownloadStore~ios.swift
+++ b/Demo/Sources/Downloads/URLAssetDownloadStore~ios.swift
@@ -4,11 +4,9 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
 import Foundation
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
 
 final class URLAssetDownloadStore {

--- a/Demo/Sources/Downloads/URLAssetLoader~ios.swift
+++ b/Demo/Sources/Downloads/URLAssetLoader~ios.swift
@@ -4,12 +4,10 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadDemoPreview
 
 import Combine
 import Foundation
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
 
 struct URLAssetLoader: AssetLoader {

--- a/Demo/Sources/Examples/ExamplesView.swift
+++ b/Demo/Sources/Examples/ExamplesView.swift
@@ -59,7 +59,7 @@ private struct MediaEntryView: View {
     @State private var certificateUrlString = ""
     @EnvironmentObject private var router: Router
 
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
     @EnvironmentObject private var downloader: DemoDownloader
 #endif
 
@@ -152,7 +152,7 @@ private struct MediaEntryView: View {
                 Text("Play")
                     .frame(maxWidth: .infinity)
             }
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
             Button(action: download) {
                 Text("Download")
                     .frame(maxWidth: .infinity)
@@ -166,7 +166,7 @@ private struct MediaEntryView: View {
         router.presented = .player(media: media)
     }
 
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
     private func download() {
         downloader.addDownload(media: media)
     }
@@ -235,7 +235,7 @@ struct ExamplesView: View {
                 Cell(title: media.title, subtitle: media.subtitle, imageUrl: media.imageUrl) {
                     router.presented = .player(media: media)
                 }
-#if DEBUG && os(iOS)
+#if DownloadDemoPreview && os(iOS)
                 .swipeActions {
                     DownloadAction(media: media)
                 }

--- a/Demo/Sources/Players/PlaybackView~ios.swift
+++ b/Demo/Sources/Players/PlaybackView~ios.swift
@@ -193,7 +193,7 @@ private struct MainView: View {
         LazyImage(source: imageSource) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
         }
         .animation(.easeIn(duration: 0.2), value: imageSource)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -236,7 +236,7 @@ private struct MainView: View {
     private func image(name: String) -> some View {
         Image(systemName: name)
             .resizable()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             // https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape
             .contentShape(Rectangle())
@@ -340,7 +340,7 @@ private extension MainView {
         if routePickerSetting == .button {
             RoutePickerView(prioritizesVideoDevices: prioritizesVideoDevices)
                 .tint(.white)
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 20)
         }
     }

--- a/Demo/Sources/Players/PlayerView~ios.swift
+++ b/Demo/Sources/Players/PlayerView~ios.swift
@@ -136,7 +136,7 @@ private struct ChapterCell: View {
             LazyImage(source: chapter.imageSource) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
             }
         }
         .animation(.defaultLinear, value: chapter.imageSource)

--- a/Demo/Sources/Players/SimplePlayerView~ios.swift
+++ b/Demo/Sources/Players/SimplePlayerView~ios.swift
@@ -43,7 +43,7 @@ struct SimplePlayerView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
                 .tint(.white)
                 .shadow(radius: 5)

--- a/Demo/Sources/Router/Router.swift
+++ b/Demo/Sources/Router/Router.swift
@@ -34,7 +34,7 @@ final class Router: ObservableObject {
     @Published var contentListsPath: [RouterDestination] = []
     @Published var searchPath: [RouterDestination] = []
 
-#if DEBUG
+#if DownloadDemoPreview
     @Published var downloadsPath: [RouterDestination] = []
 #endif
 

--- a/Demo/Sources/Search/SearchView.swift
+++ b/Demo/Sources/Search/SearchView.swift
@@ -67,7 +67,7 @@ struct SearchView: View {
 #if os(iOS)
                 .swipeActions {
                     CopyActions(text: srgMedia.urn)
-#if DEBUG
+#if DownloadDemoPreview
                     DownloadAction(media: media)
 #endif
                 }

--- a/Demo/Sources/Showcase/LiveRadioToggle/LiveRadioToggleView~ios.swift
+++ b/Demo/Sources/Showcase/LiveRadioToggle/LiveRadioToggleView~ios.swift
@@ -82,7 +82,7 @@ private struct _PlaybackView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
                 .tint(.white)
                 .shadow(radius: 5)
@@ -95,7 +95,7 @@ private struct _PlaybackView: View {
             LazyImage(source: player.metadata.imageSource) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
             }
         }
         .animation(.easeIn(duration: 0.2), value: player.metadata.imageSource)

--- a/Demo/Sources/Showcase/Multi/SingleView~ios.swift
+++ b/Demo/Sources/Showcase/Multi/SingleView~ios.swift
@@ -38,7 +38,7 @@ struct SingleView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
                 .tint(.white)
                 .shadow(radius: 5)

--- a/Demo/Sources/Views/MediaCardView~tvos.swift
+++ b/Demo/Sources/Views/MediaCardView~tvos.swift
@@ -79,7 +79,7 @@ struct MediaCardView: View {
                 case .success(let image):
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 default:
                     EmptyView()
                 }

--- a/Demo/Sources/Views/Player/PlaybackButton~ios.swift
+++ b/Demo/Sources/Views/Player/PlaybackButton~ios.swift
@@ -40,7 +40,7 @@ struct PlaybackButton: View {
                 .resizable()
                 .tint(.white)
         }
-        .aspectRatio(contentMode: .fit)
+        .scaledToFit()
         .frame(minWidth: 120, maxHeight: 90)
         .accessibilityLabel(accessibilityLabel)
         .keyboardShortcut(.space, modifiers: [])

--- a/Demo/Sources/Views/Player/SkipBackwardButton~ios.swift
+++ b/Demo/Sources/Views/Player/SkipBackwardButton~ios.swift
@@ -18,7 +18,7 @@ struct SkipBackwardButton: View {
                 .resizable()
                 .tint(.white)
         }
-        .aspectRatio(contentMode: .fit)
+        .scaledToFit()
         .frame(height: 45)
         .opacity(player.canSkipBackward() && !skipTracker.isSkipping ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipBackward())

--- a/Demo/Sources/Views/Player/SkipForwardButton~ios.swift
+++ b/Demo/Sources/Views/Player/SkipForwardButton~ios.swift
@@ -18,7 +18,7 @@ struct SkipForwardButton: View {
                 .resizable()
                 .tint(.white)
         }
-        .aspectRatio(contentMode: .fit)
+        .scaledToFit()
         .frame(height: 45)
         .opacity(player.canSkipForward() && !skipTracker.isSkipping ? 1 : 0)
         .animation(.defaultLinear, value: player.canSkipForward())

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
             targets: ["PillarboxStandardConnector"]
         )
     ],
+    traits: ["DownloadPreview"],
     dependencies: [
         .package(url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMajor(from: "6.17.0")),
         .package(url: "https://github.com/CommandersAct/iOSV5-spm.git", .upToNextMajor(from: "5.5.0")),

--- a/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
+++ b/Sources/CoreBusiness/Downloads/URNAssetDownloadStore.swift
@@ -4,13 +4,11 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
-import SwiftData
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
+import SwiftData
 
 @available(iOS 17.0, *)
 @available(tvOS, unavailable)
@@ -187,7 +185,6 @@ private extension URNAssetDownloadStore {
     }
 }
 
-@_spi(DownloaderPrivate)
 @available(iOS 17.0, *)
 @available(tvOS, unavailable)
 extension URNAssetDownloadStore: AssetDownloadStore {

--- a/Sources/CoreBusiness/Downloads/URNDownloader.swift
+++ b/Sources/CoreBusiness/Downloads/URNDownloader.swift
@@ -6,17 +6,14 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
 import PillarboxAnalytics
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
 
 @available(iOS 17.0, *)
 @available(tvOS, unavailable)
-@_spi(DownloaderPrivate)
 public final class URNDownloader: ObservableObject {
     private let downloader: Downloader<URNAssetDownloadStore>
 

--- a/Sources/CoreBusiness/Downloads/URNMetadata.swift
+++ b/Sources/CoreBusiness/Downloads/URNMetadata.swift
@@ -6,10 +6,9 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
 @available(tvOS, unavailable)
-@_spi(DownloaderPrivate)
 public struct URNMetadata: Codable {
     let analyticsData: [String: String]
     let analyticsMetadata: [String: String]

--- a/Sources/CoreBusiness/Types/URNAssetLoader.swift
+++ b/Sources/CoreBusiness/Types/URNAssetLoader.swift
@@ -5,8 +5,6 @@
 //
 
 import Combine
-
-@_spi(DownloaderPrivate)
 import PillarboxPlayer
 
 enum URNAssetLoader: AssetLoader {

--- a/Sources/Player/Downloads/Download.swift
+++ b/Sources/Player/Downloads/Download.swift
@@ -6,14 +6,13 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
 import Combine
 import Foundation
 import PillarboxCore
 
 @available(tvOS, unavailable)
-@_spi(DownloaderPrivate)
 public final class Download: ObservableObject, Identifiable {
     private typealias DownloadPlayerProperties = DownloadProperties<Void>
 

--- a/Sources/Player/Downloads/DownloadAsset.swift
+++ b/Sources/Player/Downloads/DownloadAsset.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @available(tvOS, unavailable)
 struct DownloadAsset<CustomData> {
     let wrappedValue: Asset
@@ -14,3 +16,5 @@ struct DownloadAsset<CustomData> {
         self.assetMetadata = assetMetadata
     }
 }
+
+#endif

--- a/Sources/Player/Downloads/DownloadProgress.swift
+++ b/Sources/Player/Downloads/DownloadProgress.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 @available(tvOS, unavailable)
 enum DownloadProgress {

--- a/Sources/Player/Downloads/DownloadProperties.swift
+++ b/Sources/Player/Downloads/DownloadProperties.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
 

--- a/Sources/Player/Downloads/DownloadRecord.swift
+++ b/Sources/Player/Downloads/DownloadRecord.swift
@@ -6,11 +6,10 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
 
-@_spi(DownloaderPrivate)
 @available(tvOS, unavailable)
 public struct DownloadRecord<Input, CustomData> {
     public let input: Input

--- a/Sources/Player/Downloads/DownloadSession.swift
+++ b/Sources/Player/Downloads/DownloadSession.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import Combine
 import Foundation

--- a/Sources/Player/Downloads/DownloadSessionTaskProperties.swift
+++ b/Sources/Player/Downloads/DownloadSessionTaskProperties.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
 

--- a/Sources/Player/Downloads/DownloadState.swift
+++ b/Sources/Player/Downloads/DownloadState.swift
@@ -6,9 +6,8 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
-@_spi(DownloaderPrivate)
 @available(tvOS, unavailable)
 public enum DownloadState: Equatable {
     case preparing

--- a/Sources/Player/Downloads/DownloadTask.swift
+++ b/Sources/Player/Downloads/DownloadTask.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import Foundation
 

--- a/Sources/Player/Downloads/Downloader.swift
+++ b/Sources/Player/Downloads/Downloader.swift
@@ -4,14 +4,13 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 // swiftlint:disable missing_docs
 
 import Combine
 import Foundation
 
-@_spi(DownloaderPrivate)
 @available(tvOS, unavailable)
 public final class Downloader<S>: ObservableObject where S: AssetDownloadStore {
     private let store: S

--- a/Sources/Player/Downloads/URLDownloadSession.swift
+++ b/Sources/Player/Downloads/URLDownloadSession.swift
@@ -4,7 +4,7 @@
 //  License information is available from the LICENSE file.
 //
 
-#if DEBUG
+#if DownloadPreview
 
 import AVFoundation
 import Combine

--- a/Sources/Player/Interfaces/AssetDownloadStore.swift
+++ b/Sources/Player/Interfaces/AssetDownloadStore.swift
@@ -6,12 +6,11 @@
 
 // swiftlint:disable missing_docs
 
-#if DEBUG
+#if DownloadPreview
 
 import Combine
 import Foundation
 
-@_spi(DownloaderPrivate)
 @available(tvOS, unavailable)
 public protocol AssetDownloadStore: AnyObject {
     associatedtype Loader: AssetLoader

--- a/Sources/Player/Interfaces/DownloadSessionDelegate.swift
+++ b/Sources/Player/Interfaces/DownloadSessionDelegate.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 import Foundation
 
 @available(tvOS, unavailable)
@@ -11,3 +13,5 @@ protocol DownloadSessionDelegate: AnyObject {
     func downloadSessionTask(_ task: URLSessionTask, willDownloadToLocation location: URL, forId id: String)
     func downloadSessionTask(_ task: URLSessionTask, didCompleteWithError error: (any Error)?, forId id: String)
 }
+
+#endif

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-3.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-4.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-1-4.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-1.swift
@@ -20,7 +20,7 @@ struct ContentView: View {
         Button(action: { player.skipBackward() }) {
             Image(systemName: "gobackward.10")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 30)
         }
     }
@@ -29,7 +29,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-2.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
         Button(action: { player.skipBackward() }) {
             Image(systemName: "gobackward.10")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 30)
         }
     }
@@ -30,7 +30,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
         }
     }
@@ -39,7 +39,7 @@ struct ContentView: View {
         Button(action: { player.skipForward() }) {
             Image(systemName: "goforward.10")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 30)
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/creating-basic-user-interface/creating-basic-user-interface-2-3.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
         Button(action: { player.skipBackward() }) {
             Image(systemName: "gobackward.5")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 30)
         }
     }
@@ -31,7 +31,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle.fill" : "play.circle.fill")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 50)
         }
     }
@@ -40,7 +40,7 @@ struct ContentView: View {
         Button(action: { player.skipForward() }) {
             Image(systemName: "goforward.15")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: 30)
         }
     }

--- a/Sources/Player/Player.docc/Tutorials/supporting-airplay/supporting-airplay-2-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/supporting-airplay/supporting-airplay-2-2.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
 
     private func routePicker() -> some View {
         RoutePickerView()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(width: 50)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }

--- a/Sources/Player/Player.docc/Tutorials/supporting-airplay/supporting-airplay-2-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/supporting-airplay/supporting-airplay-2-3.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
 
     private func routePicker() -> some View {
         RoutePickerView()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(width: 50)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-1.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-1.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(height: 60)
                 .tint(.white)
         }

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-2.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-2.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(height: 60)
                 .tint(.white)
         }

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-3.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-3.swift
@@ -29,7 +29,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(height: 60)
                 .tint(.white)
         }

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-4.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-4.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(height: 60)
                 .tint(.white)
         }

--- a/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-5.swift
+++ b/Sources/Player/Player.docc/Tutorials/tracking-visibility/tracking-visibility-1-5.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
         Button(action: player.togglePlayPause) {
             Image(systemName: player.shouldPlay ? "pause.circle" : "play.circle")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(height: 60)
                 .tint(.white)
         }

--- a/Tests/PlayerTests/Downloads/DownloadAssetTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadAssetTests.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Foundation
@@ -58,3 +60,5 @@ final class DownloadAssetTests: TestCase {
         expectOnlyEqualPublished(values: [playerMetadata1], from: publisher)
     }
 }
+
+#endif

--- a/Tests/PlayerTests/Downloads/DownloadAssetTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadAssetTests.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-@_spi(DownloaderPrivate)
 @testable import PillarboxPlayer
 
 import Foundation

--- a/Tests/PlayerTests/Downloads/DownloadTaskTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTaskTests.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Foundation
@@ -43,3 +45,5 @@ final class DownloadTaskTests: TestCase {
         expect(task.assetMetadata.playerMetadata).to(equal(metadata))
     }
 }
+
+#endif

--- a/Tests/PlayerTests/Downloads/DownloadTaskTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTaskTests.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-@_spi(DownloaderPrivate)
 @testable import PillarboxPlayer
 
 import Foundation

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Foundation
@@ -281,3 +283,5 @@ final class DownloadTests: TestCase {
         expect(weakDownload).to(beNil())
     }
 }
+
+#endif

--- a/Tests/PlayerTests/Downloads/DownloadTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloadTests.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-@_spi(DownloaderPrivate)
 @testable import PillarboxPlayer
 
 import Foundation

--- a/Tests/PlayerTests/Downloads/DownloaderTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloaderTests.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-@_spi(DownloaderPrivate)
 @testable import PillarboxPlayer
 
 import Nimble

--- a/Tests/PlayerTests/Downloads/DownloaderTests.swift
+++ b/Tests/PlayerTests/Downloads/DownloaderTests.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Nimble
@@ -135,3 +137,5 @@ final class DownloaderTests: TestCase {
         expect(weakDownloader).to(beNil())
     }
 }
+
+#endif

--- a/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
+++ b/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Foundation
@@ -55,3 +57,5 @@ extension AssetDownloadStoreMock: AssetDownloadStore {
         records[id] = record
     }
 }
+
+#endif

--- a/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
+++ b/Tests/PlayerTests/Tools/AssetDownloadStoreMock.swift
@@ -4,7 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-@_spi(DownloaderPrivate)
 @testable import PillarboxPlayer
 
 import Foundation

--- a/Tests/PlayerTests/Tools/DownloadSessionMock.swift
+++ b/Tests/PlayerTests/Tools/DownloadSessionMock.swift
@@ -4,6 +4,8 @@
 //  License information is available from the LICENSE file.
 //
 
+#if DownloadPreview
+
 @testable import PillarboxPlayer
 
 import Combine
@@ -87,3 +89,5 @@ extension DownloadSessionMock: URLSessionDownloadDelegate {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
# Description

This PR introduces a `DownloadPreview` trait with which downloads can be easily integrated as a feature preview. This official mechanism replaces the `@_spi(DownloaderPrivate)` attribute we were previously using.

## Hints

Some documentation about package traits:

- https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/
- https://www.massicotte.org/blog/package-traits-in-xcode/
- https://theswiftdev.com/all-about-swift-package-manager-traits/
- https://www.pointfree.co/blog/posts/216-trait-ifying-our-libraries-to-reduce-transitive-dependencies

## Changes made

- Introduced `DownloadPreview` package trait in manifest (name inspired from Swift Collection package traits).
- Removed `@_spi(DownloaderPrivate)`.
- Updated demo to use `DownloadPreview` trait instead of `@_spi(DownloaderPrivate)`. This required adding the local package explicitly as dependency (previously this dependency was implicit).
- Enabled downloads in all demo builds except release builds, using a dedicated preprocessor flag.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
