### PR TITLE
Send useful headers in monitoring events

### DIFF
--- a/Sources/CoreBusiness/Extensions/PlayerItem.swift
+++ b/Sources/CoreBusiness/Extensions/PlayerItem.swift
@@ -43,6 +43,7 @@ public extension PlayerItem {
                 ) { metadata in
                     MetricsTracker.Metadata(
                         metadataUrl: metadata.mediaCompositionUrl,
+                        metadataHeaders: metadata.mediaCompositionHeaders,
                         assetUrl: metadata.resource?.url
                     )
                 }

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -15,6 +15,9 @@ public struct MediaMetadata {
     /// The URL at which the playback context was retrieved.
     public let mediaCompositionUrl: URL?
 
+    /// Useful response headers received when fetching the media composition.
+    public let mediaCompositionHeaders: [String: String]
+
     /// The main chapter.
     public let mainChapter: MediaComposition.Chapter
 
@@ -72,6 +75,7 @@ public struct MediaMetadata {
         }
         self.mediaComposition = mediaComposition
         self.mediaCompositionUrl = mediaCompositionResponse.response.url
+        self.mediaCompositionHeaders = Self.mediaCompositionHeaders(from: mediaCompositionResponse.response)
         self.mainChapter = mainChapter
         self.resource = mainChapter.recommendedResource
         self.dataProvider = dataProvider
@@ -79,6 +83,13 @@ public struct MediaMetadata {
 
     private static func areRedundant(chapter: MediaComposition.Chapter, show: MediaComposition.Show) -> Bool {
         chapter.title.lowercased() == show.title.lowercased()
+    }
+
+    private static func mediaCompositionHeaders(from response: URLResponse) -> [String: String] {
+        guard let httpResponse = response as? HTTPURLResponse, let headers = httpResponse.allHeaderFields as? [String: String] else { return [:] }
+        return headers.filter { key, _ in
+            ["Akamai-GRN", "x-location-info", "x-proxy-detection-info", "X-tracing-id"].contains(key)
+        }
     }
 }
 

--- a/Sources/CoreBusiness/Model/MediaMetadata.swift
+++ b/Sources/CoreBusiness/Model/MediaMetadata.swift
@@ -88,7 +88,7 @@ public struct MediaMetadata {
     private static func mediaCompositionHeaders(from response: URLResponse) -> [String: String] {
         guard let httpResponse = response as? HTTPURLResponse, let headers = httpResponse.allHeaderFields as? [String: String] else { return [:] }
         return headers.filter { key, _ in
-            ["Akamai-GRN", "x-location-info", "x-proxy-detection-info", "X-tracing-id"].contains(key)
+            ["akamai-grn", "x-location-info", "x-proxy-detection-info", "x-tracing-id"].contains(key.lowercased())
         }
     }
 }

--- a/Sources/Monitoring/Tracker/MetricsTracker.swift
+++ b/Sources/Monitoring/Tracker/MetricsTracker.swift
@@ -111,15 +111,18 @@ public extension MetricsTracker {
     /// Metadata associated with the tracker.
     struct Metadata {
         let metadataUrl: URL?
+        let metadataHeaders: [String: String]
         let assetUrl: URL?
 
         /// Creates metadata.
         ///
         /// - Parameters:
         ///   - metadataUrl: The URL where metadata has been fetched.
+        ///   - metadataHeaders: Useful response headers received when fetching metadata.
         ///   - assetUrl: The URL of the asset being played.
-        public init(metadataUrl: URL? = nil, assetUrl: URL? = nil) {
+        public init(metadataUrl: URL? = nil, metadataHeaders: [String: String] = [:], assetUrl: URL? = nil) {
             self.metadataUrl = metadataUrl
+            self.metadataHeaders = metadataHeaders
             self.assetUrl = assetUrl
         }
     }
@@ -154,7 +157,8 @@ private extension MetricsTracker {
             media: .init(
                 assetUrl: metadata?.assetUrl,
                 id: configuration.identifier,
-                metadataUrl: metadata?.metadataUrl
+                metadataUrl: metadata?.metadataUrl,
+                metadataHeaders: metadata?.metadataHeaders ?? [:]
             ),
             qoeTimings: .init(events: events),
             qosTimings: .init(events: events)

--- a/Sources/Monitoring/Types/MetricStartData.swift
+++ b/Sources/Monitoring/Types/MetricStartData.swift
@@ -34,6 +34,7 @@ extension MetricStartData {
         let assetUrl: URL?
         let id: String?
         let metadataUrl: URL?
+        let metadataHeaders: [String: String]
     }
 
     struct OperatingSystem: Encodable {

--- a/Tests/MonitoringTests/MetricsTracker.swift
+++ b/Tests/MonitoringTests/MetricsTracker.swift
@@ -23,6 +23,9 @@ extension MetricsTracker.Configuration {
 extension MetricsTracker.Metadata {
     static let test = MetricsTracker.Metadata(
         metadataUrl: URL(string: "https://localhost/metadata.json"),
+        metadataHeaders: [
+            "X-Trace-Id": "12345"
+        ],
         assetUrl: URL(string: "https://localhost/asset.m3u8")
     )
 }

--- a/Tests/MonitoringTests/MetricsTrackerTests.swift
+++ b/Tests/MonitoringTests/MetricsTrackerTests.swift
@@ -193,6 +193,7 @@ final class MetricsTrackerTests: MonitoringTestCase {
                 expect(media.assetUrl).to(equal(URL(string: "https://localhost/asset.m3u8")))
                 expect(media.id).to(equal("identifier"))
                 expect(media.metadataUrl).to(equal(URL(string: "https://localhost/metadata.json")))
+                expect(media.metadataHeaders).to(equal(["X-Trace-Id": "12345"]))
 
                 let os = data.os
                 expect(os.name).notTo(beNil())


### PR DESCRIPTION
## Description

This PR improves our monitoring tracker API to support HTTP headers associated with metadata retrieval. Refer to the linked issue for more information about the specification itself.

## Changes made

- Updated `MetricsTracker` to support useful metadata headers.
- Send useful response headers from media composition requests. Only specific headers are sent to avoid transferring unnecessary or non-anonymous (e.g. IP address) data.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
