### PR TITLE
Fix download test stability

### DIFF
--- a/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Pillarbox-demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6972ec39f36ac227022d7b100fddbbf691a22bdbe5ba6d42b1119e19689e46a0",
+  "originHash" : "4f29226ef0863b5031ced2b3fd3735dbea6eb71748660244817ee0f92c0dee0b",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5-spm.git",
       "state" : {
-        "revision" : "39eb694d2df118f435dc82900cb864a568972a7c",
-        "version" : "5.5.0"
+        "revision" : "e28f6bcb00d15d9ca113d45074bab27ddb853e1e",
+        "version" : "5.5.1"
       }
     },
     {

--- a/Demo/Sources/Model/URLMedia.swift
+++ b/Demo/Sources/Model/URLMedia.swift
@@ -38,7 +38,7 @@ enum URLMedia {
         title: "Couleur 3 en vidéo (DVR)",
         subtitle: "Video livestream with DVR - HLS",
         imageUrl: "https://il.srgssr.ch/images/?imageUrl=https%3A%2F%2Fwww.rts.ch%2F2020%2F05%2F18%2F14%2F20%2F11333286.image%2F16x9&format=jpg&width=960",
-        type: .url("https://visualradio-rts-couleur3-d.akamaized.net/out/v1/6a1472634ad745f59a9e63ee8adbbc00/index.m3u8")
+        type: .url("https://visualradio-rts-couleur3-d.akamaized.net/out/v1/lsvs/visual-radio-rts-couleur-3/cmaf/hls-master.m3u8")
     )
     static let liveTimestampVideoHLS = Media(
         title: "Tageschau",

--- a/Demo/Sources/Model/URNMedia.swift
+++ b/Demo/Sources/Model/URNMedia.swift
@@ -18,7 +18,7 @@ enum URNMedia {
     static let onDemandVerticalVideo = Media(
         title: "Vertical video",
         imageUrl: "https://www.rts.ch/2022/10/06/17/32/13444380.image/4x5",
-        type: .urn("urn:rts:video:13444390")
+        type: .urn("urn:rts:video:13950405")
     )
     static let onDemandVideo = Media(
         title: "A bon entendeur",

--- a/Demo/Sources/Model/URNMedia.swift
+++ b/Demo/Sources/Model/URNMedia.swift
@@ -17,7 +17,7 @@ enum URNMedia {
     )
     static let onDemandVerticalVideo = Media(
         title: "Vertical video",
-        imageUrl: "https://www.rts.ch/2022/10/06/17/32/13444380.image/4x5",
+        imageUrl: "https://img.rts.ch/medias/2023/image/w2e9c5-26920079.image/9x16",
         type: .urn("urn:rts:video:13950405")
     )
     static let onDemandVideo = Media(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b49ca76806b797b94e0c794deb46c10af344fb8e17cb6ab90da36ee3d8f861a2",
+  "originHash" : "2e12f0a47884c9569f425a1cee76e252890bbe99f21bd5cb93381d20cadd2d88",
   "pins" : [
     {
       "identity" : "comscore-swift-package-manager",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5-spm.git",
       "state" : {
-        "revision" : "39eb694d2df118f435dc82900cb864a568972a7c",
-        "version" : "5.5.0"
+        "revision" : "e28f6bcb00d15d9ca113d45074bab27ddb853e1e",
+        "version" : "5.5.1"
       }
     },
     {

--- a/Sources/Player/Downloads/DownloadProperties.swift
+++ b/Sources/Player/Downloads/DownloadProperties.swift
@@ -129,7 +129,7 @@ struct DownloadProperties<CustomData> {
     }
 
     func withError(_ error: Error) -> Self {
-        .init(configuration: configuration, progress: progress, assetMetadata: assetMetadata, fileUrl: fileUrl, error: error)
+        .init(configuration: configuration, progress: progress, assetMetadata: assetMetadata, fileUrl: nil, error: error)
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes download test stability when repeating the following tests several times:

- `DownloadTests.testRemoveWhileInitiallyRunning()`
- `DownloadTests.testRemoveWhileDownloadingFile()`

Often the `fileUrl` store in properties was not properly cleaned up after cancellation. We namely have two error management pipelines:

- One is for the download task itself, where locations and errors are received separately and not mutually exclusive (we can have an error **and** a location).
- The other one is for metadata retrieval and cancellation errors, for which location and error are mutually exclusive. In this pipeline we namely either never started the download task (i.e. we never had a chance to receive a `fileUrl`) or we cancelled the download somehow.

## Changes made

- Erased `fileUrl` stored in properties when updated with an error.
- Updated Couleur 3 DVR and vertical video examples.
- Updated Commanders Act SDK to version 5.5.1 (prior: 5.5.0).

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
