### PR TITLE
Pin stale action to commit SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  #  v11.0.0
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it


### PR DESCRIPTION
## Description

This PR pins the stale action to a commit SHA. Repository settings enforce this requirement and, for this reason, the stale action was not running anymore.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
